### PR TITLE
Add deploy timestamp to Bamboo deploy tasks

### DIFF
--- a/script/bamboo_deploy_dev.sh
+++ b/script/bamboo_deploy_dev.sh
@@ -18,4 +18,5 @@ touch /srv/apps/curate_uc/tmp/restart.txt
 export PATH=$PATH:/opt/fits/fits-0.6.2/
 /usr/bin/crontab /srv/apps/curate_uc/script/crontab_dev
 /srv/apps/curate_uc/script/restart_resque.sh development
+/bin/date +"%m-%d-%Y %r" > /srv/apps/curate_uc/config/deploy_timestamp
 echo "The deploy to https://scholar-dev.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar-dev)' scholar@uc.edu

--- a/script/bamboo_deploy_production.sh
+++ b/script/bamboo_deploy_production.sh
@@ -19,4 +19,5 @@ mkdir -p /srv/apps/curate_uc/tmp
 touch /srv/apps/curate_uc/tmp/restart.txt
 /usr/bin/crontab /srv/apps/curate_uc/script/crontab_production1
 /srv/apps/curate_uc/script/restart_resque.sh production
+/bin/date +"%m-%d-%Y %r" > /srv/apps/curate_uc/config/deploy_timestamp
 echo "The deploy to https://scholar.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar.uc.edu)' scholar@uc.edu

--- a/script/bamboo_deploy_qa.sh
+++ b/script/bamboo_deploy_qa.sh
@@ -19,4 +19,5 @@ mkdir -p /srv/apps/curate_uc/tmp
 touch /srv/apps/curate_uc/tmp/restart.txt
 /usr/bin/crontab /srv/apps/curate_uc/script/crontab_qa1
 /srv/apps/curate_uc/script/restart_resque.sh production
+/bin/date +"%m-%d-%Y %r" > /srv/apps/curate_uc/config/deploy_timestamp
 echo "The deploy to https://scholar-qa.uc.edu is finished" | mail -s 'Scholar@UC deploy finished (scholar-qa)' scholar@uc.edu


### PR DESCRIPTION
I'm just updating the copies of the Bamboo deploy tasks we keep in this repo as a backup.  The real deploy tasks are kept on Bamboo.