### PR TITLE
Removes Build from footer in application overwrite.

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -12,7 +12,7 @@
          <a href="http://uc.edu/about/policies/non-discrimination.html">Notice of Non-Discrimination</a>
       </p>
       <p>
-        Build: <%= Curate.configuration.build_identifier %>
+        <%= Curate.configuration.build_identifier %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
There was an app over-write with the _footer partial.  This PR helps close:  https://github.com/uclibs/curate/pull/21
