### PR TITLE
Update input forms to link to Creator's Rights page instead of Sherpa/Romero.

### DIFF
--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -15,7 +15,7 @@
       <li>Publish your work in a journal</li>
     </ul>
     <p>
-      Check out <%= link_to "Creator's Rights page", creators_rights_request_path, :target => '_blank' %> for more
+      Check out the <%= link_to "Creator's Rights page", creators_rights_request_path, :target => '_blank' %> for more
       information about publisher copyright policies.
     </p>
   </section>

--- a/app/views/curation_concern/base/_form_permission.html.erb
+++ b/app/views/curation_concern/base/_form_permission.html.erb
@@ -15,7 +15,7 @@
       <li>Publish your work in a journal</li>
     </ul>
     <p>
-      Check out <a href="http://www.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> for more
+      Check out <%= link_to "Creator's Rights page", creators_rights_request_path, :target => '_blank' %> for more
       information about publisher copyright policies.
     </p>
   </section>


### PR DESCRIPTION
Update input forms to link to Creator's Rights page instead of Sherpa/Romero.