### PR TITLE
remove relative links from welcome and collection policy pages

### DIFF
--- a/app/views/page_requests/coll_policy.html.erb
+++ b/app/views/page_requests/coll_policy.html.erb
@@ -25,7 +25,7 @@
 </p>
 <p>
 	<b>Intellectual Property, Copyright, and Access</b>
-	<br/>In order to submit content to Scholar@UC, creators must agree to a <a href="https://scholar.uc.edu/distribution_license_request">non-exclusive distribution license</a> that authorizes UC to preserve, to transform, to enhance metadata, and to make available their content. Creators may choose, though are not required, to issue their content with a <a href="https://creativecommons.org/about">Creative Commons license</a> that clearly indicates how their content may be reused. Creators may choose to issue content as public domain or all rights reserved.
+	<br/>In order to submit content to Scholar@UC, creators must agree to a <a href="/distribution_license_request">non-exclusive distribution license</a> that authorizes UC to preserve, to transform, to enhance metadata, and to make available their content. Creators may choose, though are not required, to issue their content with a <a href="https://creativecommons.org/about">Creative Commons license</a> that clearly indicates how their content may be reused. Creators may choose to issue content as public domain or all rights reserved.
 </p>
 <p>
 	Creators are able to control access to their content. Creators may choose to make content visible to themselves only, to a group of predetermined individuals, to embargo content for a defined time period, or to make their content open access.

--- a/app/views/welcome_page/_welcome_text.html.erb
+++ b/app/views/welcome_page/_welcome_text.html.erb
@@ -2,10 +2,10 @@
 <p>Welcome to Scholar@UC! On this page, you will learn how to use Scholar@UC.</p>
 
 <h3 id="what-is-scholaruc">What is Scholar@UC?</h3>
-<p>Scholar@UC is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of Scholar@UC on the <a href="https://scholar.uc.edu/about_request">About page</a>. Get the latest updates on development of Scholar@UC on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
+<p>Scholar@UC is a digital repository that enables the University of Cincinnati community to share research and scholarly work with a worldwide audience and preserve it for the future. Read more about the mission of Scholar@UC on the <a href="/about_request">About page</a>. Get the latest updates on development of Scholar@UC on our <a href="http://libapps.libraries.uc.edu/scholarblog/">Scholarblog</a>.</p>
 
 <h3 id="what-types-of-content-should-i-submit-to-scholaruc">What types of content should I submit to Scholar@UC?</h3>
-<p>Scholar@UC stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <a href="https://scholar.uc.edu/coll_pol_request">Collection Policy</a>.</p>
+<p>Scholar@UC stores and preserves the scholarly output and creative works of UC faculty, staff, and students. Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>, <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature. Learn more about types of content you can share on the <a href="/coll_pol_request">Collection Policy</a>.</p>
 <p>Students should work with a faculty member to share scholarly output and creative works, such a capstone projects.</p>
 
 <h3 id="how-do-i-get-started">How do I get started?</h3>
@@ -15,10 +15,10 @@
 <p>Under the Help button on the main Scholar@UC menu, you will find the following help topics:</p>
 
 <ul>
-  <li><a href="https://scholar.uc.edu/faq_request">FAQs</a> – Answers to a variety of commonly asked questions</li> 
-  <li><a href="https://scholar.uc.edu/format_advice_request">File Format Advice</a> – Help with finding the right file format for the content you submit to Scholar@UC</li> 
-  <li><a href="https://scholar.uc.edu/creators_rights_request">Creator’s Rights</a> – Information on Copyright and Intellectual Property</li>
+  <li><a href="/faq_request">FAQs</a> – Answers to a variety of commonly asked questions</li> 
+  <li><a href="/format_advice_request">File Format Advice</a> – Help with finding the right file format for the content you submit to Scholar@UC</li> 
+  <li><a href="/creators_rights_request">Creator’s Rights</a> – Information on Copyright and Intellectual Property</li>
 </ul>
 
 <h4 id="need-further-assistance">Need Further Assistance?</h4>
-<p><a href="https://scholar.uc.edu/contact_requests/new">Contact the Scholar@UC Team</a>.</p>
+<p><a href="/contact_requests/new">Contact the Scholar@UC Team</a>.</p>


### PR DESCRIPTION
Used grep to confirm there weren't any other hardcoded references to the root page.

Closes #442 