### PR TITLE
Bundle update all gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: fc67122a4137484ac78fda2fb8d24bb1ee81e293
-  ref: fc67122a4137484ac78fda2fb8d24bb1ee81e293
+  revision: c81b93eb98e4f4c4c7af04a72cff32f44d089eac
+  ref: c81b93eb98e4f4c4c7af04a72cff32f44d089eac
   specs:
     curate (0.6.6)
       active_attr
@@ -77,7 +77,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.14.1)
+    activerecord-import (0.15.0)
       activerecord (>= 3.2)
     activeresource (4.1.0)
       activemodel (~> 4.0)
@@ -197,9 +197,9 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
-    exception_notification (4.1.4)
-      actionmailer (~> 4.0)
-      activesupport (~> 4.0)
+    exception_notification (4.2.1)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
     execjs (2.7.0)
     extlib (0.9.16)
     factory_girl (4.2.0)
@@ -217,7 +217,7 @@ GEM
       faraday_middleware (~> 0.9)
       loofah (~> 2.0)
       sax-machine (~> 1.0)
-    ffi (1.9.10)
+    ffi (1.9.14)
     font-awesome-rails (4.2.0.0)
       railties (>= 3.2, < 5.0)
     font-awesome-sass (4.6.2)
@@ -256,8 +256,7 @@ GEM
       httparty (>= 0.7.3)
       mimemagic
       multipart-post
-    httparty (0.13.7)
-      json (~> 1.8)
+    httparty (0.14.0)
       multi_xml (>= 0.5.2)
     hydra-access-controls (6.4.2)
       active-fedora (~> 6.7)
@@ -305,7 +304,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.1)
+    jwt (1.5.4)
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -354,9 +353,9 @@ GEM
       i18n
       nokogiri
     oauth (0.5.1)
-    oauth2 (1.1.0)
+    oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0, < 1.5.2)
+      jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
@@ -426,7 +425,7 @@ GEM
       rdf (~> 1.1)
     rdoc (4.2.2)
       json (~> 1.4)
-    redis (3.3.0)
+    redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.26.0)
@@ -557,9 +556,9 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     trollop (1.16.2)
-    tzinfo (0.3.50)
+    tzinfo (0.3.51)
     uber (0.0.15)
-    uglifier (3.0.0)
+    uglifier (3.0.1)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
activerecord-import 0.15.0 (was 0.14.1)
exception_notification 4.2.1 (was 4.1.4)
ffi 1.9.14 (was 1.9.10)
httparty 0.14.0 (was 0.13.7)
jwt 1.5.4 (was 1.5.1)
oauth2 1.2.0 (was 1.1.0)
redis 3.3.1 (was 3.3.0)
tzinfo 0.3.51 (was 0.3.50)
uglifier 3.0.1 (was 3.0.0)