### PR TITLE
Reinstate empty tests

### DIFF
--- a/spec/actors/curation_concerns/actors/work_actor_spec.rb
+++ b/spec/actors/curation_concerns/actors/work_actor_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate curation_concerns:work Work`
+require 'rails_helper'
+
+describe CurationConcerns::Actors::WorkActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/curation_concerns/works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/works_controller_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate curation_concerns:work Work`
+require 'rails_helper'
+
+describe CurationConcerns::WorksController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/forms/curation_concerns/work_form_spec.rb
+++ b/spec/forms/curation_concerns/work_form_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate curation_concerns:work Work`
+require 'rails_helper'
+
+describe CurationConcerns::WorkForm do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/models/qa/local_authority_entry_spec.rb
+++ b/spec/models/qa/local_authority_entry_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Qa::LocalAuthorityEntry, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/qa/local_authority_spec.rb
+++ b/spec/models/qa/local_authority_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Qa::LocalAuthority, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate curation_concerns:work Work`
+require 'rails_helper'
+
+describe Work do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,7 @@ RSpec.configure do |config|
 
   config.include Capybara::RSpecMatchers, type: :input
   config.include FactoryGirl::Syntax::Methods
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
Fixes #965 

Reinstates placeholder tests created by the sufia spec generator.

Changes proposed in this pull request:
* Put back empty tests. 

