### PR TITLE
Change error page images from relative to absolute links

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -27,12 +27,12 @@
 <div id="title-bar" class="row-fluid">
             <div class="span12">
             <div id="site-title" class="pull-left">
-              <a href="https://scholar.uc.edu"><img src="scholar@uc.png" alt="scholar.uc.edu"></a>
+              <a href="https://scholar.uc.edu"><img src="/scholar@uc.png" alt="scholar.uc.edu"></a>
     	         <h6 id="site-subtitle">The UC digital repository, part of the <a href="http://research.uc.edu">UC Research Hub.</a></h6>
             </div>
 
             <div id="logo" class="pull-right visible-desktop">
-             <a href="http://www.uc.edu/"> <img src="UC_logo.png" alt="uc.edu"></a>
+             <a href="http://www.uc.edu/"> <img src="/UC_logo.png" alt="uc.edu"></a>
             </div>
           </div>
           </div>
@@ -70,7 +70,7 @@ The page you are looking for may have been removed, had its name changed, or is 
       <p>
         Brought to you by the <a href="http://libraries.uc.edu/">University of Cincinnati Libraries</a> and <a href="http://ucit.uc.edu/">UC Information Technologies</a>.<br />
         Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
-        <a href="http://projecthydra.org/"><img src="powered_by_hydra.png" alt="Powered by Hydra"></a>
+        <a href="http://projecthydra.org/"><img src="/powered_by_hydra.png" alt="Powered by Hydra"></a>
       </p>
 
     </div>

--- a/public/422.html
+++ b/public/422.html
@@ -27,12 +27,12 @@
 <div id="title-bar" class="row-fluid">
             <div class="span12">
             <div id="site-title" class="pull-left">
-              <a href="https://scholar.uc.edu"><img src="scholar@uc.png" alt="scholar.uc.edu"></a>
+              <a href="https://scholar.uc.edu"><img src="/scholar@uc.png" alt="scholar.uc.edu"></a>
     	         <h6 id="site-subtitle">The UC digital repository, part of the <a href="http://research.uc.edu">UC Research Hub.</a></h6>
             </div>
 
             <div id="logo" class="pull-right visible-desktop">
-             <a href="http://www.uc.edu/"> <img src="UC_logo.png" alt="uc.edu"></a>
+             <a href="http://www.uc.edu/"> <img src="/UC_logo.png" alt="uc.edu"></a>
             </div>
           </div>
           </div>
@@ -68,7 +68,7 @@
       <p>
         Brought to you by the <a href="http://libraries.uc.edu/">University of Cincinnati Libraries</a> and <a href="http://ucit.uc.edu/">UC Information Technologies</a>.<br />
         Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
-        <a href="http://projecthydra.org/"><img src="powered_by_hydra.png" alt="Powered by Hydra"></a>
+        <a href="http://projecthydra.org/"><img src="/powered_by_hydra.png" alt="Powered by Hydra"></a>
       </p>
 
     </div>

--- a/public/500.html
+++ b/public/500.html
@@ -29,12 +29,12 @@
 <div id="title-bar" class="row-fluid">
             <div class="span12">
             <div id="site-title" class="pull-left">
-              <a href="https://scholar.uc.edu"><img src="scholar@uc.png" alt="scholar.uc.edu"></a>
+              <a href="https://scholar.uc.edu"><img src="/scholar@uc.png" alt="scholar.uc.edu"></a>
     	         <h6 id="site-subtitle">The UC digital repository, part of the <a href="http://research.uc.edu">UC Research Hub.</a></h6>
             </div>
 
             <div id="logo" class="pull-right visible-desktop">
-             <a href="http://www.uc.edu/"> <img src="UC_logo.png" alt="uc.edu"></a>
+             <a href="http://www.uc.edu/"> <img src="/UC_logo.png" alt="uc.edu"></a>
             </div>
           </div>
           </div>
@@ -71,7 +71,7 @@
       <p>
         Brought to you by the <a href="http://libraries.uc.edu/">University of Cincinnati Libraries</a> and <a href="http://ucit.uc.edu/">UC Information Technologies</a>.<br />
         Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
-        <a href="http://projecthydra.org/"><img src="powered_by_hydra.png" alt="Powered by Hydra"></a>
+        <a href="http://projecthydra.org/"><img src="/powered_by_hydra.png" alt="Powered by Hydra"></a>
       </p>
 
     </div>


### PR DESCRIPTION
The images on the 400/500/422 error pages were relative instead of absolute.  That means that https://scholar.uc.edu/notfound looks fine, but https://scholar.uc.edu/not/found has broken images.  This commit fixes that.