### PR TITLE
Add rake task to immediately run a solr reindex

### DIFF
--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -1,0 +1,7 @@
+namespace :solr do
+  desc "Resolrize the repository objects NOW"
+  task :reindexnow => :environment do
+    ActiveFedora::Base.reindex_everything
+  end
+end
+


### PR DESCRIPTION
This adds a simple rake task that immediately starts a solr reindex.  No background workers are needed.  I called the task "reindexnow" so it's clear that this task does not wait for workers to run.

`rake solr:reindexnow`

Since this task simply calls `ActiveFedora::Base.reindex_everything` and uses no new code, no tests are needed.  I did test this on scholar-qa by manually making changes in Fedora and then verifying the changes showed up in the index after running the reindex task.