### PR TITLE
Allow password resets for uc.edu users when shibboleth is turned off

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -3,9 +3,9 @@ class Devise::PasswordsController
 
   # POST /resource/password
   def create
-    if resource_params['email'].end_with? '@uc.edu'
-      redirect_to login_path
-      flash[:notice] = "You cannot reset passwords for @uc.edu accounts.  Use your UC Central Login instead"
+    if AUTH_CONFIG['shibboleth_enabled'] && (resource_params['email'].end_with? '@uc.edu')
+        redirect_to login_path
+        flash[:notice] = "You cannot reset passwords for @uc.edu accounts.  Use your UC Central Login instead"
     else
       self.resource = resource_class.send_reset_password_instructions(resource_params)
       yield resource if block_given?

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,8 @@
 <h2>Forgot your password?</h2>
 
-<p>Note: If you have a <strong>uc.edu</strong> email address, do <strong>not</strong> use this form to reset your password. Use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p> 
+  <% if AUTH_CONFIG['shibboleth_enabled'] %>
+    <p>Note: If you have a <strong>uc.edu</strong> email address, do <strong>not</strong> use this form to reset your password. Use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p> 
+  <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= devise_error_messages! %>

--- a/config/authentication.yml
+++ b/config/authentication.yml
@@ -1,11 +1,11 @@
 development:
-  shibboleth_enabled: false 
+  shibboleth_enabled: false
   signups_enabled:    true
 
 test:
-  shibboleth_enabled: false 
-  signups_enabled:    true 
+  shibboleth_enabled: true
+  signups_enabled:    false
 
 production:
   shibboleth_enabled: false
-  signups_enabled:    true 
+  signups_enabled:    true

--- a/config/authentication.yml.sample
+++ b/config/authentication.yml.sample
@@ -3,8 +3,8 @@ development:
   signups_enabled:    true
 
 test:
-  shibboleth_enabled: false
-  signups_enabled:    true
+  shibboleth_enabled: true
+  signups_enabled:    false
 
 production:
   shibboleth_enabled: false

--- a/config/initializers/curate_config.rb
+++ b/config/initializers/curate_config.rb
@@ -9,7 +9,7 @@ Curate.configure do |config|
   # config.default_antivirus_instance = lambda {|filename| … }
 
   # # Used for constructing permanent URLs
-  config.application_root_url = 'bamboo_application_url'
+  config.application_root_url = 'http://localhost:3000/'
 
   # # Override the file characterization runner that is used
   # config.characterization_runner = lambda {|filename| … }

--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -21,7 +21,11 @@ describe 'UC account workflow', FeatureSupport.options do
   describe 'overridden devise password reset page' do
     it 'shows a Central Login option' do
       visit new_user_password_path
-      page.should have_content('Central Login form')
+      if yaml['test']['shibboleth_enabled'] == true
+        page.should have_content('Central Login form')
+      else
+        page.should_not have_content('Central Login form')
+      end
     end
 
     it 'does not display the Shared links at the bottom' do

--- a/spec/views/shared/_brand_bar.html.erb_spec.rb
+++ b/spec/views/shared/_brand_bar.html.erb_spec.rb
@@ -8,7 +8,14 @@ describe 'shared/_brand_bar.html.erb' do
   end
 
   def have_login_section
-    have_tag('.login', with: { href: new_user_session_path } )
+    filepath = "config/authentication.yml"
+    yaml = YAML.load_file(filepath)
+
+    if yaml['test']['shibboleth_enabled'] == true
+      have_tag('.login', with: { href: login_path } )
+    else
+      have_tag('.login', with: { href: new_user_session_path } )
+    end
   end
 
   def have_user_menu_section(&block)


### PR DESCRIPTION
There is a bug in the SHibboleth implementation that prevents uc.edu addresses from doing a password reset even when Shibboleth authentication is turned off.  So when Scholar is running on larry with no shibboleth, uc.edu user are currently unable to do a password reset.  This commit resolves that issue.

<!---
@huboard:{"order":427.75,"milestone_order":482,"custom_state":""}
-->
