### PR TITLE
Log out of Shibboleth IdP after application logout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   gem 'rspec-html-matchers', '~>0.4'
   gem 'rspec-rails', '~>2.14.0'
   gem 'capybara', "~> 2.1"
+  gem 'show_me_the_cookies'
 #  gem 'vcr'
 #  gem 'webmock'
 #  gem 'database_cleaner', '< 1.1.0'
@@ -86,3 +87,4 @@ end
 gem 'omniauth-openid'
 gem 'omniauth-shibboleth'
 gem 'feedjira'
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,4 +23,14 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  private
+
+  def after_sign_out_path_for(resource_or_scope)
+    if cookies[:login_type] == "shibboleth"
+      "/Shibboleth.sso/Logout?return=https%3A%2F%2Fbamboo_shibboleth_logout%2Fidp%2Fprofile%2FLogout"
+    else
+      root_path
+    end
+  end
 end

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -11,6 +11,7 @@ class CallbacksController < Devise::OmniauthCallbacksController
       end
 
       sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      cookies[:login_type] = "shibboleth"
       flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
     else
       redirect_to landing_page

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,9 @@
+require Curate::Engine.root.join('app/controllers/sessions_controller.rb')
+class SessionsController
+
+  def create
+    cookies[:login_type] = "local"
+    super
+  end
+
+end

--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -131,4 +131,20 @@ describe 'UC account workflow', FeatureSupport.options do
       expect(page).to have_content 'You updated your account successfully'
     end
   end
+
+  describe 'a user using a UC Shibboleth login' do
+    it "redirects to the UC Shibboleth logout page after logout" do
+      create_cookie('login_type', 'shibboleth')
+      visit('/users/sign_out')
+      page.should have_content("You have been logged out of the University of Cincinnati's Login Service")
+    end
+  end
+
+  describe 'a user using a local login' do
+    it "redirects to the home page after logout" do
+      create_cookie('login_type', 'local')
+      visit('/users/sign_out')
+      page.should have_title("Scholar@UC")
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,4 +44,7 @@ RSpec.configure do |config|
 
   #Include FactoryGirl syntax
   config.include FactoryGirl::Syntax::Methods
+
+  # Allow cookies to be set in feature tests (for UC Shibboleth testing)
+  config.include ShowMeTheCookies, :type => :feature
 end

--- a/spec/support/test_routes.rb
+++ b/spec/support/test_routes.rb
@@ -1,0 +1,11 @@
+class ShibbolethLogoutController < ActionController::Base
+  def show
+    render text: "You have been logged out of the University of Cincinnati's Login Service"
+  end
+end
+
+test_routes = Proc.new do
+  get '/Shibboleth.sso/Logout' => 'shibboleth_logout#show'
+end
+
+Rails.application.routes.eval_block(test_routes)


### PR DESCRIPTION
Note: This adds a new gem called show_me_the_cookies to the test section of the Gemfile that allows feature tests to set cookies.  This also stubs a "/Shibboleth.sso/Logout" route in the specs since we can't test the true Shibboleth logout URL in our local environments.

closes #558 