### PR TITLE
Add re-captcha to contact form to prevent spamming

### DIFF
--- a/app/controllers/contact_requests_controller.rb
+++ b/app/controllers/contact_requests_controller.rb
@@ -1,15 +1,28 @@
 class ContactRequestsController < ApplicationController
   SUCCESS_NOTICE = "Thank you.  Your message has been sent to the Scholar@UC team."
+  FAIL_NOTICE = "You must complete the Captcha to confirm the form."
 
   def new
   end
 
-  def create
-    name = params[:name]
-    email = params[:email]
-    comments = params[:comments]
-    NotificationMailer.notify(name,email,comments).deliver
-    redirect_to catalog_index_path, notice: SUCCESS_NOTICE
+  def verify_google_recaptcha(key,response)
+    status = `curl "https://www.google.com/recaptcha/api/siteverify?secret=#{CAPTCHA_SERVER['secret_key']}&response=#{response}"`
+    hash = JSON.parse(status)
+    hash["success"] == true ? true : false
   end
 
+  def create
+    @name = params[:name]
+    @email = params[:email]
+    @comments = params[:comments]
+    status = verify_google_recaptcha(CAPTCHA_SERVER['secret_key'],params["g-recaptcha-response"])
+
+    if (status)
+      NotificationMailer.notify(@name,@email,@comments).deliver
+      redirect_to catalog_index_path, notice: SUCCESS_NOTICE
+    else
+      flash.now[:notice] = FAIL_NOTICE
+      render :action => 'new'
+    end
+  end
 end

--- a/app/views/contact_requests/new.html.erb
+++ b/app/views/contact_requests/new.html.erb
@@ -6,7 +6,7 @@
   <div class="row">
     <div class="span12">
 
-      <h2>Contact the Scholar@UC Team</h2>
+      <h2>Contact the Scholar@UC Team <script src='https://www.google.com/recaptcha/api.js'></script> </h2>
 
       <form method="post" action="/contact_requests" name="contactForm" id="contactForm">
 
@@ -14,7 +14,7 @@
 
         <p>
           <label for="name" class="col-sm-2 control-label">Your Name:</label>
-          <input style="width:40%;min-width:200px;" type="text" class="form-control" id="name" name="name" required autofocus autocomplete="on">
+          <input style="width:40%;min-width:200px;" type="text" class="form-control" id="name" name="name" value = "<%=@name%>" required autofocus autocomplete="on">
         </p>
 
         <% defined?(current_user.user_key) ? useremail = current_user.user_key : useremail = '' %>
@@ -26,7 +26,7 @@
 
         <p>
           <label for="comments" class="col-sm-2 control-label">Comments, Questions, Help Requests, etc.:</label>
-          <textarea style="width:40%;min-width:200px;" class="form-control" name="comments" id="comments" required rows="6"></textarea>
+          <textarea style="width:40%;min-width:200px;" class="form-control" name="comments" id="comments" required rows="6"><%="#{@comments}"%></textarea>
         </p>
 
 <!-- Temporarily disable additional information
@@ -76,9 +76,11 @@
 
         <input type="hidden" id="userAgent" name="userAgent" value="">
 
-        <p style="margin:2em 0;">(ADD RECAPTCHA HERE)</p>
+        <p style="margin:2em 0;">(ADD RECAPTCHA HERE)</p>         
 -->
-        <button class="btn btn-lg btn-primary" type="submit">Send</button>
+        <div class="g-recaptcha" data-sitekey= "<%=CAPTCHA_SERVER['site_key']%>"></div>
+
+        <button  style="margin-top: 15px; width: 60px; border: 1px solid black;" class="btn btn-lg btn-primary" type="submit">Send</button>
 
       </form>
 

--- a/config/initializers/load_captcha_configs.rb
+++ b/config/initializers/load_captcha_configs.rb
@@ -1,0 +1,2 @@
+CAPTCHA_SERVER = YAML.load_file(Rails.root.join('config', 'recaptcha.yml'))[Rails.env]
+

--- a/config/recaptcha.yml
+++ b/config/recaptcha.yml
@@ -1,0 +1,11 @@
+# stores ReCaptcha image server url
+
+development:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key
+test:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key
+production:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ CurateApp::Application.routes.draw do
   get 'faq_request' => 'page_requests#view_faq'
   get 'distribution_license_request' => 'page_requests#view_distribution_license'
   get 'creators_rights_request' => 'page_requests#view_creators_rights'
+  get 'contact_requests' => 'contact_requests#new'
 
   resources :contact_requests
 

--- a/spec/controllers/contact_requests_controller_spec.rb
+++ b/spec/controllers/contact_requests_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ContactRequestsController do
+  describe 'GET #new' do
+    let(:user) { FactoryGirl.create(:user) }
+    it 'is allowed when not logged in' do
+      get(:new)
+      expect(response.status).to eq(200)
+      expect(response).to render_template('new')
+    end
+  end
+
+  describe 'POST #create' do
+
+    it 'successfully allows reCaptcha' do
+      ContactRequestsController.any_instance.stub(:verify_google_recaptcha).and_return(true)
+      NotificationMailer.any_instance.stub(:notify).and_return(true)
+      post(:create)
+      response.should redirect_to(catalog_index_path)
+    end
+
+    it 'fails on reCaptcha failure' do
+      ContactRequestsController.stub(:verify_google_recaptcha).and_return(false)
+      post(:create) 
+      response.should render_template("contact_requests/new")
+    end
+  end
+end


### PR DESCRIPTION
Moves bamboo variables into YAML.

Adds test for contact_requests_controller.

Contact request form repopulates on recaptcha fail