### PR TITLE
Bundle update all gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,8 @@ GEM
     browser (1.1.0)
     builder (3.1.4)
     cancan (1.6.10)
-    capybara (2.5.0)
+    capybara (2.6.0)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -223,14 +224,6 @@ GEM
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
-    googleauth (0.5.1)
-      faraday (~> 0.9)
-      jwt (~> 1.4)
-      logging (~> 2.0)
-      memoist (~> 0.12)
-      multi_json (~> 1.11)
-      os (~> 0.9)
-      signet (~> 0.7)
     hashie (3.4.3)
     hike (1.2.3)
     hooks (0.3.6)
@@ -242,8 +235,6 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    httpclient (2.7.1)
-    hurley (0.2)
     hydra-access-controls (6.4.2)
       active-fedora (~> 6.7)
       activesupport
@@ -299,11 +290,7 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    little-plugger (1.1.4)
     logger (1.2.8)
-    logging (2.0.0)
-      little-plugger (~> 1.1)
-      multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -316,7 +303,6 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    memoist (0.14.0)
     mime-types (1.25.1)
     mimemagic (0.3.1)
     mini_magick (3.8.1)
@@ -333,7 +319,7 @@ GEM
       redis
     noid (0.6.6)
       backports
-    nokogiri (1.6.7.1)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
@@ -362,7 +348,6 @@ GEM
     omniauth-shibboleth (1.2.1)
       omniauth (>= 1.0.0)
     orm_adapter (0.5.0)
-    os (0.9.6)
     paperclip (3.4.2)
       activemodel (>= 3.0.0)
       activerecord (>= 3.0.0)
@@ -413,8 +398,6 @@ GEM
     redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    representable (2.3.0)
-      uber (~> 0.0.7)
     resque (1.25.2)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
@@ -476,6 +459,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    show_me_the_cookies (3.1.0)
+      capybara (~> 2.0)
     signet (0.7.2)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -592,9 +577,10 @@ DEPENDENCIES
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.0)
   sdoc
+  show_me_the_cookies
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
I'm doing another bundle update since the sprint was extended by a week.

nokogiri 1.6.7.2 (was 1.6.7.1) with native extensions
capybara 2.6.0 (was 2.5.0)