### PR TITLE
Bundle update all gems:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: e8251663553e282e48e74a084e02cc9834addda5
-  ref: e8251663553e282e48e74a084e02cc9834addda5
+  revision: fc67122a4137484ac78fda2fb8d24bb1ee81e293
+  ref: fc67122a4137484ac78fda2fb8d24bb1ee81e293
   specs:
     curate (0.6.6)
       active_attr
@@ -23,6 +23,8 @@ GIT
       chronic (>= 0.10.2)
       devise (~> 3.2.0)
       devise-guests (~> 0.3)
+      google-api-client (= 0.8.6)
+      google_drive (= 1.0.6)
       httparty
       hydra-batch-edit (~> 1.1.1)
       hydra-collections (~> 1.3.0)
@@ -75,12 +77,12 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.13.0)
-      activerecord (>= 3.0)
-    activeresource (4.0.0)
+    activerecord-import (0.14.1)
+      activerecord (>= 3.2)
+    activeresource (4.1.0)
       activemodel (~> 4.0)
       activesupport (~> 4.0)
-      rails-observers (~> 0.1.1)
+      rails-observers (~> 0.1.2)
     activesupport (4.0.13)
       i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
@@ -90,6 +92,10 @@ GEM
     acts_as_follower (0.2.1)
     addressable (2.4.0)
     arel (4.0.2)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -131,7 +137,7 @@ GEM
       ruby-box
       sass-rails
       skydrive
-    browser (2.1.0)
+    browser (2.2.0)
     builder (3.1.4)
     cancan (1.6.10)
     capybara (2.7.1)
@@ -147,6 +153,10 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
       mimemagic (>= 0.3.0)
+    change_manager (1.0.0)
+      rails (~> 4.0.13)
+      resque
+      resque-scheduler
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -191,6 +201,7 @@ GEM
       actionmailer (~> 4.0)
       activesupport (~> 4.0)
     execjs (2.7.0)
+    extlib (0.9.16)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.2.1)
@@ -213,22 +224,22 @@ GEM
       sass (>= 3.2)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
-    google-api-client (0.9.8)
+    google-api-client (0.8.6)
+      activesupport (>= 3.2)
       addressable (~> 2.3)
-      googleauth (~> 0.5)
-      httpclient (~> 2.7)
-      hurley (~> 0.1)
-      memoist (~> 0.11)
-      mime-types (>= 1.6)
-      representable (~> 2.3.0)
-      retriable (~> 2.0)
-      thor (~> 0.19)
-    google_drive (2.0.1)
-      google-api-client (>= 0.9.0, < 1.0.0)
-      googleauth (>= 0.5.0, < 1.0.0)
-      nokogiri (>= 1.5.3, < 2.0.0)
-      oauth (>= 0.3.6, < 1.0.0)
-      oauth2 (>= 0.5.0, < 2.0.0)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      googleauth (~> 0.3)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    google_drive (1.0.6)
+      google-api-client (>= 0.7.0, < 0.9)
+      nokogiri (>= 1.4.4, != 1.5.2, != 1.5.1)
+      oauth (>= 0.3.6)
+      oauth2 (>= 0.5.0)
     googleauth (0.5.1)
       faraday (~> 0.9)
       jwt (~> 1.4)
@@ -248,8 +259,6 @@ GEM
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    httpclient (2.8.0)
-    hurley (0.2)
     hydra-access-controls (6.4.2)
       active-fedora (~> 6.7)
       activesupport
@@ -300,6 +309,8 @@ GEM
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     little-plugger (1.1.4)
     logger (1.2.8)
     logging (2.1.0)
@@ -322,7 +333,7 @@ GEM
     mimemagic (0.3.1)
     mini_magick (3.8.1)
       subexec (~> 0.2.1)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (4.7.5)
     mono_logger (1.1.0)
     morphine (0.1.1)
@@ -335,8 +346,9 @@ GEM
     netrc (0.11.0)
     noid (0.6.6)
       backports
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
@@ -373,10 +385,10 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    poltergeist (1.9.0)
+    pkg-config (1.1.7)
+    poltergeist (1.10.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
-      multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
@@ -417,8 +429,6 @@ GEM
     redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    representable (2.3.0)
-      uber (~> 0.0.7)
     resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
@@ -429,10 +439,15 @@ GEM
       rake
       resque (~> 1.20)
       trollop (~> 1.16)
+    resque-scheduler (4.3.0)
+      mono_logger (~> 1.0)
+      redis (~> 3.3)
+      resque (~> 1.26)
+      rufus-scheduler (~> 3.2)
     rest-client (1.7.3)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (2.1.0)
+    retriable (1.4.1)
     rsolr (1.0.13)
       builder (>= 2.1.2)
     rspec (2.14.1)
@@ -470,6 +485,7 @@ GEM
       mime-types
       nokogiri
       rest-client
+    rufus-scheduler (3.2.1)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -483,7 +499,7 @@ GEM
       rdoc (~> 4.0)
     show_me_the_cookies (3.1.0)
       capybara (~> 2.0)
-    signet (0.7.2)
+    signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (~> 1.5)
@@ -519,7 +535,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
-    stomp (1.3.5)
+    stomp (1.4.1)
     subexec (0.2.3)
     sufia-models (3.4.0)
       active-fedora (~> 6.7.0)
@@ -541,7 +557,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     trollop (1.16.2)
-    tzinfo (0.3.49)
+    tzinfo (0.3.50)
     uber (0.0.15)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
@@ -573,6 +589,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   capybara (~> 2.1)
+  change_manager
   clamav
   coffee-rails (~> 4.0.0)
   curate!
@@ -596,6 +613,8 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.0.13)
   rake (= 10.5)
+  resque
+  resque-scheduler
   rspec-html-matchers (~> 0.4)
   rspec-rails (~> 2.14.0)
   sass-rails (~> 4.0.0)


### PR DESCRIPTION
tzinfo 0.3.50 (was 0.3.49)
activerecord-import 0.14.1 (was 0.13.0)
activeresource 4.1.0 (was 4.0.0)
mini_portile2 2.1.0 (was 2.0.0)
nokogiri 1.6.8 (was 1.6.7.2)
poltergeist 1.10.0 (was 1.9.0)
retriable 1.4.1 (was 2.1.0)
change_manager  (new)
resque (new)
resque-scheduler (new)