### PR TITLE
Adjust bamboo variable to use different Shibboleth logout URL for production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(resource_or_scope)
     if cookies[:login_type] == "shibboleth"
-      "/Shibboleth.sso/Logout?return=https%3A%2F%2Fbamboo_shibboleth_logout%2Fidp%2Fprofile%2FLogout"
+      "/Shibboleth.sso/Logout?return=https%3A%2F%2Fbamboo_shibboleth_logout"
     else
       root_path
     end


### PR DESCRIPTION
This commit uses a bamboo variable to construct the entire Shibboleth logout URL instead of just the Shibboleth logout domain name.  This is needed because production Shibboleth has a different logout URL that QA/dev.