### PR TITLE
Bundle update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: 1b7f3ca4eae69964d1e3630ed31529a950038803
-  ref: 1b7f3ca4eae69964d1e3630ed31529a950038803
+  revision: 999b7b514517eaef63c379095c3d30fa1cf55583
+  ref: 999b7b514517eaef63c379095c3d30fa1cf55583
   specs:
     curate (0.6.6)
       active_attr
@@ -66,7 +66,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.10.0)
+    activerecord-import (0.11.0)
       activerecord (>= 3.0)
     activeresource (4.0.0)
       activemodel (~> 4.0)
@@ -129,7 +129,8 @@ GEM
     browser (1.1.0)
     builder (3.1.4)
     cancan (1.6.10)
-    capybara (2.5.0)
+    capybara (2.6.2)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -223,14 +224,6 @@ GEM
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
-    googleauth (0.5.1)
-      faraday (~> 0.9)
-      jwt (~> 1.4)
-      logging (~> 2.0)
-      memoist (~> 0.12)
-      multi_json (~> 1.11)
-      os (~> 0.9)
-      signet (~> 0.7)
     hashie (3.4.3)
     hike (1.2.3)
     hooks (0.3.6)
@@ -242,8 +235,6 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    httpclient (2.7.1)
-    hurley (0.2)
     hydra-access-controls (6.4.2)
       active-fedora (~> 6.7)
       activesupport
@@ -280,7 +271,7 @@ GEM
       activesupport (>= 3.2.13, < 5.0)
       rest-client (~> 1.6.7)
     i18n (0.7.0)
-    ice_nine (0.11.1)
+    ice_nine (0.11.2)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2.0)
@@ -293,17 +284,13 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.2)
+    jwt (1.5.1)
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
-    little-plugger (1.1.4)
     logger (1.2.8)
-    logging (2.0.0)
-      little-plugger (~> 1.1)
-      multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -316,7 +303,6 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    memoist (0.14.0)
     mime-types (1.25.1)
     mimemagic (0.3.1)
     mini_magick (3.8.1)
@@ -333,19 +319,19 @@ GEM
       redis
     noid (0.6.6)
       backports
-    nokogiri (1.6.7.1)
+    nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
     oauth (0.4.7)
-    oauth2 (1.0.0)
+    oauth2 (1.1.0)
       faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+      jwt (~> 1.0, < 1.5.2)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
+      rack (>= 1.2, < 3)
     om (3.0.7)
       activemodel
       activesupport
@@ -362,14 +348,13 @@ GEM
     omniauth-shibboleth (1.2.1)
       omniauth (>= 1.0.0)
     orm_adapter (0.5.0)
-    os (0.9.6)
     paperclip (3.4.2)
       activemodel (>= 3.0.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    poltergeist (1.8.1)
+    poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -413,8 +398,6 @@ GEM
     redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    representable (2.3.0)
-      uber (~> 0.0.7)
     resque (1.25.2)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
@@ -476,6 +459,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    show_me_the_cookies (3.1.0)
+      capybara (~> 2.0)
     signet (0.7.2)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -484,8 +469,8 @@ GEM
     simple_form (3.0.4)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    sinatra (1.4.6)
-      rack (~> 1.4)
+    sinatra (1.4.7)
+      rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     skydrive (1.2.0)
@@ -541,7 +526,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     uuidtools (2.1.5)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -550,7 +535,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.4)
+    warden (1.2.6)
       rack (>= 1.0)
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
@@ -592,9 +577,10 @@ DEPENDENCIES
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.0)
   sdoc
+  show_me_the_cookies
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
ice_nine 0.11.2 (was 0.11.1)
unf_ext 0.0.7.2 (was 0.0.7.1)
jwt 1.5.1 (was 1.5.2)
warden 1.2.6 (was 1.2.4)
nokogiri 1.6.7.2 (was 1.6.7.1) with native extensions
sinatra 1.4.7 (was 1.4.6)
oauth2 1.1.0 (was 1.0.0)
capybara 2.6.2 (was 2.5.0)
activerecord-import 0.11.0 (was 0.10.0)
poltergeist 1.9.0 (was 1.8.1)