### PR TITLE
Change labels on Dashboard buttons to reflect link location.

### DIFF
--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -9,3 +9,8 @@ en:
       suffix:           "@uc.edu"
     footer:
       copyright_html: "<strong>Copyright &copy; University of Cincinnati</strong> Licensed under the Apache License, Version 2.0"
+    dashboard:
+      view_collections:         "View My Collections"
+      create_collection:        "Create Collection"
+      view_files:               "View My Files"
+      view_works:               "View My Works"

--- a/spec/features/display_dashboard_spec.rb
+++ b/spec/features/display_dashboard_spec.rb
@@ -21,7 +21,7 @@ describe "The Dashboard", type: :feature do
     end
 
     it "lets the user view works" do
-      click_link "View Works"
+      click_link "View My Works"
       expect(page).to have_content "My Works"
       expect(page).to have_content "My Collections"
       expect(page).to have_content "My Highlights"


### PR DESCRIPTION
Fixes #961 

Changes the labels on the Dashboard buttons to View My Works and View My Collections to reflect the actual link location.  

https://trello.com/c/PDRQpyO0/17-as-a-user-i-want-a-clearer-label-the-button-says-view-collections-so-that-is-better-represents-where-it-is-taken-us-to-my-collec
