### PR TITLE
Add Bamboo deploy tasks and crontabs

### DIFF
--- a/script/bamboo_deploy_dev.sh
+++ b/script/bamboo_deploy_dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This is a copy of the tasks performed by Bamboo to deploy to scholar-dev.uc.edu
+
+echo "The deploy to https://scholar-dev.uc.edu has started" | mail -s 'Scholar@UC deploy started (scholar-dev)' scholar@uc.edu
+rm -rf /srv/apps/curate_uc/*
+cp -R /srv/apps/curate/curate_uc-STAGE/* /srv/apps/curate_uc
+cd /srv/apps/curate_uc
+chmod +x /srv/apps/curate_uc/script/*.sh
+/srv/apps/curate_uc/script/kill_resque_pool.sh
+export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin
+gem install --user-install bundler
+/srv/apps/curate_uc/script/copy_config_bamboo.sh
+bundle install --path vendor/bundle
+bundle exec rake db:migrate
+mkdir -p /srv/apps/curate_uc/tmp
+touch /srv/apps/curate_uc/tmp/restart.txt
+export PATH=$PATH:/opt/fits/fits-0.6.2/
+/usr/bin/crontab /srv/apps/curate_uc/script/crontab_dev
+/srv/apps/curate_uc/script/restart_resque.sh development
+echo "The deploy to https://scholar-dev.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar-dev)' scholar@uc.edu

--- a/script/bamboo_deploy_production.sh
+++ b/script/bamboo_deploy_production.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a copy of the tasks performed by Bamboo to deploy to scholar.uc.edu
+
+echo "The deploy to https://scholar.uc.edu has started" | mail -s 'Scholar@UC deploy started (scholar.uc.edu)' scholar@uc.edu
+/srv/apps/curate_uc/script/rotate_log.sh
+rm -rf /srv/apps/curate_uc/*
+cp -R /srv/apps/curate/curate_uc-STAGE/* /srv/apps/curate_uc
+cd /srv/apps/curate_uc
+chmod +x /srv/apps/curate_uc/script/*.sh
+/srv/apps/curate_uc/script/kill_resque_pool.sh
+cp /srv/apps/curate_uc/public/robots.prod.txt /srv/apps/curate_uc/public/robots.txt
+export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin:/opt/fits/fits-0.6.2/
+gem install --user-install bundler
+/srv/apps/curate_uc/script/copy_config_bamboo.sh
+bundle install --path vendor/bundle
+bundle exec rake db:migrate RAILS_ENV=production
+mkdir -p /srv/apps/curate_uc/tmp
+touch /srv/apps/curate_uc/tmp/restart.txt
+/usr/bin/crontab /srv/apps/curate_uc/script/crontab_production1
+/srv/apps/curate_uc/script/restart_resque.sh production
+echo "The deploy to https://scholar.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar.uc.edu)' scholar@uc.edu

--- a/script/bamboo_deploy_qa.sh
+++ b/script/bamboo_deploy_qa.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a copy of the tasks performed by Bamboo to deploy to scholar-qa.uc.edu
+
+echo "The deploy to https://scholar-qa.uc.edu has started" | mail -s 'Scholar@UC deploy started (scholar-qa)' scholar@uc.edu
+/srv/apps/curate_uc/script/rotate_log.sh
+rm -rf /srv/apps/curate_uc/*
+cp -R /srv/apps/curate/curate_uc-STAGE/* /srv/apps/curate_uc
+cd /srv/apps/curate_uc
+chmod +x /srv/apps/curate_uc/script/*.sh
+/srv/apps/curate_uc/script/kill_resque_pool.sh
+cp /srv/apps/curate_uc/public/robots.qa.txt /srv/apps/curate_uc/public/robots.txt
+export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin:/opt/fits/fits-0.6.2/
+gem install --user-install bundler
+/srv/apps/curate_uc/script/copy_config_bamboo.sh
+bundle install --path vendor/bundle
+bundle exec rake db:migrate RAILS_ENV=production
+mkdir -p /srv/apps/curate_uc/tmp
+touch /srv/apps/curate_uc/tmp/restart.txt
+/usr/bin/crontab /srv/apps/curate_uc/script/crontab_qa1
+/srv/apps/curate_uc/script/restart_resque.sh production
+echo "The deploy to https://scholar-qa.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar-qa)' scholar@uc.edu

--- a/script/crontab_dev
+++ b/script/crontab_dev
@@ -1,0 +1,5 @@
+0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhyddwl2 development
+30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhyddwl2
+30 9 * * 5 df -h
+1 0 * * * /srv/apps/curate_uc/script/release_embargo.sh 2> /dev/null
+0 * * * * export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin; cd /srv/apps/curate_uc; /srv/apps/.gem/ruby/2.1.0/bin/bundle exec rake rss_feed:update_feed 2> /dev/null

--- a/script/crontab_production1
+++ b/script/crontab_production1
@@ -1,0 +1,6 @@
+0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydpwl1 production
+30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydpwl1
+30 9 * * 5 df -h
+0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh
+0 1 * * * /srv/apps/curate_uc/script/release_embargo.sh 2> /dev/null
+0 * * * * export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin; cd /srv/apps/curate_uc; /srv/apps/.gem/ruby/2.1.0/bin/bundle exec rake rss_feed:update_feed

--- a/script/crontab_production2
+++ b/script/crontab_production2
@@ -1,0 +1,5 @@
+0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydpwl2 production
+30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydpwl2
+0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh
+30 9 * * 5 df -h
+10 0 * * * /srv/apps/curate_uc/script/release_embargo.sh

--- a/script/crontab_qa1
+++ b/script/crontab_qa1
@@ -1,0 +1,6 @@
+0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydqwl1 production
+30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydqwl1
+30 9 * * 5 df -h
+0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh
+1 0 * * * /srv/apps/curate_uc/script/release_embargo.sh
+0 * * * * export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin; cd /srv/apps/curate_uc; /srv/apps/.gem/ruby/2.1.0/bin/bundle exec rake rss_feed:update_feed

--- a/script/crontab_qa2
+++ b/script/crontab_qa2
@@ -1,0 +1,5 @@
+0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydqwl2 production
+30 * * * * /srv/apps/curate_uc/script/resque_alert.sh LibHydQwl2
+30 9 * * 5 df -h
+0 1 1 * * /srv/apps/curate_uc/script/rotate_log.sh
+10 0 * * * /srv/apps/curate_uc/script/release_embargo.sh 2> /dev/null


### PR DESCRIPTION
A copy of the Bamboo deploy tasks are being committed here for
safekeeping and to track the history of changes.

The cron jobs for each server are being committed here for
safekeeping.  Updating a crontab file in the repo will also
update the actual cron jobs on the server during the next deploy.