### PR TITLE
Bundle update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: cf124ad505a48c228deb354578c30d9474733636
-  ref: cf124ad505a48c228deb354578c30d9474733636
+  revision: 6c8c3f83ff94a7b624b800b9664df3ac6aa14129
+  ref: 6c8c3f83ff94a7b624b800b9664df3ac6aa14129
   specs:
     curate (0.6.6)
       active_attr
@@ -18,7 +18,7 @@ GIT
       bootstrap-datepicker-rails
       breach-mitigation-rails
       breadcrumbs_on_rails
-      browse-everything
+      browse-everything (= 0.9.1)
       browser
       chronic (>= 0.10.2)
       devise (~> 3.2.0)
@@ -75,7 +75,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.12.0)
+    activerecord-import (0.13.0)
       activerecord (>= 3.0)
     activeresource (4.0.0)
       activemodel (~> 4.0)
@@ -135,17 +135,17 @@ GEM
       ruby-box
       sass-rails
       skydrive
-    browser (2.0.2)
+    browser (2.0.3)
     builder (3.1.4)
     cancan (1.6.10)
-    capybara (2.6.2)
+    capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    carrierwave (0.10.0)
+    carrierwave (0.11.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
       json (>= 1.7)
@@ -233,6 +233,14 @@ GEM
       nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
       oauth (>= 0.3.6)
       oauth2 (>= 0.5.0)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
     hashie (3.4.3)
     hike (1.2.3)
     hooks (0.3.6)
@@ -244,6 +252,8 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
+    httpclient (2.7.1)
+    hurley (0.2)
     hydra-access-controls (6.4.2)
       active-fedora (~> 6.7)
       activesupport
@@ -296,11 +306,15 @@ GEM
       activesupport (>= 3.0.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    little-plugger (1.1.4)
     logger (1.2.8)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
     mailboxer (0.11.0)
       carrierwave (>= 0.5.8)
       foreigner (>= 0.9.1)
@@ -309,6 +323,7 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
+    memoist (0.14.0)
     mime-types (2.99.1)
     mimemagic (0.3.1)
     mini_magick (3.8.1)
@@ -357,6 +372,7 @@ GEM
     openseadragon (0.1.0)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
+    os (0.9.6)
     paperclip (3.4.2)
       activemodel (>= 3.0.0)
       activerecord (>= 3.0.0)
@@ -407,6 +423,8 @@ GEM
     redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    representable (2.3.0)
+      uber (~> 0.0.7)
     resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
@@ -531,11 +549,10 @@ GEM
     trollop (1.16.2)
     turbolinks (2.5.3)
       coffee-rails
-    tzinfo (0.3.47)
+    tzinfo (0.3.48)
     uber (0.0.15)
-    uglifier (2.7.2)
-      execjs (>= 0.3.0)
-      json (>= 1.8.0)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)


### PR DESCRIPTION
Gems updated on 4/15/16:
* activerecord-import 0.13.0 (was 0.12.0)
* browser 2.0.3 (was 2.0.2)
* capybara 2.7.0 (was 2.6.2)
* carrierwave 0.11.0 (was 0.10.0)
* mail 2.6.4 (was 2.6.3)
* tzinfo 0.3.48 (was 0.3.47)
* uglifier 3.0.0 (was 2.7.2)