### PR TITLE
Bundle update all gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,27 @@ GIT
       rest-client (~> 1.7.3)
 
 GIT
+  remote: https://github.com/uclibs/browse-everything.git
+  revision: f240725e6ca10434df18820203bd7a386a6f2b97
+  branch: base/kaltura
+  specs:
+    browse-everything (0.9.1)
+      bootstrap-sass
+      dropbox-sdk (>= 1.6.2)
+      font-awesome-rails
+      google-api-client (~> 0.8.6)
+      google_drive
+      httparty
+      kaltura
+      rails (>= 3.1)
+      ruby-box
+      sass-rails
+      skydrive
+
+GIT
   remote: https://github.com/uclibs/curate.git
-  revision: c81b93eb98e4f4c4c7af04a72cff32f44d089eac
-  ref: c81b93eb98e4f4c4c7af04a72cff32f44d089eac
+  revision: 1494b223ead31521cc922bad9643c448c5efaa0f
+  ref: 1494b223ead31521cc922bad9643c448c5efaa0f
   specs:
     curate (0.6.6)
       active_attr
@@ -77,7 +95,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.15.0)
+    activerecord-import (0.16.1)
       activerecord (>= 3.2)
     activeresource (4.1.0)
       activemodel (~> 4.0)
@@ -118,29 +136,18 @@ GEM
       sass-rails
     block_helpers (0.3.3)
       activesupport (>= 2.0)
-    bootstrap-datepicker-rails (1.6.1.1)
+    bootstrap-datepicker-rails (1.6.4.1)
       railties (>= 3.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     breach-mitigation-rails (0.2.2)
       activesupport
       rack
-    breadcrumbs_on_rails (2.3.1)
-    browse-everything (0.9.1)
-      bootstrap-sass
-      dropbox-sdk (>= 1.6.2)
-      font-awesome-rails
-      google-api-client
-      google_drive
-      httparty
-      rails (>= 3.1)
-      ruby-box
-      sass-rails
-      skydrive
+    breadcrumbs_on_rails (3.0.1)
     browser (2.2.0)
     builder (3.1.4)
     cancan (1.6.10)
-    capybara (2.7.1)
+    capybara (2.10.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -176,7 +183,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    daemons (1.2.3)
+    daemons (1.2.4)
     debug_inspector (0.0.2)
     deprecation (1.0.0)
       activesupport
@@ -220,7 +227,7 @@ GEM
     ffi (1.9.14)
     font-awesome-rails (4.2.0.0)
       railties (>= 3.2, < 5.0)
-    font-awesome-sass (4.6.2)
+    font-awesome-sass (4.7.0)
       sass (>= 3.2)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
@@ -248,7 +255,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    hashie (3.4.4)
+    hashie (3.4.6)
     hike (1.2.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
@@ -304,7 +311,10 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
-    jwt (1.5.4)
+    jwt (1.5.6)
+    kaltura (0.1.1)
+      hashie (>= 1.0.0)
+      httparty (>= 0.7.8)
     kaminari (0.15.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -327,9 +337,9 @@ GEM
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
-    memoist (0.14.0)
-    mime-types (2.99.2)
-    mimemagic (0.3.1)
+    memoist (0.15.0)
+    mime-types (2.99.3)
+    mimemagic (0.3.2)
     mini_magick (3.8.1)
       subexec (~> 0.2.1)
     mini_portile2 (2.1.0)
@@ -345,10 +355,9 @@ GEM
     netrc (0.11.0)
     noid (0.6.6)
       backports
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    nom-xml (0.5.4)
+    nom-xml (0.6.0)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
@@ -384,8 +393,7 @@ GEM
       activesupport (>= 3.0.0)
       cocaine (~> 0.5.0)
       mime-types
-    pkg-config (1.1.7)
-    poltergeist (1.10.0)
+    poltergeist (1.11.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -484,7 +492,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rufus-scheduler (3.2.1)
+    rufus-scheduler (3.2.2)
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -493,7 +501,7 @@ GEM
       sprockets-rails (~> 2.0)
     sax-machine (1.3.2)
     scrub_rb (1.0.1)
-    sdoc (0.4.1)
+    sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     show_me_the_cookies (3.1.0)
@@ -510,8 +518,8 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    sitemap_generator (5.1.0)
-      builder
+    sitemap_generator (5.2.0)
+      builder (~> 3.0)
     skydrive (1.2.0)
       activesupport
       httmultiparty
@@ -533,8 +541,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.11)
-    stomp (1.4.1)
+    sqlite3 (1.3.12)
+    stomp (1.4.3)
     subexec (0.2.3)
     sufia-models (3.4.0)
       active-fedora (~> 6.7.0)
@@ -556,9 +564,11 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     trollop (1.16.2)
-    tzinfo (0.3.51)
+    turbolinks (2.5.3)
+      coffee-rails
+    tzinfo (0.3.52)
     uber (0.0.15)
-    uglifier (3.0.1)
+    uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -587,6 +597,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass
+  browse-everything!
   capybara (~> 2.1)
   change_manager
   clamav
@@ -603,6 +614,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jettywrapper (~> 1.8.3)
   jquery-rails
+  kaltura
   kaminari (= 0.15.1)
   mysql2 (= 0.3.20)
   omniauth-openid
@@ -621,7 +633,8 @@ DEPENDENCIES
   show_me_the_cookies
   sitemap_generator
   sqlite3
+  turbolinks (= 2.5.3)
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
@scherztc `bundle update` results:

activerecord-import 0.16.1 (was 0.15.0)
bootstrap-datepicker-rails 1.6.4.1 (was 1.6.1.1)
breadcrumbs_on_rails 3.0.1 (was 2.3.1)
capybara 2.10.1 (was 2.7.1)
daemons 1.2.4 (was 1.2.3)
font-awesome-sass 4.7.0 (was 4.6.2)
hashie 3.4.6 (was 3.4.4)
jwt 1.5.6 (was 1.5.4)
kaltura 0.1.1 (new)
memoist 0.15.0 (was 0.14.0)
mime-types 2.99.3 (was 2.99.2)
mimemagic 0.3.2 (was 0.3.1)
nokogiri 1.6.8.1 (was 1.6.8)
nom-xml 0.6.0 (was 0.5.4)
pkg-config 1.1.7 (new)
poltergeist 1.11.0 (was 1.10.0)
rufus-scheduler 3.2.2 (was 3.2.1)
sdoc 0.4.2 (was 0.4.1)
sitemap_generator 5.2.0 (was 5.1.0)
sqlite3 1.3.12 (was 1.3.11)
stomp 1.4.3 (was 1.4.1)
tzinfo 0.3.52 (was 0.3.51)
uglifier 3.0.3 (was 3.0.1)