### PR TITLE
Remove UC header from and improve error pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -19,40 +19,6 @@
 
 </head>
 <body>
-  <div id="uc_header">
-    <div class="uc_globalnavResponsive section navbar navbar-inverse navbar-static-top">
-       <div class="navbar-inner uc_globalnav" role="navigation" id="ucNav">
-         <div class="container">
-           <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           </a>
-           <div class="nav-collapse collapse">
-             <ul class="nav">
-              <li><a class="uc_NavLink" href="http://www.uc.edu?from=uc_globalnav">UC Home</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/visitors.html?from=uc_globalnav">Visit UC</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/foundation.html?from=uc_globalnav">Support&nbsp;UC&nbsp;<i class="fa fa-play"></i></a></li>
-              <li><a class="uc_NavLink" href="https://ucdirectory.uc.edu/?from=uc_globalnav">Directories</a></li>
-              <li class="dropdown"> <a href="#" class="dropdown-toggle uc_NavLink" data-toggle="dropdown">UC Tools <b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://blackboard.uc.edu?from=uctools">Blackboard</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://bblearn.uc.edu?from=uctools">BbLearn</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://onestop.uc.edu?from=uctools">OneStop</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://mail.uc.edu?from=uctools">Student Email</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucowa.uc.edu/?from=uctools">UCMail</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucfilespace.uc.edu/?from=uctools">UCFileSpace</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://www.ucflex.uc.edu/">UC Flex/ESS</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://www.uc.edu/pss/?from=uctools">Password Help</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://sslvpn.uc.edu?from=uctools">UC VPN</a></li>
-                </ul>
-              </li>
-            </ul>
-           </div>
-         </div>
-       </div>
-    </div>
-  </div>
 <header id="banner" role="banner">
     <hgroup>
       <br clear="all" />
@@ -91,9 +57,10 @@ The page you are looking for may have been removed, had its name changed, or is 
 <h2>Please try the following:</h2>
 <ul>
   <li>If you typed the page address in the Address bar, make sure that it is spelled correctly. </li>
-  <li>Go to the <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
+  <li>Go to <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
   <li>Click the Back button on your browser to try another link. </li>
   <li>If you reached this page using a bookmark, the page you're looking for may have moved.</li>
+  <li><a href="/contact_requests/new">Contact us</a> for assistance.</li>
 </ul>
   </div>
 </body>

--- a/public/422.html
+++ b/public/422.html
@@ -19,40 +19,6 @@
 
 </head>
 <body>
-  <div id="uc_header">
-    <div class="uc_globalnavResponsive section navbar navbar-inverse navbar-static-top">
-       <div class="navbar-inner uc_globalnav" role="navigation" id="ucNav">
-         <div class="container">
-           <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           </a>
-           <div class="nav-collapse collapse">
-             <ul class="nav">
-              <li><a class="uc_NavLink" href="http://www.uc.edu?from=uc_globalnav">UC Home</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/visitors.html?from=uc_globalnav">Visit UC</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/foundation.html?from=uc_globalnav">Support&nbsp;UC&nbsp;<i class="fa fa-play"></i></a></li>
-              <li><a class="uc_NavLink" href="https://ucdirectory.uc.edu/?from=uc_globalnav">Directories</a></li>
-              <li class="dropdown"> <a href="#" class="dropdown-toggle uc_NavLink" data-toggle="dropdown">UC Tools <b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://blackboard.uc.edu?from=uctools">Blackboard</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://bblearn.uc.edu?from=uctools">BbLearn</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://onestop.uc.edu?from=uctools">OneStop</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://mail.uc.edu?from=uctools">Student Email</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucowa.uc.edu/?from=uctools">UCMail</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucfilespace.uc.edu/?from=uctools">UCFileSpace</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://www.ucflex.uc.edu/">UC Flex/ESS</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://www.uc.edu/pss/?from=uctools">Password Help</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://sslvpn.uc.edu?from=uctools">UC VPN</a></li>
-                </ul>
-              </li>
-            </ul>
-           </div>
-         </div>
-       </div>
-    </div>
-  </div>
 <header id="banner" role="banner">
     <hgroup>
       <br clear="all" />
@@ -89,9 +55,10 @@
 <h2>Please try the following:</h2>
 <ul>
   <li>If you typed the page address in the Address bar, make sure that it is spelled correctly. </li>
-  <li>Go to the <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
+  <li>Go to <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
   <li>Click the Back button on your browser to try another link. </li>
   <li>If you reached this page using a bookmark, the page you're looking for may have moved.</li>
+  <li><a href="/contact_requests/new">Contact us</a> for assistance.</li>
 </ul>
   </div>
 </body>

--- a/public/500.html
+++ b/public/500.html
@@ -21,40 +21,6 @@
 </head>
 
 <body>
-  <div id="uc_header">
-    <div class="uc_globalnavResponsive section navbar navbar-inverse navbar-static-top">
-       <div class="navbar-inner uc_globalnav" role="navigation" id="ucNav">
-         <div class="container">
-           <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           <span class="icon-bar"></span>
-           </a>
-           <div class="nav-collapse collapse">
-             <ul class="nav">
-              <li><a class="uc_NavLink" href="http://www.uc.edu?from=uc_globalnav">UC Home</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/visitors.html?from=uc_globalnav">Visit UC</a></li>
-              <li><a class="uc_NavLink" href="http://www.uc.edu/foundation.html?from=uc_globalnav">Support&nbsp;UC&nbsp;<i class="fa fa-play"></i></a></li>
-              <li><a class="uc_NavLink" href="https://ucdirectory.uc.edu/?from=uc_globalnav">Directories</a></li>
-              <li class="dropdown"> <a href="#" class="dropdown-toggle uc_NavLink" data-toggle="dropdown">UC Tools <b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://blackboard.uc.edu?from=uctools">Blackboard</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://bblearn.uc.edu?from=uctools">BbLearn</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://onestop.uc.edu?from=uctools">OneStop</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://mail.uc.edu?from=uctools">Student Email</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucowa.uc.edu/?from=uctools">UCMail</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://ucfilespace.uc.edu/?from=uctools">UCFileSpace</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://www.ucflex.uc.edu/">UC Flex/ESS</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="http://www.uc.edu/pss/?from=uctools">Password Help</a></li>
-                  <li class="uc_ToolDropItem"><a class="uc_ToolDropLink" href="https://sslvpn.uc.edu?from=uctools">UC VPN</a></li>
-                </ul>
-              </li>
-            </ul>
-           </div>
-         </div>
-       </div>
-    </div>
-  </div>
 <header id="banner" role="banner">
     <hgroup>
       <br clear="all" />
@@ -92,9 +58,10 @@
 <h2>Please try the following:</h2>
 <ul>
   <li>If you typed the page address in the Address bar, make sure that it is spelled correctly. </li>
-  <li>Go to the <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
+  <li>Go to <a href="/">scholar.uc.edu</a>, and then look for links to the information you want.</li>
   <li>Click the Back button on your browser to try another link. </li>
   <li>If you reached this page using a bookmark, the page you're looking for may have moved.</li>
+  <li><a href="/contact_requests/new">Contact us</a> for assistance.</li>
 </ul>
   </div>
 </body>


### PR DESCRIPTION
Closes #395 

I read up a bit on error page best practice before editing these. The recommendations were to make the branding as consistent as possible while providing only useful actions. Accordingly, I kept the Scholar@UC header, and added a link to the Contact page as a final item on the list of actions. I removed the UC header, because that's most likely to change and least likely to help a user encountering an error.

![image](https://cloud.githubusercontent.com/assets/2651187/9409453/b295021c-47e8-11e5-81c5-0b4d427accc9.png)
