### PR TITLE
Bundle update all gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: e4ac6116430d588f8f7f0db866e0653dc0f492fe
-  ref: e4ac6116430d588f8f7f0db866e0653dc0f492fe
+  revision: cf124ad505a48c228deb354578c30d9474733636
+  ref: cf124ad505a48c228deb354578c30d9474733636
   specs:
     curate (0.6.6)
       active_attr
@@ -99,7 +99,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     backports (3.6.8)
-    bcrypt (3.1.10)
+    bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -116,7 +116,7 @@ GEM
       sass-rails
     block_helpers (0.3.3)
       activesupport (>= 2.0)
-    bootstrap-datepicker-rails (1.6.0)
+    bootstrap-datepicker-rails (1.6.0.1)
       railties (>= 3.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -407,7 +407,7 @@ GEM
     redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    resque (1.25.2)
+    resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -531,7 +531,7 @@ GEM
     trollop (1.16.2)
     turbolinks (2.5.3)
       coffee-rails
-    tzinfo (0.3.46)
+    tzinfo (0.3.47)
     uber (0.0.15)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -587,6 +587,7 @@ DEPENDENCIES
   poltergeist
   quiet_assets
   rails (= 4.0.13)
+  rake (= 10.5)
   rspec-html-matchers (~> 0.4)
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.0)


### PR DESCRIPTION
bcrypt 3.1.11 (was 3.1.10)
bootstrap-datepicker-rails 1.6.0.1 (was 1.6.0)
resque 1.26.0 (was 1.25.2)
tzinfo 0.3.47 (was 0.3.46)