### PR TITLE
Fix missing # in copy_config_bamboo.sh

### DIFF
--- a/script/copy_config_bamboo.sh
+++ b/script/copy_config_bamboo.sh
@@ -1,4 +1,4 @@
-!/bin/bash
+#!/bin/bash
 
 # Copy bamboo config files to proper locations
 


### PR DESCRIPTION
The script is missing the pound sign on the first line.