### PR TITLE
Bundle update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,16 @@
 GIT
+  remote: git://github.com/uclibs/hydra-remote_identifier.git
+  revision: c757c798eda1bc6d2bd847d308cf09ae36cef90b
+  branch: setting-status
+  specs:
+    hydra-remote_identifier (0.6.8)
+      activesupport (>= 3.2.13, < 5.0)
+      rest-client (~> 1.7.3)
+
+GIT
   remote: https://github.com/uclibs/curate.git
-  revision: 5081228b23db80a8503e1b4e6336f9908d19f01b
-  ref: 5081228b23db80a8503e1b4e6336f9908d19f01b
+  revision: 715b3392aa0f224493d35067830dc28c416f947f
+  ref: 715b3392aa0f224493d35067830dc28c416f947f
   specs:
     curate (0.6.6)
       active_attr
@@ -66,7 +75,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.11.0)
+    activerecord-import (0.12.0)
       activerecord (>= 3.0)
     activeresource (4.0.0)
       activemodel (~> 4.0)
@@ -126,7 +135,7 @@ GEM
       ruby-box
       sass-rails
       skydrive
-    browser (1.1.0)
+    browser (2.0.2)
     builder (3.1.4)
     cancan (1.6.10)
     capybara (2.6.2)
@@ -150,7 +159,7 @@ GEM
     cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
-    coderay (1.1.0)
+    coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     coffee-rails (4.0.1)
@@ -219,7 +228,7 @@ GEM
       retriable (>= 1.4)
       signet (>= 0.5.0)
       uuidtools (>= 2.1.0)
-    google_drive (1.0.5)
+    google_drive (1.0.6)
       google-api-client (>= 0.7.0, < 0.9)
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
@@ -267,9 +276,6 @@ GEM
       hydra-access-controls (= 6.4.2)
       hydra-core (= 6.4.2)
       rails (>= 3.2.6)
-    hydra-remote_identifier (0.6.7)
-      activesupport (>= 3.2.13, < 5.0)
-      rest-client (~> 1.6.7)
     i18n (0.7.0)
     ice_nine (0.11.2)
     jbuilder (1.5.3)
@@ -303,7 +309,7 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    mime-types (1.25.1)
+    mime-types (2.99.1)
     mimemagic (0.3.1)
     mini_magick (3.8.1)
       subexec (~> 0.2.1)
@@ -317,6 +323,7 @@ GEM
     mysql2 (0.3.20)
     nest (1.1.2)
       redis
+    netrc (0.11.0)
     noid (0.6.6)
       backports
     nokogiri (1.6.7.2)
@@ -325,7 +332,7 @@ GEM
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    oauth (0.4.7)
+    oauth (0.5.1)
     oauth2 (1.1.0)
       faraday (>= 0.8, < 0.10)
       jwt (~> 1.0, < 1.5.2)
@@ -410,8 +417,9 @@ GEM
       rake
       resque (~> 1.20)
       trollop (~> 1.16)
-    rest-client (1.6.9)
-      mime-types (~> 1.16)
+    rest-client (1.7.3)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     retriable (2.1.0)
     rsolr (1.0.13)
       builder (>= 2.1.2)
@@ -497,7 +505,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
-    stomp (1.3.4)
+    stomp (1.3.5)
     subexec (0.2.3)
     sufia-models (3.4.0)
       active-fedora (~> 6.7.0)
@@ -565,6 +573,7 @@ DEPENDENCIES
   feedjira
   font-awesome-rails (= 4.2.0.0)
   font-awesome-sass
+  hydra-remote_identifier!
   jbuilder (~> 1.2)
   jettywrapper (~> 1.8.3)
   jquery-rails


### PR DESCRIPTION
mime-types 2.99.1 (was 1.25.1)
stomp 1.3.5 (was 1.3.4)
coderay 1.1.1 (was 1.1.0)
oauth 0.5.1 (was 0.4.7)
browser 2.0.2 (was 1.1.0)
rest-client 1.7.3 (was 1.6.9)
hydra-remote_identifier 0.6.8 (was 0.6.7)
activerecord-import 0.12.0 (was 0.11.0)
google_drive 1.0.6 (was 1.0.5)