### PR TITLE
Allow Shibboleth attribute updates if never signed in

### DIFF
--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -1,65 +1,35 @@
 class CallbacksController < Devise::OmniauthCallbacksController
   def shibboleth
-    unless current_user
-      @omni = request.env["omniauth.auth"]
-      @email = use_uid_if_email_is_blank
-
-      unless user_exists?
-        create_user
-        create_profile
-        create_person
-        WelcomeMailer.welcome_email(@email).deliver
-      end
-
-      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
-      cookies[:login_type] = "shibboleth"
-      flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
-    else
+    if current_user
       redirect_to landing_page
+    else
+      get_shibboleth_attributes
+      create_or_update_account
+      sign_in_shibboleth_user
     end
   end
 
   private
 
-  def user_exists?
-    @user = User.find_by_provider_and_uid(@omni['provider'], @omni['uid'])
+  def get_shibboleth_attributes
+    @omni = request.env["omniauth.auth"]
+    @email = use_uid_if_email_is_blank
   end
 
-  def create_user
-    @user = User.create provider: @omni.provider,
-                             uid: @omni.uid,
-                           email: @email,
-                        password: Devise.friendly_token[0,20],
-                           title: @omni.extra.raw_info.title,
-                       telephone: @omni.extra.raw_info.telephoneNumber,
-                      first_name: @omni.extra.raw_info.givenName,
-                       last_name: @omni.extra.raw_info.sn,
-                        ucstatus: @omni.extra.raw_info.uceduPrimaryAffiliation,
-                    ucdepartment: @omni.extra.raw_info.ou,
-                    user_does_not_require_profile_update: false
+  def create_or_update_account
+    if user_exists?
+      @profile = @user.profile
+      @person = @user.person
+      update_shibboleth_attributes if user_has_never_logged_in?
+    else
+      create_account
+    end
   end
 
-  def create_profile
-    @profile = Profile.create depositor: @user.email,
-                                  title: "#{@user.first_name} #{@user.last_name}"
-
-    apply_deposit_authorization(@profile)
-    @profile.save
-  end
-
-  def create_person
-    @person = Person.create depositor: @user.email,
-                           first_name: @user.first_name,
-                            last_name: @user.last_name,
-                                email: @user.email,
-                                title: @user.title,
-                  campus_phone_number: @user.telephone,
-                              profile: @profile
-
-    @user.repository_id = @person.pid
-
-    apply_deposit_authorization(@person)
-    @person.save
+  def sign_in_shibboleth_user
+    sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+    cookies[:login_type] = "shibboleth"
+    flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
   end
 
   def use_uid_if_email_is_blank
@@ -76,6 +46,75 @@ class CallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def user_exists?
+    @user = User.find_by_provider_and_uid(@omni['provider'], @omni['uid'])
+  end
+
+  def update_shibboleth_attributes
+    update_user_shibboleth_attributes
+    update_profile_shibboleth_attributes
+    update_person_shibboleth_attributes
+  end
+
+  def user_has_never_logged_in?
+    @user.sign_in_count == 0
+  end
+
+  def create_account
+    create_user
+    create_profile
+    create_person
+    send_welcome_email
+  end
+
+  def create_user
+    @user = User.create provider: @omni.provider, uid: @omni.uid, email: @email,
+      password: Devise.friendly_token[0,20], user_does_not_require_profile_update: false
+    update_user_shibboleth_attributes
+  end
+
+  def update_user_shibboleth_attributes
+    @user.title        = @omni.extra.raw_info.title
+    @user.telephone    = @omni.extra.raw_info.telephoneNumber
+    @user.first_name   = @omni.extra.raw_info.givenName
+    @user.last_name    = @omni.extra.raw_info.sn
+    @user.ucstatus     = @omni.extra.raw_info.uceduPrimaryAffiliation
+    @user.ucdepartment = @omni.extra.raw_info.ou
+    @user.save
+  end
+
+  def create_profile
+    @profile = Profile.create depositor: @user.email
+    update_profile_shibboleth_attributes
+    apply_deposit_authorization(@profile)
+    @profile.save
+  end
+
+  def update_profile_shibboleth_attributes
+    @profile.title = "#{@user.first_name} #{@user.last_name}"
+    @profile.save
+  end
+
+  def create_person
+    @person = Person.create depositor: @user.email, email: @user.email, profile: @profile
+    update_person_shibboleth_attributes
+    @user.repository_id = @person.pid
+    apply_deposit_authorization(@person)
+    @person.save
+  end
+
+  def update_person_shibboleth_attributes
+    @person.first_name = @user.first_name
+    @person.last_name = @user.last_name
+    @person.title = @user.title
+    @person.campus_phone_number = @user.telephone
+    @person.save
+  end
+
+  def send_welcome_email
+    WelcomeMailer.welcome_email(@email).deliver
+  end
+
   def apply_deposit_authorization(target)
     target.apply_depositor_metadata(@user.user_key)
     target.read_groups = [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
@@ -83,4 +122,3 @@ class CallbacksController < Devise::OmniauthCallbacksController
   end
 
 end
-

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -5,21 +5,22 @@ describe CallbacksController do
   let(:uid) { 'sixplus2@test.com' }
   before(:each) do
     @request.env["devise.mapping"] = Devise.mappings[:user]
-    OmniAuth.config.add_mock(provider, {uid: uid, credentials: {}})
+    omniauth_hash = { provider: 'shibboleth',
+                      uid: uid,
+                      extra: {
+                        raw_info: {
+                          mail: uid,
+                          title: 'title',
+                          telephoneNumber: '123-456-7890',
+                          givenName: 'Fake',
+                          sn: 'User',
+                          uceduPrimaryAffiliation: 'staff',
+                          ou: 'department'
+                        }
+                      }
+    }
+    OmniAuth.config.add_mock(provider, omniauth_hash)
     request.env["omniauth.auth"] = OmniAuth.config.mock_auth[provider]
-  end
-
-  context 'with a registered user' do
-    let(:user) { FactoryGirl.create(:shibboleth_user) }
-    before(:each) do
-      User.should_receive(:find_by_provider_and_uid).with(provider.to_s, uid).and_return(user)
-    end
-    it 'should assign the user and redirect' do
-      get provider
-      expect(flash[:notice]).to match(/You are now signed in as */)
-      expect(assigns(:user)).to eq(user)
-      expect(response).to be_redirect
-    end
   end
 
   context 'with a user who is already logged in' do
@@ -28,10 +29,46 @@ describe CallbacksController do
       controller.stub(:current_user).and_return(user)
     end
     it 'redirects to catalog index path' do
-      get :shibboleth
+      get provider
       response.should redirect_to(catalog_index_path)
     end
   end
 
+  shared_examples 'Shibboleth login' do
+    before(:each) do
+      allow(User).to receive(:find_by_provider_and_uid).with(provider.to_s, uid).and_return(user)
+      unless person.nil?
+        person.profile = profile
+        person.save
+      end
+    end
+    it 'assigns the user and redirects' do
+      get provider
+      expect(flash[:notice]).to match(/You are now signed in as */)
+      expect(assigns(:user)).to eq(user)
+      expect(response).to be_redirect
+    end
+  end
+
+  context 'with a brand new user' do
+    let(:person) { FactoryGirl.create(:shibboleth_person) }
+    let(:user) { FactoryGirl.create(:user, email: 'new.user@example.com') }
+    let(:profile) { FactoryGirl.create(:shibboleth_profile) }
+    it_behaves_like 'Shibboleth login'
+  end
+
+  context 'with a registered user who has previously logged in' do
+    let(:person) { FactoryGirl.create(:shibboleth_person) }
+    let(:user) { FactoryGirl.create(:shibboleth_user, count: 1, person_pid: person.pid) }
+    let(:profile) { FactoryGirl.create(:shibboleth_profile) }
+    it_behaves_like 'Shibboleth login'
+  end
+
+  context 'with a registered user who has never logged in' do
+    let(:person) { FactoryGirl.create(:shibboleth_person) }
+    let(:user) { FactoryGirl.create(:shibboleth_user, count: 0, person_pid: person.pid) }
+    let(:profile) { FactoryGirl.create(:shibboleth_profile) }
+    it_behaves_like 'Shibboleth login'
+  end
 end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,24 @@
 FactoryGirl.define do
-  factory :shibboleth_user, class: 'User' do
+  factory :shibboleth_person, class: Person do
+    depositor 'fake.user@uc.edu'
     email 'fake.user@uc.edu'
+  end
+
+  factory :shibboleth_profile, class: Profile do
+    depositor 'fake.user@uc.edu'
+  end
+
+  factory :shibboleth_user, class: 'User' do
+    ignore do
+      count 1
+      person_pid nil
+    end
+    email 'fake.user@uc.edu'
+    first_name 'Fake'
+    last_name 'User'
     password '12345678'
     password_confirmation '12345678'
+    sign_in_count {"#{count}"}
+    repository_id {"#{person_pid}"}
   end
 end


### PR DESCRIPTION
I can run through this with whoever reviews.  Two main changes here:

1) A refactor of the Callbacks Controller that will make it easier to understand what's going on here in the future.  Plus some addition specs that check multiple conditions (brand new user logging in, existing user logging in for first time, existing user who has logged in before, user who is already logged in now).

2) Right now we only overwrite a user's profile data with their Shibboleth attributes the first time they log in.  This allows the user to change their profile data later without it being overwritten the next time they log in.  However, we will sometimes need to create users before they log in when we migrate data from the DRC.  So there's a change here that will pull down an existing user's Shibboleth attributes during their first log in instead of doing it when the account is created.