### PR TITLE
Bypass login page when user already logged in

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,16 +1,20 @@
 class CallbacksController < Devise::OmniauthCallbacksController
   def shibboleth
-    @omni = request.env["omniauth.auth"]
-    @email = use_uid_if_email_is_blank
+    unless current_user
+      @omni = request.env["omniauth.auth"]
+      @email = use_uid_if_email_is_blank
 
-    unless user_exists?
-      create_user
-      create_profile
-      create_person
+      unless user_exists?
+        create_user
+        create_profile
+        create_person
+      end
+
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
+    else
+      redirect_to catalog_index_path
     end
-
-    sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
-    flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
   end
 
   private

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -13,7 +13,7 @@ class CallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
       flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
     else
-      redirect_to catalog_index_path
+      redirect_to landing_page
     end
   end
 

--- a/app/controllers/page_requests_controller.rb
+++ b/app/controllers/page_requests_controller.rb
@@ -38,7 +38,7 @@ class PageRequestsController < ApplicationController
 
   def login
     if current_user
-      redirect_to catalog_index_path
+      redirect_to landing_page
     elsif AUTH_CONFIG['shibboleth_enabled']
       render 'login'
     else

--- a/app/controllers/page_requests_controller.rb
+++ b/app/controllers/page_requests_controller.rb
@@ -37,7 +37,9 @@ class PageRequestsController < ApplicationController
   end
 
   def login
-    if AUTH_CONFIG['shibboleth_enabled']
+    if current_user
+      redirect_to catalog_index_path
+    elsif AUTH_CONFIG['shibboleth_enabled']
       render 'login'
     else
       redirect_to new_user_session_path

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -21,5 +21,17 @@ describe CallbacksController do
       expect(response).to be_redirect
     end
   end
+
+  context 'with a user who is already logged in' do
+    let(:user) { FactoryGirl.create(:user) }
+    before do
+      controller.stub(:current_user).and_return(user)
+    end
+    it 'redirects to catalog index path' do
+      get :shibboleth
+      response.should redirect_to(catalog_index_path)
+    end
+  end
+
 end
 

--- a/spec/controllers/page_requests_controller_spec.rb
+++ b/spec/controllers/page_requests_controller_spec.rb
@@ -8,7 +8,7 @@ describe PageRequestsController do
         expect(response).to render_template('terms')
     end
   end
-  
+
    describe '#view_distribution_license' do
     it 'renders a distribution license page' do
         get :view_distribution_license
@@ -64,5 +64,17 @@ describe PageRequestsController do
       expect(response).to render_template('creators_rights')
     end
   end
+
+  describe '#login' do
+    let(:user) { FactoryGirl.create(:user) }
+    before do
+      controller.stub(:current_user).and_return(user)
+    end
+    it 'redirects to catalog index path when already logged in' do
+      get :login
+      response.should redirect_to(catalog_index_path)
+    end
+  end
+
 end
 


### PR DESCRIPTION
closes #568

Redirect /login and /users/auth/shibboleth to /catalog when a user
is already logged in. This may help with Hailstorm traversals.