### PR TITLE
Add scripts to support the resque-scheduler service

### DIFF
--- a/script/check_resque_scheduler_running.sh
+++ b/script/check_resque_scheduler_running.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if resque workers are running
+# Restart workers if they are not running
+# Usage: check_resque_scheduler_running.sh <hostname> <development|production>
+
+if ps aux | grep -v grep | grep 'resque-scheduler' > /dev/null 2>&1
+  then
+    sleep 1;
+  else
+    echo "Hydra server $1 did not have resque-scheduler running.  It has been automatically restarted and will be checked again in one hour." > /tmp/resquealert
+    sleep 1
+    mail -s "Scholar resque-scheduler restarted on $1" scholar@uc.edu < /tmp/resquealert
+    cd /srv/apps/curate_uc/script
+    export PATH=$PATH:/srv/apps/.gem/ruby/2.1.0/bin:/opt/fits/fits-0.6.2/
+    /srv/apps/curate_uc/script/restart_resque_scheduler.sh $2
+fi

--- a/script/crontab_dev
+++ b/script/crontab_dev
@@ -1,4 +1,5 @@
 0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhyddwl2 development
+0 * * * * /srv/apps/curate_uc/script/check_resque_scheduler_running.sh libhyddwl2 development
 30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhyddwl2
 30 9 * * 5 df -h
 1 0 * * * /srv/apps/curate_uc/script/release_embargo.sh 2> /dev/null

--- a/script/crontab_production1
+++ b/script/crontab_production1
@@ -1,4 +1,5 @@
 0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydpwl1 production
+0 * * * * /srv/apps/curate_uc/script/check_resque_scheduler_running.sh libhydpwl1 production
 30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydpwl1
 30 9 * * 5 df -h
 0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh

--- a/script/crontab_production2
+++ b/script/crontab_production2
@@ -1,4 +1,5 @@
 0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydpwl2 production
+0 * * * * /srv/apps/curate_uc/script/check_resque_scheduler_running.sh libhydpwl2 production
 30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydpwl2
 0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh
 30 9 * * 5 df -h

--- a/script/crontab_qa1
+++ b/script/crontab_qa1
@@ -1,4 +1,5 @@
 0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydqwl1 production
+0 * * * * /srv/apps/curate_uc/script/check_resque_scheduler_running.sh libhydqwl1 production
 30 * * * * /srv/apps/curate_uc/script/resque_alert.sh libhydqwl1
 30 9 * * 5 df -h
 0 0 1 * * /srv/apps/curate_uc/script/rotate_log.sh

--- a/script/crontab_qa2
+++ b/script/crontab_qa2
@@ -1,4 +1,5 @@
 0 * * * * /srv/apps/curate_uc/script/check_resque_running.sh libhydqwl2 production
+0 * * * * /srv/apps/curate_uc/script/check_resque_scheduler_running.sh libhydqwl2 production
 30 * * * * /srv/apps/curate_uc/script/resque_alert.sh LibHydQwl2
 30 9 * * 5 df -h
 0 1 1 * * /srv/apps/curate_uc/script/rotate_log.sh

--- a/script/kill_resque_scheduler.sh
+++ b/script/kill_resque_scheduler.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Stops the current resque-scheduler
+
+RESQUE_SCHEDULER_PIDFILE="/tmp/scholar-resque-scheduler.pid"
+
+if [ -f $RESQUE_SCHEDULER_PIDFILE ]; then
+  PID=$(cat $RESQUE_SCHEDULER_PIDFILE)
+  kill -2 $PID
+  rm $RESQUE_SCHEDULER_PIDFILE
+fi

--- a/script/resque_alert.sh
+++ b/script/resque_alert.sh
@@ -2,7 +2,7 @@
 
 RESQUE_POOL_PIDFILE="/tmp/scholar-resque-pool.pid"
 RESQUE_STATUSFILE="/tmp/badresqueprocesses"
-EMAIL_TO="hortongn@ucmail.uc.edu"
+EMAIL_TO="scholar@uc.edu"
 
 # Get the PID of the resque pool
 [ -f $RESQUE_POOL_PIDFILE ] && {
@@ -10,7 +10,7 @@ EMAIL_TO="hortongn@ucmail.uc.edu"
 }
 
 # Find any resque processes that are not part of the current pool
-ps -ef | grep -v grep | grep -v alert | grep -v $PID | grep resque > $RESQUE_STATUSFILE
+ps -ef | grep resque | grep -v "grep\|alert\|$PID\|resque-scheduler" > $RESQUE_STATUSFILE
 
 # Send an email if the previous step found rogue resque processes
 if [ -s "$RESQUE_STATUSFILE" ]

--- a/script/restart_resque_scheduler.sh
+++ b/script/restart_resque_scheduler.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Stops and then starts resque-scheduler in either production or development environment
+# script/restart_resque_scheduler.sh [production|development]
+
+ENVIRONMENT=$1
+RESQUE_SCHEDULER_PIDFILE="/tmp/scholar-resque-scheduler.pid"
+APP_DIRECTORY="/srv/apps/curate_uc"
+
+cd $APP_DIRECTORY
+script/kill_resque_scheduler.sh
+sleep 60
+
+bundle exec resque-scheduler --environment $ENVIRONMENT --pidfile $RESQUE_SCHEDULER_PIDFILE &


### PR DESCRIPTION
These scripts have already been manually tested on scholar-dev, but I will also test them on QA after they’ve been merged.  This will let us easily start/stop the resque-scheduler service and get alerts when it’s not running.  (resque-scheduler is what sends email to people when they've been added to groups, delegates, etc.)