### PR TITLE
Set Fedora timeout to allow for larger files

### DIFF
--- a/config/fedora.yml.bamboo
+++ b/config/fedora.yml.bamboo
@@ -2,14 +2,17 @@ development:
   user: fedoraAdmin
   password: bamboo_fedora_password
   url: bamboo_fedora_url
+  timeout: 1200
 test: &TEST  
   user: fedoraAdmin
   password: fedoraAdmin
   url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 4001}/fedora-test" %>
+  timeout: 1200
 production:
   user: fedoraAdmin
   password: bamboo_fedora_password
   url: bamboo_fedora_url
+  timeout: 1200
 cucumber:
   <<: *TEST
 ci:

--- a/config/fedora.yml.sample
+++ b/config/fedora.yml.sample
@@ -2,14 +2,17 @@ development:
   user: fedoraAdmin
   password: fedoraAdmin
   url: http://127.0.0.1:4001/fedora
+  timeout: 1200
 test: &TEST  
   user: fedoraAdmin
   password: fedoraAdmin
   url: <%= "http://127.0.0.1:#{ENV['TEST_JETTY_PORT'] || 4001}/fedora-test" %>
+  timeout: 1200
 production:
   user: fedoraAdmin
   password: fedoraAdmin
   url: http://127.0.0.1:4001/fedora
+  timeout: 1200
 cucumber:
   <<: *TEST
 ci:


### PR DESCRIPTION
I found the length of timeout that would let a user upload a 3 GB file in our server environment.  I then doubled that number to allow for people on a slower connection.  User should have up to 20 minutes to get their file uploaded and ingested.