### PR TITLE
Bundle update all gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       ruby-box
       sass-rails
       skydrive
-    browser (1.0.1)
+    browser (1.1.0)
     builder (3.1.4)
     cancan (1.6.10)
     capybara (2.5.0)
@@ -180,7 +180,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    exception_notification (4.1.2)
+    exception_notification (4.1.3)
       actionmailer (~> 4.0)
       activesupport (~> 4.0)
     execjs (2.6.0)
@@ -211,7 +211,7 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    google_drive (1.0.4)
+    google_drive (1.0.5)
       google-api-client (>= 0.7.0, < 0.9)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
@@ -321,7 +321,7 @@ GEM
       redis
     noid (0.6.6)
       backports
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
@@ -341,9 +341,9 @@ GEM
       mediashelf-loggable
       nokogiri (>= 1.4.2)
       solrizer (~> 3.1.0)
-    omniauth (1.2.2)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
@@ -395,7 +395,7 @@ GEM
       rdf-xsd (>= 1.0)
     rdf-xsd (1.1.2)
       rdf (~> 1.1)
-    rdoc (4.2.0)
+    rdoc (4.2.1)
       json (~> 1.4)
     redis (3.2.2)
     redis-namespace (1.5.2)
@@ -460,7 +460,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    signet (0.7.0)
+    signet (0.7.2)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
-  remote: https://github.com/uclibs/curate_fork.git
-  revision: 0bb1b747903aaea559aabf38b558f8354000efb5
-  ref: 0bb1b747903aaea559aabf38b558f8354000efb5
+  remote: https://github.com/uclibs/curate.git
+  revision: 3a222ed6774a2a14ea4f074d38abe2d0e9a4705c
+  ref: 3a222ed6774a2a14ea4f074d38abe2d0e9a4705c
   specs:
     curate (0.6.6)
       active_attr
@@ -79,7 +79,7 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     acts_as_follower (0.2.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     arel (4.0.2)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
@@ -180,9 +180,9 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    exception_notification (4.1.1)
-      actionmailer (>= 3.0.4)
-      activesupport (>= 3.0.4)
+    exception_notification (4.1.2)
+      actionmailer (~> 4.0)
+      activesupport (~> 4.0)
     execjs (2.6.0)
     extlib (0.9.16)
     factory_girl (4.2.0)
@@ -196,7 +196,7 @@ GEM
     ffi (1.9.10)
     font-awesome-rails (4.2.0.0)
       railties (>= 3.2, < 5.0)
-    font-awesome-sass (4.4.0)
+    font-awesome-sass (4.5.0)
       sass (>= 3.2)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
@@ -216,13 +216,13 @@ GEM
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
-    googleauth (0.4.2)
+    googleauth (0.5.0)
       faraday (~> 0.9)
       jwt (~> 1.4)
       logging (~> 2.0)
       memoist (~> 0.12)
       multi_json (~> 1.11)
-      signet (~> 0.6)
+      signet (~> 0.7)
     hashie (3.4.3)
     hike (1.2.3)
     hooks (0.3.6)
@@ -304,7 +304,7 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    memoist (0.13.0)
+    memoist (0.14.0)
     mime-types (1.25.1)
     mimemagic (0.3.0)
     mini_magick (3.8.1)
@@ -460,9 +460,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    signet (0.6.1)
+    signet (0.7.0)
       addressable (~> 2.3)
-      extlib (~> 0.9)
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
@@ -534,7 +533,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.3)
+    warden (1.2.4)
       rack (>= 1.0)
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)


### PR DESCRIPTION
Gems updated on 1/04/15:

* addressable 2.4.0 (was 2.3.8)
* memoist 0.14.0 (was 0.13.0)
* signet 0.7.2 (was 0.6.1)
* googleauth 0.5.0 (was 0.4.2)
* warden 1.2.4 (was 1.2.3)
* exception_notification 4.1.3 (was 4.1.1)
* font-awesome-sass 4.5.0 (was 4.4.0)
* nokogiri 1.6.7.1 (was 1.6.7)
* browser 1.1.0 (was 1.0.1)
* omniauth 1.3.1 (was 1.2.2)
* rdoc 4.2.1 (was 4.2.0)