### PR TITLE
Feature/#885 migrate static

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# comment forced by rubocop
+class StaticController < ApplicationController
+  def about
+    render "static/about"
+  end
+
+  def coll_policy
+    render "static/coll_policy"
+  end
+
+  def format_advice
+    render "static/format_advice"
+  end
+
+  def faq
+    render "static/faq"
+  end
+
+  def distribution_license
+    render "static/distribution_license"
+  end
+
+  def documenting_data
+    render "static/documenting_data_help"
+  end
+
+  def creators_rights
+    render "static/creators_rights"
+  end
+end

--- a/app/views/static/_about_text.html.erb
+++ b/app/views/static/_about_text.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%=t('sufia.product_name') %> is a digital repository that enables the <%=t('sufia.institution_name') %> community to share its research and scholarly work with a worldwide audience. Faculty and staff can use <%=t('sufia.product_name') %> to collect their work in one location and create a durable and citeable record of their papers, presentations, publications, datasets, or other scholarly creations. Students, through an approved process, may contribute capstone projects such as senior design projects, theses, and dissertations.
+</p>
+<p>a
+  The mission of <%=t('sufia.product_name') %> is to preserve the permanent intellectual output of UC, to advance discovery and innovation, to foster scholarship and learning through the transformation of data into knowledge, to collect a corpus of works that can be used for teaching and to inspire derivative works, and to enhance discoverability and access to these resources.
+</p>
+<p>
+  <%=t('sufia.product_name') %> is an open source, agile development project supported in partnership by the <%=t('sufia.institution_name') %> Libraries and UC Information Technologies. Our source code repository is found on github.com in two places: <a href="https://github.com/uclibs/scholar_uc" target="_blank">our application code</a> and a <a href="https://github.com/uclibs/curate" target="_blank">Ruby on Rails engine</a>.  Our application is built on top of <a href="http://projecthydra.org" target="_blank">Project Hydra</a>, a repository framework used by institutions worldwide to provide access to their digital content, and an open source community to facilitate shared software development.
+</p>
+<p>
+  The development of Scholar@UC is aided by a group of early adopters who help to prioritize new developments.  To join this group (or to directly suggest improvements) <a href="contact_requests/new.html">contact the Scholar@UC team</a>.  Regular updates about Scholar@UC can be found on <a href="http://libapps.libraries.uc.edu/scholarblog" target="_blank">ScholarBlog: the blog for Scholar@UC</a>.  For additional information, please <a href="contact_requests/new.html">contact the Scholar@UC team</a>.
+</p>

--- a/app/views/static/_legally_binding_text.html.erb
+++ b/app/views/static/_legally_binding_text.html.erb
@@ -1,0 +1,41 @@
+<p>
+By agreeing to and submitting this license, you (the creator(s) or copyright owner(s)) grant to the <%= I18n.t('sufia.institution_name') %> the non-exclusive right to reproduce, migrate or transfer, and/or distribute your submission (including the abstract) worldwide in print and electronic format and in any medium, including but not limited to audio, video, or a computer interface. If you are an authorized submission proxy, the creator(s) or copyright owner(s) are bound by the terms of this license.
+</p>
+
+<p>
+You agree that the <%= I18n.t('sufia.institution_name') %> may, without changing the content, migrate or transfer the submission to any medium or format for the purpose of preservation. You agree that the <%= I18n.t('sufia.institution_name') %> may revise or enhance the descriptive and access metadata associated with your submission.
+</p>
+
+<p>
+You agree that <%= I18n.t('sufia.institution_name') %> may keep or transmit to additional, non-public archives more than one copy of this submission for purposes of security, back-up, and preservation.
+</p>
+
+<p>
+You understand that you may request the <%= I18n.t('sufia.institution_name') %> to remove your submitted materials from the repository; however, you acknowledge that the <%= I18n.t('sufia.institution_name') %> cannot control or retract works that may have been accessed by third parties prior to your request for removal. If the submission is removed you agree that the item can be replaced by a page with a statement declaring that the item was removed by your request.
+</p>
+
+<p>
+You warrant and represent that you have the full right, power, and authority to enter into this Agreement and to grant the rights granted herein; and that the University’s inclusion and use of the work will not violate any rights of any kind or nature whatsoever, including copyright, of any third party.  You warrant and represent submission materials which contain work for which you do not hold copyright that use of such work constitutes fair use, or you have obtained the unrestricted permission from the copyright owner to grant the <%= I18n.t('sufia.institution_name') %> the rights required under this license.  You shall noticeably point out and provide appropriate attribution to such third-party owned material within the text or content of the submission.  Where challenges to copyright arise, the <%= I18n.t('sufia.institution_name') %> reserves the right to restrict access to and/or remove the material.
+</p>
+
+<p>
+You agree that this submission does not include data that is classified as restricted, per the <a href="http://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Protection_Policy_9_1_1.pdf"><%= I18n.t('sufia.institution_name') %> Data Protection Policy, Policy 9.1.1</a>, does not to your knowledge contain malicious software, and adheres to <a href="http://www.uc.edu/infosec/policies.html"><%= I18n.t('sufia.institution_name') %> computing policies and guidelines</a>.
+</p>
+
+<p>
+<%=I18n.t('sufia.product_name')%> affirms the academic freedom principles outlined in the <a href="http://www.uc.edu/content/dam/uc/provost/docs/academicpersonnel/a-z/AAUP-UC 2013-16 CBA_4June14.pdf"><i>Collective Bargaining Agreement between the <%= I18n.t('sufia.institution_name') %> and American Association of University Professors <%= I18n.t('sufia.institution_name') %> Chapter</i></a> (Article 2 and Article 3). <%=I18n.t('sufia.product_name')%> also recognizes the <%= I18n.t('sufia.institution_name') %>’s existing Copyright (<a href="http://www.uc.edu/content/dam/uc/trustees/docs/rules_10/10-19-02.pdf">University Rule 3361:10-19-02</a>) and Patent (<a href="http://www.uc.edu/content/dam/uc/trustees/docs/rules_10/10-19-01.pdf">University Rule 3361:10-19-01</a>) policies.
+</p>
+
+<p>
+IF THE SUBMISSION IS BASED UPON WORK THAT HAS BEEN SPONSORED OR SUPPORTED BY AN AGENCY OR ORGANIZATION OTHER THAN THE UNIVERSITY OF CINCINNATI, YOU REPRESENT THAT YOU HAVE FULFILLED ANY RIGHT OF REVIEW OR OTHER OBLIGATIONS REQUIRED BY ANY CONTRACT OR AGREEMENT WITH SUCH AGENCY OR ORGANIZATION.
+</p>
+
+<p>
+<%= I18n.t('sufia.institution_name') %> will clearly identify your name(s) as the creator(s) or owner(s) of the submission, and will not make any alteration, other than as allowed by this license, to your submission.
+</p>
+
+<p>
+Non-Exclusive Distribution License
+<br/><%=I18n.t('sufia.product_name')%>
+<p>Approved by the Office of General Counsel, 03-23-2015</p>
+</p>

--- a/app/views/static/about.html.erb
+++ b/app/views/static/about.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "About #{application_name}" %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+      <h2>What is <%=t('sufia.product_name') %>?</h2>
+      <%= render :partial => 'about_text' %>
+    </div>
+  </div>
+</div>

--- a/app/views/static/coll_policy.html.erb
+++ b/app/views/static/coll_policy.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, "#{application_name} Collection Policy" %>
+ 
+<div class="container">
+  <div class="row">
+    <div class="span12">
+ 
+<h2>
+	Collection Policy
+</h2>
+ 
+<p>
+	<b>Mission</b>
+	<br/>The mission of Scholar@UC is to preserve the intellectual output of UC, to advance discovery and innovation, to foster scholarship and learning through the transformation of data into knowledge, to collect a corpus of works that can be used for teaching and to inspire derivative works, and to enhance discoverability and access to these resources.
+</p>
+<p>
+	<b>Content</b>
+	<br/>Scholar@UC was developed to store and share the scholarly output and creative works of UC faculty (current and emeritus), staff, and students. Original research outputs and creative works of the University community will be preserved and made available. Works that are deposited in Scholar@UC should support the mission of the University of Cincinnati. Students should work with a faculty member to share scholarly output and creative works, such a capstone projects. Those interested in depositing UC records should contact <a href="http://www.libraries.uc.edu/arb/records-management.html">Records Management</a>.
+</p>
+<p>
+	Examples of appropriate content include, but are not limited to: <a href="https://en.wikipedia.org/wiki/Grey_literature">grey literature</a>; <a href="https://en.wikipedia.org/wiki/Preprint">pre-</a>, <a href="https://en.wikipedia.org/wiki/Postprint">post-</a>, and published versions of academic papers, manuscripts, senior design projects, theses and dissertations (mediated by the Graduate School), posters, datasets, presentations, and other creative works. Content may be text, image, video, audio, or mixed-media in nature.
+	<br><br>
+	<strong>Content classified as restricted by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Protection_Policy_9_1_1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> or by export control should never be deposited to Scholar@UC.</strong>
+</p>
+<p>
+	<b>Intellectual Property, Copyright, and Access</b>
+	<br/>In order to submit content to Scholar@UC, creators must agree to a <a href="/distribution_license_request">non-exclusive distribution license</a> that authorizes UC to preserve, to transform, to enhance metadata, and to make available their content. Creators may choose, though are not required, to issue their content with a <a href="https://creativecommons.org/about">Creative Commons license</a> that clearly indicates how their content may be reused. Creators may choose to issue content as public domain or all rights reserved.
+</p>
+<p>
+	Creators are able to control access to their content. Creators may choose to make content visible to themselves only, to a group of predetermined individuals, to embargo content for a defined time period, or to make their content open access.
+</p>
+<p>
+	<b>Withdrawal</b>
+	<br/>Scholar@UC is intended to permanently preserve the intellectual output of UC. However, creators retain the right to delete their content at any time. If deleted content included a Digital Object Identifier (DOI), a record of the last known metadata (tombstone) may be displayed to users attempting to access the content through the DOI.
+</p>
+  
+    </div>
+  </div>
+</div>

--- a/app/views/static/creators_rights.html.erb
+++ b/app/views/static/creators_rights.html.erb
@@ -1,0 +1,94 @@
+<% content_for :page_title, "#{application_name} Creator's Rights" %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+      <h2>
+        Creator&#39s Rights
+      </h2>
+      <p>
+        Contributing to <a href="/"><%=t('sufia.product_name') %></a> may raise questions about what rights you may hold as the creator of a work.
+
+        First and foremost, you are the creator of your work and you are in control of its copyright.  This is your
+        right; in no way does contributing to <a href="/"><%=t('sufia.product_name') %></a> limit your ability to
+        claim or enforce copyright on your work.  However, you may have entered into publishing agreements that
+        restrict you from sharing your work, especially if you agreed to relinquish or transfer your copyright as part of an author agreement.
+      </p>
+
+      <p>
+        <a href="http://www.sparc.arl.org" target="_blank">The Scholarly Publishing and Academic Resources
+          Coalition</a> has created useful guidelines to help you navigate through the legalese of scholarly
+        communications.  We encourage you to visit this website for a fuller understanding and to take a look at the
+        <a href="http://www.sparc.arl.org/resources/authors/addendum-2007" target="_blank">author addendum</a>,
+        &#34a legal instrument that modifies the publisher’s agreement and allows you to keep key rights to your articles.&#34
+        Adding an author addendum to your authorship agreements grants you rights you may otherwise lose under a standard agreement.
+      </p>
+
+      <p>
+        Another resource that may be useful is the <a href="http://www.sherpa.ac.uk/romeo/" target="_blank">SHERPA/RoMEO</a> resource from the University of Nottingham.
+        This resource is a database of academic publishers and their standard terms. If you signed a standard
+        publishing agreement with one of these companies, this resource will help you determine what rights you have
+        under that agreement.  For example, it may help you determine whether it is okay to archive, or submit to
+        <a href="/"><%=t('sufia.product_name') %></a> a pre-print, post-print, publisher’s version, or other version.
+      </p>
+
+      <p>
+        For future scholarly works, consider seeking out an open access journal.  These are journals that are more
+        generous with ensuring authors retain their intellectual property rights.  A typical OA journal may request
+        right of first publication, but assures that the author retains copyright, and may allow authors to add pre-
+        and post-prints of articles to institutional or subject repositories.
+      </p>
+      <br/>
+      <div class="well">
+        <h3>Taking Back Control: Managing Copyright and Intellectual Property</h3>
+
+        <strong>How does copyright affect me?</strong><br/>
+        As the author of an article published in a scholarly journal, you may be asked to sign away your copyrights, in full or in part, to the publisher as a condition of publication. When you transfer copyright you:
+        <ul>
+          <li>
+            lose the right to post copies of your own work on your own website without permission of the publisher.
+          </li>
+          <li>
+            you cannot legally make copies of your own work for distribution to students or colleagues.
+          </li>
+        </ul>
+
+        <p>
+            <strong>How does copyright affect my publisher?</strong><br/>
+            When you surrender your copyright you also surrender control of your work. You give up your scholarly
+          output to publishers for free and the publishers, in turn, sell your intellectual property back to our
+          institutions for increasingly unreasonable subscription rates. This business model has made science,
+          technology and medicine (STM) publishing a highly profitable sector of the publishing industry.
+        </p>
+
+        <p>
+            <strong>What is copyright?</strong><br/>
+            Copyright gives the author or creator of an original work, exclusive control of how that work is
+          reproduced, distributed or performed. When you transfer copyright, you no longer have control of how your work is distributed.
+        </p>
+
+        <p>
+          <strong>Why would an individual relinquish copyright to a corporation?</strong><br/>
+          One reason for surrendering copyright is that corporations may have better capabilities for marketing and
+          distribution of that work. In the recording industry, for example, an artist might transfer copyright to
+          the record label in exchange for royalties.  The record label, in turn, would then ensure that the
+          recording is marketed and distributed widely in order to maximize the artist’s royalties.
+        </p>
+        <p>
+          <strong>Why should I retain copyright?</strong><br/>
+            By retaining copyright for articles you submit to commercial or society publishers, you are taking back
+          control of your own scholarly output. When you own the copyright of your own work, you have the freedom to
+          disseminate your work as you please whether this means posting a copy of your article on your own website,
+          distributing copies to students and colleagues or posting it to a repository [such as <a href="/"><%=t('sufia.product_name') %></a>].
+          Widespread dissemination of your work, in turn, means that your work can be read by more people and thus has greater potential impact.
+        </p>
+
+        <small>Source: “Take Back Control: Managing Copyright and Intellectual Property.” 2005. Accessed February 12,
+                     2015. <a href="http://www.lib.berkeley.edu/scholarlypublishing/copyright.pdf" target="_blank">http://www.lib
+          .berkeley.edu/scholarlypublishing/copyright.pdf</a></small>
+      </div>
+
+
+    </div>
+  </div>
+</div>

--- a/app/views/static/distribution_license.html.erb
+++ b/app/views/static/distribution_license.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "#{application_name} Distribution License" %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+      <h2>Non-Exclusive Distribution License</h2>
+      <%= render :partial => 'legally_binding_text' %>
+    </div>
+  </div>
+</div>

--- a/app/views/static/documenting_data_help.html.erb
+++ b/app/views/static/documenting_data_help.html.erb
@@ -1,0 +1,58 @@
+<% content_for :page_title, "#{application_name} File Format Advice" %>
+<%= render 'shared/header' %>
+<%= render 'shared/flash_message' %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+
+<h2> Documenting Data </h2>
+
+<hr>
+
+<blockquote>
+	“Data without context are inert, but data within contexts become information, knowledge.”
+	<br>
+	From: Changing the Subject: Art and Attention in the Internet Age By Sven Birkerts
+</blockquote>
+
+<p>
+	Proper documentation provides the context that your data needs to persist through time, to integrate into new systems and to give you credit for your contributions in the form of data citations. Where possible, you should contribute the following information along with your dataset:
+</p>
+
+<ol type="1">
+	<li><b>Complete Metadata</b> - Metadata aids Discovery and Reuse. Scholar@UC requires metadata such as title of work, creator name, data submitted and description. All text is searchable. You should write a detailed description to increase discoverability of your content. Also provided are additional metadata fields under the Show Additional Description link. Here you can add in additional fields such as subject terms for search enhancement. If you are following a suggested schema for your discipline, indicate that in the description or in the next document – the README file. </li>
+	<br>
+
+	<li><b>README.txt File</b> - This is a text document that provides relevant information such as purpose of the project and the organizational structure or relationship of the files. It explains terms that are unique to the dataset, keywords, omissions and errors. If you are using a file naming convention, you can explain it in the readme file. It is also the place to put additional details that were not included in the metadata, such as additional information about external storage of the data, metadata schema followed and researcher contact information.     <br><br>
+
+	A good example can be found in the <a href="http://dataabinitio.com/?p=378" target="_blank">Data ab Initio blog post README.txt by Kristin Briney</a></li>
+	<br>
+
+	<li><b>Data Dictionary/Codebook</b> - This document explains all the variables and abbreviations associated with the dataset. 
+	<br><br>
+
+	Here are links to example data dictionaries from The University of Texas at Austin's Population Research Center (<a href="http://www.utexas.edu/cola/redcap/Project-Examples.php" target="_blank">data dictionary examples</a>) and IRSA (<a href="http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/dd_tbl.html" target="_blank">data dictionary example</a>) provide two quick examples of data dictionaries.</li>
+	<br>
+
+	<li><b>Methodology/Protocol</b> - This document details the steps taken to collect the data. If you submitted modified data instead of a raw data set, you can explain those steps in this document.</li>
+	<br>
+</ol>
+
+<h2> Additional Resources on Documentation for Data: </h2>
+<ol type="1">
+	<li><a href="http://www.icpsr.umich.edu/icpsrweb/content/deposit/guide/index.html" target="_blank">ICPSR's Guide to Social Science Data Preparation and Archiving</a></li>
+	<li><a href="https://www.dataone.org/best-practices" target="_blank">DataOne Best Practices</a></li>
+	<li><a href="http://datalib.edina.ac.uk/mantra/" target="_blank">Mantra Research Data Management Training</a></li>
+	<li><a href="http://datadryad.org/pages/faq" target="_blank">DataDryad FAQ</a></li>
+	<li><a href="http://www.dcc.ac.uk/resources/how-guides" target="_blank">Digital Curation Centre How-to Guides & Checklists</a></li>
+</ol>
+
+<h2> Copyright and Data </h2>
+<p>
+	Copyright is intended to protect creators’ rights concerning their creative works such as written works, images, video. In most cases data is considered fact and not protected by copyright. For guidance on whether your data falls under copyright, you can consult <a href="http://dataabinitio.com/?p=632" target="_blank">this blog post</a> and <a href="https://figshare.com/articles/Data_and_Copyright/3117838" target="_blank">flyer</a> by Kristen Briney. 
+</p>
+
+	</div>
+  </div>
+</div>

--- a/app/views/static/faq.html.erb
+++ b/app/views/static/faq.html.erb
@@ -1,0 +1,163 @@
+<% content_for :page_title, "#{application_name} FAQ" %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+
+      <h2>
+        Frequently Asked Questions</h2>
+      <ul>
+        <li><a href="#faq_1234">If I have a problem with the system, where do I go for assitance?</a></li>
+        <li><a href="#faq_951">How can I allow someone else to submit works on my behalf?</a></li>
+        <li><a href="#faq_5678">How can I group my works into collections of related works?</a></li>
+        <li><a href="#faq_4321">How can I share access to selected works with a group of collaborators?</a></li>
+        <li><a href="#faq_8765">How do I upload an access file? </a></li>
+        <li><a href="#faq_1346">How do I upload a preservation file? </a></li>
+        <li><a href="#faq_4679">I'm having trouble uploading a file over 200 MB; what should I do?</a></li>
+        <li><a href="#faq_7946">May I publish, contribute, or otherwise distribute my content elsewhere?</a></li>
+        <li><a href="#faq_1379">What file formats should I use when uploading to <%=t('sufia.product_name') %>?</a></li>
+        <li><a href="#faq_7913">What happens to my works if I delete them?</a></li>
+        <li><a href="#faq_159">Where do I go if I want to consult with subject area specialists on content?</a></li>
+        <li><a href="#faq_3456">What's restricted data?</a></li>
+        <li><a href="#faq_6543">What’s the difference between delegates, editors, and groups?</a></li>
+        <li><a href="#faq_1010">How do work access rights impact my DOIs?</a></li>
+        <li><a href="#faq_6789">What happens to my content when I delete a work?</a></li>
+
+      </ul>
+      <p>
+        <a name="faq_1234" id="faq_1234"></a>If I have a problem with the system, where do I go for assistance? </p>
+      <blockquote>
+        Use the <a href="../contact">contact form</a> to submit any inquiry about <%=t('sufia.product_name') %>, including technical issues.
+      </blockquote>
+      <p><a name="faq_951" id="faq_951"></a>
+        How can I allow someone else to submit works on my behalf?
+      </p>
+      <blockquote>
+        <%=t('sufia.product_name') %> allows you to assign delegates, who will be able to submit new works on your behalf. They will retain access to modify these works until you remove their access. If you're logged in, you can access this from the “My Delegates” link under your account name, above.
+      </blockquote>
+
+      <p><a name="faq_5678" id="faq_5678"></a>
+        How can I group my works into collections of related works?
+      </p>
+      <blockquote>
+        <%=t('sufia.product_name') %> allows you to create collections, to which you can add any works that you or others have submitted to <%=t('sufia.product_name') %>. You can set a custom title, description, and image for your collections.
+      </blockquote>
+
+      <p><a name="faq_4321" id="faq_4321"></a>
+        How can I share access to selected works with a group of collaborators?
+      </p>
+      <blockquote>
+        <%=t('sufia.product_name') %> allows you to create groups of collaborators, which you can assign to individual works. This will give individuals in the group the ability to edit assigned works and to view restricted works of yours. You can also assign editing rights to individuals, without first placing them in groups, by designating them as editors of your work. If you're logged in, you can access this from the “My Groups” link under your account name, above.
+      </blockquote>
+
+
+      <p><a name="faq_8765" id="faq_8765"></a>
+        How do I upload an access file?
+      </p>
+      <blockquote>
+        When completing the submission form for <%=t('sufia.product_name') %>, you may upload files. We recommend uploading your access file at the same time you are describing your work.
+        <br><br>
+        For more information, please see <a href="../format_advice">File Format Advice</a>.
+      </blockquote>
+
+      <p><a name="faq_1346" id="faq_1346"></a>
+        How do I upload a preservation file?
+      </p>
+
+      <blockquote>
+        After your work is uploaded and you are viewing the record, you will see a row of buttons towards the bottom of the page (if logged in). In the row of buttons, click <span class="fakebutton">Attach a File</span> to upload an additional file to your record. We recommend granting private access rights to preservation files. This will make it easier for users to know which they should download.
+        <br><br>
+        For more information, please see <a href="../format_advice">File Format Advice</a>.
+      </blockquote>
+
+      <p><a name="faq_4679" id="faq_4679"></a>
+        I'm having trouble uploading a file over 200 MB; what should I do?
+      </p>
+
+      <blockquote>
+        We recommend that you use the <a href="../contact">contact form</a> for assistance with files larger than 200 MB, but if you have trouble uploading any file, please use the <a href="../contact">contact form</a> for assistance.
+      </blockquote>
+
+
+      <p><a name="faq_7946" id="faq_7946"></a>
+        May I publish, contribute, or otherwise distribute my content elsewhere?
+      </p>
+      <blockquote>
+        Yes. When you submit content to <%=t('sufia.product_name') %> you agree to a non-exclusive <a class="a" href="../distribution_license">distribution license</a> that grants UC the right to enhance metadata, to replicate the content for preservation, and to make the content available through computer interfaces. This license in no way prevents you from distributing your content through other channels.
+      </blockquote>
+
+      <p><a name="faq_1379" id="faq_1379"></a>
+        What file formats should I use when uploading to <%=t('sufia.product_name') %>?
+      </p>
+
+      <blockquote>
+        File format is an important consideration when contributing your work to <%=t('sufia.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
+        <br><br>
+        An access file typically uses common formats that people are familiar with, usually compressed. It makes them easy to download and use. Examples of access formats are JPEG and MP3.
+        <br><br>
+        Preservation files should be the highest quality format available for your content, preferably uncompressed. They can be used to create new access files in the future, as formats change over time. Examples of preservation formats are TIFF and WAV. Uploading a preservation file will help guarantee your content will be easily used in the future.
+        <br><br>
+        For more information, please see <a href="../format_advice">File Format Advice</a>.
+      </blockquote>
+
+
+      <p><a name="faq_7913" id="faq_7913"></a>
+        What happens to my works if I delete them?
+      </p>
+      <blockquote>
+        If you have not requested a Digital Object Identifier (DOI) for your work, you can withdraw any works you have submitted and they will be removed from <%=t('sufia.product_name') %>. If you have requested a DOI, the work will be removed from <%=t('sufia.product_name') %>, but a brief citation will be retained at our DOI provider's website that displays the work's citation information, and the reason for it's unavailability.
+      </blockquote>
+
+
+
+      <p><a name="faq_159" id="faq_159"></a>
+        Where do I go if I want to consult with subject area specialists on content?
+      </p>
+      <blockquote>
+        Access the <a href="http://www.libraries.uc.edu/help/subject-librarians.html">Subject Librarians directory</a> to find contact info for subject area specialists.
+      </blockquote>
+
+
+      <p><a name="faq_3456" id="faq_3456"></a>
+        What's restricted data?
+      </p>
+      <blockquote>
+        Restricted data is data that is private, confidential, classified as restricted by export control, or data that could be used to personally identify an individual. Some examples include social security numbers, financial account numbers, electronically stored bio-metric information, and data from research involving human subjects. Restricted Data is defined by <a href="https://www.uc.edu/content/dam/uc/infosec/docs/policies/Data_Protection_Policy_9_1_1.pdf">University of Cincinnati Policy 9.1.1 (Data Protection Policy)</a> and should be reviewed for additional information.
+      </blockquote>
+
+
+      <p><a name="faq_6543" id="faq_6543"></a>
+        What’s the difference between delegates, editors, and groups?
+      </p>
+      <blockquote>
+        Delegates are people you authorize who can create, edit, and delete works on your behalf. They can do anything you can do, so please exercise discretion when authorizing another person as a delegate. Your delegates may be managed from the My Delegates page. 
+        <br><br>
+        Editors are individuals to whom you have granted the ability to view and make changes to a specific work. If you would like to grant a group of individuals these rights, you can create a Group on the My Groups page. For example, if you work with a group of researchers on a single work, you can create a group of those researchers and grant that group viewing and editing privileges.
+        <br><br>
+        Editors (and groups) are like delegates, but whereas delegates have all the powers of the person they represent, editors (and groups) can only view and make changes to specific works.
+      </blockquote>
+
+      <p><a name="faq_1010" id="faq_1010"></a>
+        How do work access rights impact my DOIs?
+      </p>
+      <blockquote>
+        If you use Scholar@UC to request a DOI, it will be either <i>public</i>, <i>reserved</i>, or <i>unavailable</i>.
+        <br><br>
+        <i>Public</i> DOIs are available for all <span class="label label-success">Open Access</span> works, and work normally.
+        <br><br>
+        <i>Reserved</i> DOIs are granted to any <span class="label label-warning">Open Access with Embargo</span>, <span class="label label-info"><%=t('sufia.institution_name') %></span>, or <span class="label label-important">Private</span> works for which you request a DOI. A <i>reserved</i> DOI will not yet redirect to your work, but it will be availble on the display page for your work for your reference. A <i>reserved</i> DOI will become <i>public</i> if you make your work <span class="label label-success">Open Access</span> or if your <span class="label label-warning">Embargo</span> expires.
+        <br><br>
+        <i>Unavailable</i> DOIs are maintained for works for which you have requested a DOI where you have deleted the work or where you have changed the access rights from <span class="label label-success">Open Access</span> to <span class="label label-warning">Open Access with Embargo</span>, <span class="label label-info"><%=t('sufia.institution_name') %></span>, or <span class="label label-important">Private</span>. A tombstone page will indicate that the work is not available because it was withdrawn from the author. If you change your work back to <span class="label label-success">Open Access</span>, the DOI will change back to <i>public</i> status.
+        <br><br>
+      </blockquote>
+
+      <p><a name="faq_6789" id="faq_6789"></a>
+        What happens to my content when I delete a work?
+      </p>
+      <blockquote>
+        When you delete content from Scholar@UC it is immediately removed from public view. However, the content isn’t removed from the application for 30-days and can be recovered upon your request by contacting scholar@uc.edu. After 30-days, the content will be permanently removed from Scholar@UC. If deleted content included a Digital Object Identifier (DOI), a record of the last known metadata (tombstone) may be displayed to users attempting to access the content through the DOI.
+      </blockquote>
+
+    </div>
+  </div>
+</div>

--- a/app/views/static/format_advice.html.erb
+++ b/app/views/static/format_advice.html.erb
@@ -1,0 +1,171 @@
+<% content_for :page_title, "#{application_name} File Format Advice" %>
+
+<div class="container">
+  <div class="row">
+    <div class="span12">
+
+      <h2>
+	    File Format Advice
+      </h2>
+
+      <p>
+        Choosing the right file format for your content is an important consideration when contributing your work to <%=t('sufia.product_name') %>. The future usability of your content will depend on the file format you use. Because of this, we recommend uploading two files for each work: an access file and a preservation file.
+      </p>
+
+      <h4>
+        Access Files
+      </h4>
+
+      <p>
+        Access files use common formats, ones that we typically use every day. They often use compression, for easy delivery over the web. Access files are what most people will download when viewing you work. Below are some typical access formats.
+      </p>
+
+
+      <table class="table-bordered table-format-advice">
+        <thead>
+          <tr>
+            <th>
+              Text
+            </th>
+            <th>
+              Still Image
+            </th>
+            <th>
+              Audio
+            </th>
+            <th>
+              Video
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <ul>
+                <li>
+                  MS Office (DOCX, XSLSX, etc.)
+                </li>
+                <li>
+                  PDF
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  JPG
+                </li>
+                <li>
+                  PNG
+                </li>
+                <li>
+                  GIF
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  MP3
+                </li>
+                <li>
+                  MP4
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  MP4
+                </li>
+                <li>
+                  MPEG
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        It is recommended that you upload an access file at the time you complete your submission.
+      </p>
+
+      <h4>
+        Preservation Files
+      </h4>
+
+      <p>
+        Preservation files use more stable formats than access files, whose formats are more likely to change with technology. They are often uncompressed and very large. Preservation formats can be used to create new access files, when new formats emerge. Below are some typical preservation formats.
+      </p>
+
+      <table class="table-bordered table-format-advice">
+        <thead>
+          <tr>
+            <th>
+              Text
+            </th>
+            <th>
+              Still Image
+            </th>
+            <th>
+              Audio
+            </th>
+            <th>
+              Video
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <ul>
+                <li>
+                  Open Office (ODT, ODS)
+                </li>
+                <li>
+                  CSV
+                </li>
+                <li>
+                  PDF/A-1
+                </li>
+                <li>
+                  PDF/A-2
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  TIFF
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  WAV
+                </li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>
+                  AVI
+                </li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        It is recommended that you upload a preservation file after the work submission has been completed. When logged in and viewing the work, near the bottom of your screen you will see a row of buttons that includes:  <span class='fakebutton'>Attach a File</span>
+      </p>
+      <p>
+        It is also recommended that preservation files be set to private access rights, so users will not be confused about which they should download.
+      </p>
+
+    </div>
+  </div>
+</div>

--- a/app/views/static/help.html.erb
+++ b/app/views/static/help.html.erb
@@ -1,0 +1,18 @@
+<div class="container">
+  <div class="row">
+    <div class="span12">
+
+      <h2>Help Pages</h2>
+      <ul>
+        <li><a href="/coll_policy">Collection Policy</a></li>
+        <li><a href="/terms">Terms of Use</a></li>
+        <li><a href="/format_advice">File Format Advice</a></li>
+        <li><a href="http://librarycopyright.net/resources/fairuse/" target="_blank">Fair Use</a></li>
+        <li><a href="/faq">FAQ</a></li>
+        <li><a href="/documenting_data">Documenting Data</a></li>
+        <li><a href="/creators_rights">Creator's Rights</a></li>
+      </ul>
+
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,13 @@ Rails.application.routes.draw do
 
   # route for splash page
   get 'splash' => 'page_requests#splash_page'
+  get 'about' => 'static#about'
+  get 'coll_policy' => 'static#coll_policy'
+  get 'format_advice' => 'static#format_advice'
+  get 'faq' => 'static#faq'
+  get 'distribution_license' => 'static#distribution_license'
+  get 'documenting_data' => 'static#documenting_data'
+  get 'creators_rights' => 'static#creators_rights'
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe StaticController do
+  describe '#about' do
+    it 'renders the about page' do
+      get :about
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/about')
+    end
+  end
+  describe '#coll_policy' do
+    it 'renders the collection policy page' do
+      get :coll_policy
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/coll_policy')
+    end
+  end
+  describe '#format_advice' do
+    it 'renders the format advice page' do
+      get :format_advice
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/format_advice')
+    end
+  end
+  describe '#faq' do
+    it 'renders the faq advice page' do
+      get :faq
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/faq')
+    end
+  end
+  describe '#distribution_license' do
+    it 'renders the distribution_license page' do
+      get :distribution_license
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/distribution_license')
+    end
+  end
+  describe '#documenting_data' do
+    it 'renders the documenting_data page' do
+      get :documenting_data
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/documenting_data_help')
+    end
+  end
+  describe '#creators_rights' do
+    it 'renders the creators_rights page' do
+      get :creators_rights
+      expect(response.status).to be == 200
+      expect(response).to render_template('static/creators_rights')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #885  ; refs #884 

Adds all of the About and Help pages that are present in scholar 2 (except Welcome page)

Changes proposed in this pull request:
* Help directs to a page containing links to all the help pages (unlike the dropdown approach in 2.x)
* About contains only the _about_text 
* 
