### PR TITLE
Replace uid with email for person and profile objects (hotfix)

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -27,10 +27,10 @@ class CallbacksController < Devise::OmniauthCallbacksController
                   ucstatus: omni.extra.raw_info.uceduPrimaryAffiliation,
               ucdepartment: omni.extra.raw_info.ou
 
-      @profile = Profile.create depositor: @user.uid,
+      @profile = Profile.create depositor: @user.email,
                                     title: @user.title
 
-      @person = Person.create depositor: @user.uid,
+      @person = Person.create depositor: @user.email,
                              first_name: @user.first_name,
                               last_name: @user.last_name,
                                   email: @user.email

--- a/config/authentication.yml.bamboo
+++ b/config/authentication.yml.bamboo
@@ -7,5 +7,5 @@ test:
   signups_enabled:    false
 
 production:
-  shibboleth_enabled: false
+  shibboleth_enabled: true
   signups_enabled:    false


### PR DESCRIPTION
The person and profile objects were accidentally using the user's uid instead of email address.  This has been fixed on production, but the change now needs to be committed and merged.

This also includes a commit to turn shibboleth authentication on for future deploys.