### PR TITLE
Pin font-awesome-rails to 4.2.0.0 to fix triangle symbol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "clamav"
 
 gem "bootstrap-sass"
 gem "font-awesome-sass"
+gem "font-awesome-rails", "4.2.0.0"
 
 gem "devise"
 gem "devise-guests", "~> 0.3"


### PR DESCRIPTION
Confirmed on QA that this fixes the triangle symbol in the UC menu bar.