### PR TITLE
Update all gems to latest versions (rebase and merge after PR #559)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/uclibs/curate_fork.git
-  revision: 98e0eda8ba58aa4dcd8a237e2b0a6667f650780d
-  ref: 98e0eda8ba58aa4dcd8a237e2b0a6667f650780d
+  revision: 0bb1b747903aaea559aabf38b558f8354000efb5
+  ref: 0bb1b747903aaea559aabf38b558f8354000efb5
   specs:
     curate (0.6.6)
       active_attr
@@ -89,7 +89,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    backports (3.6.6)
+    backports (3.6.7)
     bcrypt (3.1.10)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -107,7 +107,7 @@ GEM
       sass-rails
     block_helpers (0.3.3)
       activesupport (>= 2.0)
-    bootstrap-datepicker-rails (1.4.0)
+    bootstrap-datepicker-rails (1.5.0)
       railties (>= 3.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -115,7 +115,7 @@ GEM
       activesupport
       rack
     breadcrumbs_on_rails (2.3.1)
-    browse-everything (0.8.4)
+    browse-everything (0.9.1)
       bootstrap-sass
       dropbox-sdk (>= 1.6.2)
       font-awesome-rails
@@ -140,14 +140,14 @@ GEM
       activesupport (>= 3.2.0)
       json (>= 1.7)
       mime-types (>= 1.16)
-    childprocess (0.5.6)
+    childprocess (0.5.8)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     clamav (0.4.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
-    cocaine (0.5.7)
+    cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
     coercible (1.0.0)
@@ -158,7 +158,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.9.1.1)
+    coffee-script-source (1.10.0)
     daemons (1.2.3)
     debug_inspector (0.0.2)
     deprecation (0.2.2)
@@ -180,6 +180,9 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
+    exception_notification (4.1.1)
+      actionmailer (>= 3.0.4)
+      activesupport (>= 3.0.4)
     execjs (2.6.0)
     extlib (0.9.16)
     factory_girl (4.2.0)
@@ -187,7 +190,7 @@ GEM
     factory_girl_rails (4.2.1)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.10)
@@ -208,8 +211,8 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    google_drive (1.0.1)
-      google-api-client (>= 0.7.0)
+    google_drive (1.0.4)
+      google-api-client (>= 0.7.0, < 0.9)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
@@ -220,7 +223,7 @@ GEM
       memoist (~> 0.12)
       multi_json (~> 1.11)
       signet (~> 0.6)
-    hashie (3.4.2)
+    hashie (3.4.3)
     hike (1.2.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
@@ -257,7 +260,7 @@ GEM
       activesupport (>= 3.2.13, < 5.0)
       hydra-file_characterization
       mini_magick
-    hydra-file_characterization (0.3.2)
+    hydra-file_characterization (0.3.3)
       activesupport (>= 3.0.0)
     hydra-head (6.4.2)
       hydra-access-controls (= 6.4.2)
@@ -280,7 +283,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.1)
+    jwt (1.5.2)
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -301,12 +304,12 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    memoist (0.12.0)
+    memoist (0.13.0)
     mime-types (1.25.1)
     mimemagic (0.3.0)
     mini_magick (3.8.1)
       subexec (~> 0.2.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (4.7.5)
     mono_logger (1.1.0)
     morphine (0.1.1)
@@ -318,9 +321,9 @@ GEM
       redis
     noid (0.6.6)
       backports
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    nom-xml (0.5.3)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
+    nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
@@ -353,7 +356,7 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    poltergeist (1.7.0)
+    poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -394,7 +397,7 @@ GEM
       rdf (~> 1.1)
     rdoc (4.2.0)
       json (~> 1.4)
-    redis (3.2.1)
+    redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
@@ -410,7 +413,7 @@ GEM
     rest-client (1.6.9)
       mime-types (~> 1.16)
     retriable (1.4.1)
-    rsolr (1.0.12)
+    rsolr (1.0.13)
       builder (>= 2.1.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -491,7 +494,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
+    sqlite3 (1.3.11)
     stomp (1.3.4)
     subexec (0.2.3)
     sufia-models (3.4.0)
@@ -516,7 +519,7 @@ GEM
     trollop (1.16.2)
     turbolinks (2.5.3)
       coffee-rails
-    tzinfo (0.3.45)
+    tzinfo (0.3.46)
     uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -533,7 +536,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.3)
       rack (>= 1.0)
-    websocket-driver (0.6.2)
+    websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xml-simple (1.1.5)
@@ -554,6 +557,7 @@ DEPENDENCIES
   curate!
   devise
   devise-guests (~> 0.3)
+  exception_notification
   factory_girl_rails (~> 4.2.0)
   font-awesome-rails (= 4.2.0.0)
   font-awesome-sass


### PR DESCRIPTION
* tzinfo 0.3.46 (was 0.3.45)
* nokogiri 1.6.7 (was 1.6.6.2) with native extensions
* nom-xml 0.5.4 (was 0.5.3)
* rsolr 1.0.13 (was 1.0.12)
* backports 3.6.7 (was 3.6.6)
* bootstrap-datepicker-rails 1.5.0 (was 1.4.0)
* faraday 0.9.2 (was 0.9.1)
* jwt 1.5.2 (was 1.5.1)
* memoist 0.13.0 (was 0.12.0)
* google_drive 1.0.4 (was 1.0.1)
* browse-everything 0.9.1 (was 0.8.4)
* childprocess 0.5.8 (was 0.5.6)
* cocaine 0.5.8 (was 0.5.7)
* coffee-script-source 1.10.0 (was 1.9.1.1)
* hydra-file_characterization 0.3.3 (was 0.3.2)
* redis 3.2.2 (was 3.2.1)
* hashie 3.4.3 (was 3.4.2)
* websocket-driver 0.6.3 (was 0.6.2)
* poltergeist 1.8.1 (was 1.7.0)
* sqlite3 1.3.11 (was 1.3.10)