### PR TITLE
add date_created and notes as searchable fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 
 gem "kaminari", "0.15.1"
 
+
 gem "curate", git: "https://github.com/uclibs/curate.git", ref: "456fbe1a5bd5eae8b108ec071c2d9ea799e58fb5"
 gem "clamav"
 gem "hydra-remote_identifier", github: "uclibs/hydra-remote_identifier", branch: "setting-status"

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 gem "kaminari", "0.15.1"
 
 
-gem "curate", git: "https://github.com/uclibs/curate.git", ref: "456fbe1a5bd5eae8b108ec071c2d9ea799e58fb5"
+gem "curate", git: "https://github.com/uclibs/curate.git", ref: "c81b93eb98e4f4c4c7af04a72cff32f44d089eac"
 gem "clamav"
 gem "hydra-remote_identifier", github: "uclibs/hydra-remote_identifier", branch: "setting-status"
 gem "sitemap_generator"

--- a/config/search_config.yml
+++ b/config/search_config.yml
@@ -12,6 +12,7 @@ development:
       - desc_metadata__coverage_spatial_tesim
       - desc_metadata__coverage_temporal_tesim
       - desc_metadata__creator_tesim
+      - desc_metadata__date_created_tesim
       - desc_metadata__degree_tesim
       - desc_metadata__department_tesim
       - desc_metadata__description_tesim
@@ -19,6 +20,8 @@ development:
       - desc_metadata__journal_title_tesim
       - desc_metadata__language_teim
       - desc_metadata__language_tesim
+      - desc_metadata__note_tesim
+      - desc_metadata__note_teim
       - desc_metadata__publisher_tesim
       - desc_metadata__publisher_digital_tesim
       - desc_metadata__rights_tesim
@@ -47,6 +50,7 @@ test:
       - desc_metadata__coverage_spatial_tesim
       - desc_metadata__coverage_temporal_tesim
       - desc_metadata__creator_tesim
+      - desc_metadata__date_created_tesim
       - desc_metadata__degree_tesim
       - desc_metadata__department_tesim
       - desc_metadata__description_tesim
@@ -54,6 +58,8 @@ test:
       - desc_metadata__journal_title_tesim
       - desc_metadata__language_teim
       - desc_metadata__language_tesim
+      - desc_metadata__note_tesim
+      - desc_metadata__note_teim
       - desc_metadata__publisher_tesim
       - desc_metadata__publisher_digital_tesim
       - desc_metadata__rights_tesim
@@ -82,6 +88,7 @@ production:
       - desc_metadata__coverage_spatial_tesim
       - desc_metadata__coverage_temporal_tesim
       - desc_metadata__creator_tesim
+      - desc_metadata__date_created_tesim
       - desc_metadata__degree_tesim
       - desc_metadata__department_tesim
       - desc_metadata__description_tesim
@@ -89,6 +96,8 @@ production:
       - desc_metadata__journal_title_tesim
       - desc_metadata__language_teim
       - desc_metadata__language_tesim
+      - desc_metadata__note_tesim
+      - desc_metadata__note_teim
       - desc_metadata__publisher_tesim
       - desc_metadata__publisher_digital_tesim
       - desc_metadata__rights_tesim

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -174,6 +174,30 @@ describe 'Keyword search' do
       expect(page).to have_selector("#document_#{@object.noid}")
     end
 
+    it 'returns results for date created' do
+      @object = create(:generic_work, date_created: '1990-01-02')
+
+      visit('/')
+      within('.search-form') do
+        fill_in 'q', with: '1990-01-02'
+        click_button("keyword-search-submit")
+      end
+
+      expect(page).to have_selector("#document_#{@object.noid}")
+    end
+
+    it 'returns results for notes' do
+      @object = create(:generic_work, note: 'hfas123645')
+
+      visit('/')
+      within('.search-form') do
+        fill_in 'q', with: 'hfas123645'
+        click_button("keyword-search-submit")
+      end
+
+      expect(page).to have_selector("#document_#{@object.noid}")
+    end
+
     it 'returns results for type' do
       @object = create(:article, type: "lmn234")
 


### PR DESCRIPTION
closes #155 

should be reviewed with uclibs/curate#78

SMALL ISSUE:

There is a small issue we found where the note field does not use the usual `desc_metadata__note_tesim` datastream and instead uses a `desc_metadata__note_teim` datastream. This only affects the generic work work-type

I've put a temporary fix in as it is a relatively minor issue especially seeing as how we are switching codebases within the year. It should not interfere with functionality as is but we would like to see if anyone has any feedback for a more permanent, proper solution.