### PR TITLE
Add rake task to generate UC users

### DIFF
--- a/lib/task_helpers/account_helper.rb
+++ b/lib/task_helpers/account_helper.rb
@@ -1,0 +1,35 @@
+module AccountHelper
+
+  def generate_uc_account(sixplus2, first_name, last_name)
+    unless User.where(email: "#{sixplus2}@ucmail.uc.edu").exists?
+      password = Devise.friendly_token[0,20]
+      email = "#{sixplus2}@ucmail.uc.edu"
+
+      user = User.create user_does_not_require_profile_update: true, email: email, first_name: first_name, last_name: last_name, password: password, password_confirmation: password
+
+      profile = Profile.new depositor: email
+      profile.apply_depositor_metadata(user.user_key)
+      profile.read_groups = [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+      profile.save
+
+      person = Person.new depositor: email, email: email, profile: profile
+      person.first_name = first_name
+      person.last_name = last_name
+      person.apply_depositor_metadata(user.user_key)
+      person.read_groups = [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
+      person.save
+
+      user.repository_id = person.pid
+      user.save
+      user.provider = 'shibboleth'
+      user.uid = "#{sixplus2}@uc.edu"
+      user.save!
+
+      person.read_groups = ['make_public']
+      person.save!
+      person.to_solr
+      profile.to_solr
+    end
+  end
+
+end

--- a/lib/tasks/account.rake
+++ b/lib/tasks/account.rake
@@ -1,0 +1,18 @@
+require "#{Rails.root}/lib/task_helpers/account_helper"
+include AccountHelper
+
+namespace :account do
+  task :generate, [:sixplus2, :first_name, :last_name] => [:environment] do |t, args|
+    if args[:sixplus2].to_s.present?
+    if generate_uc_account(args[:sixplus2].to_s, args[:first_name].to_s, args[:last_name].to_s) 
+      puts "Account generated for #{args[:first_name].to_s} #{args[:last_name].to_s} (#{args[:sixplus2].to_s}@ucmail.uc.edu)" 
+    else
+      puts "Account could not be generated. A user with email #{args[:sixplus2].to_s}@ucmail.uc.edu may already exist." 
+    end
+    else
+      puts "Usage:   rake account:generate['sixplus2','Firstname','Lastname'] (no spaces between the parameters)"
+      puts "Example: rake account:generate['jonestn','Ted','Jones']"
+    end
+  end
+end
+

--- a/spec/lib/tasks/rake_spec.rb
+++ b/spec/lib/tasks/rake_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'rake'
+
+describe "Rake tasks" do
+  describe "account:generate" do
+
+    before do
+      load File.expand_path("../../../../lib/tasks/account.rake", __FILE__)
+      Rake::Task.define_task(:environment)
+    end
+
+    it 'creates a user' do
+      Rake::Task["account:generate"].invoke('bearcat1','Bear','Cat')
+      user = User.where(email: 'bearcat1@ucmail.uc.edu', first_name: 'Bear', last_name: 'Cat').first
+      expect(user).to be_present
+      expect(user.person).to be_present
+      expect(user.profile).to be_present
+    end
+
+  end
+end
+


### PR DESCRIPTION
This rake task generates the basic structure for a UC user so that work ownership can be assigned to him/her.

Run `rake account:generate` to see usage information.