### PR TITLE
Migrate contact form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'rspec-activemodel-mocks'
+  gem 'rspec-its', '~> 1.1'
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -514,6 +514,9 @@ GEM
     rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
@@ -667,6 +670,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rsolr (~> 1.0)
   rspec-activemodel-mocks
+  rspec-its (~> 1.1)
   rspec-rails
   rubocop (~> 0.42.0)
   rubocop-rspec (= 1.7)

--- a/app/models/sufia/contact_form.rb
+++ b/app/models/sufia/contact_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Sufia
+  class ContactForm
+    include ActiveModel::Model
+
+    attr_accessor :contact_method, :name, :email, :subject, :message
+    validates :email, :name, :subject, :message, presence: true
+    validates :email, format: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i, allow_blank: true
+
+    # - can't use this without ActiveRecord::Base validates_inclusion_of :category, in: ISSUE_TYPES
+
+    # They should not have filled out the `contact_method' field. That's there to prevent spam.
+    def spam?
+      contact_method.present?
+    end
+
+    # Declare the e-mail headers. It accepts anything the mail method
+    # in ActionMailer accepts.
+    def headers
+      {
+        subject: "#{Sufia.config.subject_prefix} #{subject}",
+        to: Sufia.config.contact_email,
+        from: email
+      }
+    end
+  end
+end

--- a/app/views/contact_form/create.html.erb
+++ b/app/views/contact_form/create.html.erb
@@ -1,0 +1,1 @@
+<h1>Contact Form</h1>

--- a/app/views/contact_form/new.html.erb
+++ b/app/views/contact_form/new.html.erb
@@ -1,0 +1,35 @@
+<h1>Contact the Scholar@UC Team</h1>
+
+<% if user_signed_in? %>
+  <% nm = current_user.name %>
+  <% em = current_user.email %>
+<% else %>
+  <% nm = '' %>
+  <% em = '' %>
+<% end %>
+
+<%= form_for @contact_form, url: sufia.contact_form_index_path,
+                            html: { class: 'form-horizontal' } do |f| %>
+  <%= f.text_field :contact_method, class: 'hide' %>
+  <div class="form-group">
+    <%= f.label :name, 'Your Name', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :name, value: nm, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email, 'Your Email', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :email, value: em, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :subject, 'Subject', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :message, 'Message', class: "col-sm-2 control-label" %>
+    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+  </div>
+
+  <%= f.submit value: "Send", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/sufia/contact_mailer/contact.html.erb
+++ b/app/views/sufia/contact_mailer/contact.html.erb
@@ -1,0 +1,5 @@
+<p><%= @contact_form.name %></p>
+<p>From: <%= %("#{@contact_form.name}" <#{@contact_form.email}>) %></p>
+
+<p><%= @contact_form.subject %></p>
+<p><%= @contact_form.message %></p>

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -3,7 +3,7 @@ Sufia.config do |config|
   # Injected via `rails g sufia:work Work`
   config.register_curation_concern :work
   # Email recipient of messages sent via the contact form
-  # config.contact_email = "repo-admin@example.org"
+  config.contact_email = "scholar@ucmail.uc.edu"
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"

--- a/spec/controllers/contact_form_controller_spec.rb
+++ b/spec/controllers/contact_form_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe ContactFormController do
+  routes { Sufia::Engine.routes }
+  let(:user) { create(:user) }
+  let(:required_params) do
+    {
+      name: "Rose Tyler",
+      email: "rose@timetraveler.org",
+      subject: "The Doctor",
+      message: "Run."
+    }
+  end
+
+  before { sign_in(user) }
+
+  describe "#new" do
+    subject { response }
+    before { get :new }
+    it { is_expected.to be_success }
+  end
+
+  describe "#create" do
+    subject { flash }
+    before { post :create, sufia_contact_form: params }
+    context "with the required parameters" do
+      let(:params) { required_params }
+      its(:notice) { is_expected.to eq("Thank you for your message!") }
+    end
+
+    context "without a name" do
+      let(:params)  { required_params.except(:name) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Name can't be blank") }
+    end
+
+    context "without an email" do
+      let(:params)  { required_params.except(:email) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email can't be blank") }
+    end
+
+    context "without a subject" do
+      let(:params)  { required_params.except(:subject) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Subject can't be blank") }
+    end
+
+    context "without a message" do
+      let(:params)  { required_params.except(:message) }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Message can't be blank") }
+    end
+
+    context "with an invalid email" do
+      let(:params)  { required_params.merge(email: "bad-wolf") }
+      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email is invalid") }
+    end
+  end
+
+  describe "#after_deliver" do
+    context "with a successful email" do
+      it "calls #after_deliver" do
+        expect(controller).to receive(:after_deliver)
+        post :create, sufia_contact_form: required_params
+      end
+    end
+    context "with an unsuccessful email" do
+      it "does not call #after_deliver" do
+        expect(controller).not_to receive(:after_deliver)
+        post :create, params: { contact_form: required_params.except(:email) }
+      end
+    end
+  end
+
+  context "when encoutering a RuntimeError" do
+    let(:logger) { double(info?: true) }
+    before do
+      allow(controller).to receive(:logger).and_return(logger)
+      allow(Sufia::ContactMailer).to receive(:contact).and_raise(RuntimeError)
+    end
+    it "is logged via Rails" do
+      expect(logger).to receive(:error).with("Contact form failed to send: #<RuntimeError: RuntimeError>")
+      post :create, sufia_contact_form: required_params
+    end
+  end
+end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -7,12 +7,11 @@ describe "Sending an email via the contact form", type: :feature do
   it "sends mail" do
     visit '/'
     click_link "Contact"
-    expect(page).to have_content "Contact Form"
+    expect(page).to have_content "Contact the Scholar@UC Team"
     fill_in "Your Name", with: "Test McPherson"
     fill_in "Your Email", with: "archivist1@example.com"
     fill_in "Message", with: "I am contacting you regarding ScholarSphere."
     fill_in "Subject", with: "My Subject is Cool"
-    select "Depositing content", from: "Issue Type"
     click_button "Send"
     expect(page).to have_content "Thank you for your message!"
   end


### PR DESCRIPTION
Fixes #888 

Setup contact form and configure mailer to use Scholar@UC support email address.

Changes proposed in this pull request:
* Setup contact form
* Override Sufia views to remove category selector

