### PR TITLE
Add recpatcha to contact form for non-authenticated users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,6 +100,10 @@ Rails/OutputSafety:
   Exclude:
   #everything here was sufia-specific
 
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/controllers/contact_form_controller_spec.rb'
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/views/**/*'

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -137,3 +137,7 @@ div.input-group-btn button.btn-primary:active {
 .header-uc-logo {
   height: 100%;
 }
+
+.g-recaptcha {
+  margin-bottom: 20px;
+}

--- a/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/contact_form_controller_behavior.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module Sufia
+  module ContactFormControllerBehavior
+    extend ActiveSupport::Concern
+    FAIL_NOTICE = "You must complete the Captcha to confirm the form."
+
+    included do
+      before_action :build_contact_form
+    end
+
+    def new
+    end
+
+    def create
+      # not spam and a valid form
+      if @contact_form.valid? && passes_captcha_or_is_logged_in?
+        ContactMailer.contact(@contact_form).deliver_now
+        flash.now[:notice] = 'Thank you for your message!'
+        @contact_form = ContactForm.new
+      else
+        flash.now[:error] = 'Sorry, this message was not sent successfully. '
+        flash.now[:error] << FAIL_NOTICE unless passes_captcha_or_is_logged_in?
+        flash.now[:error] << @contact_form.errors.full_messages.map(&:to_s).join(", ")
+      end
+      render :new
+    rescue RuntimeError => e
+      logger.error("Contact form failed to send: #{e.inspect}")
+      flash.now[:error] = 'Sorry, this message was not delivered.'
+      render :new
+    end
+
+    def verify_google_recaptcha(_key, response)
+      status = `curl "https://www.google.com/recaptcha/api/siteverify?secret=#{CAPTCHA_SERVER['secret_key']}&response=#{response}"`
+      hash = JSON.parse(status)
+      hash["success"] == true ? true : false
+    end
+
+    protected
+
+      def build_contact_form
+        @contact_form = Sufia::ContactForm.new(contact_form_params)
+      end
+
+      def contact_form_params
+        return {} unless params.key?(:sufia_contact_form)
+        params.require(:sufia_contact_form).permit(:contact_method, :category, :name, :email, :subject, :message)
+      end
+
+      def passes_captcha_or_is_logged_in?
+        return true if current_user.present?
+        verify_google_recaptcha(CAPTCHA_SERVER['secret_key'], params["g-recaptcha-response"])
+      end
+  end
+end

--- a/app/controllers/contact_form_controller.rb
+++ b/app/controllers/contact_form_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class ContactFormController < ApplicationController
+  include Sufia::ContactFormControllerBehavior
+end

--- a/app/views/contact_form/new.html.erb
+++ b/app/views/contact_form/new.html.erb
@@ -1,3 +1,4 @@
+<script src='https://www.google.com/recaptcha/api.js'></script> 
 <h1>Contact the Scholar@UC Team</h1>
 
 <% if user_signed_in? %>
@@ -30,6 +31,10 @@
     <%= f.label :message, 'Message', class: "col-sm-2 control-label" %>
     <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
   </div>
+
+  <% if current_user.blank? %>
+    <div class="g-recaptcha" data-sitekey= "<%=CAPTCHA_SERVER['site_key']%>"></div>
+  <% end %>
 
   <%= f.submit value: "Send", class: "btn btn-primary" %>
 <% end %>

--- a/config/initializers/load_captcha_configs.rb
+++ b/config/initializers/load_captcha_configs.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+CAPTCHA_SERVER = YAML.load_file(Rails.root.join('config', 'recaptcha.yml'))[Rails.env]

--- a/config/recaptcha.yml
+++ b/config/recaptcha.yml
@@ -1,0 +1,11 @@
+# stores ReCaptcha image server url
+
+development:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key
+test:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key
+production:
+  site_key: bamboo_captcha_site_key
+  secret_key: bamboo_captcha_secret_key

--- a/spec/controllers/contact_form_controller_spec.rb
+++ b/spec/controllers/contact_form_controller_spec.rb
@@ -13,72 +13,74 @@ describe ContactFormController do
     }
   end
 
-  before { sign_in(user) }
-
-  describe "#new" do
-    subject { response }
-    before { get :new }
-    it { is_expected.to be_success }
-  end
-
-  describe "#create" do
-    subject { flash }
-    before { post :create, sufia_contact_form: params }
-    context "with the required parameters" do
-      let(:params) { required_params }
-      its(:notice) { is_expected.to eq("Thank you for your message!") }
+  describe 'while user is unauthenticated' do
+    it 'successfully allows reCaptcha' do
+      described_class.any_instance.stub(:verify_google_recaptcha).and_return(true)
+      Sufia::ContactMailer.any_instance.stub(:mail).and_return(true)
+      post :create, sufia_contact_form: required_params
+      expect(flash[:notice]).to match(/Thank you for your message/)
     end
 
-    context "without a name" do
-      let(:params)  { required_params.except(:name) }
-      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Name can't be blank") }
-    end
-
-    context "without an email" do
-      let(:params)  { required_params.except(:email) }
-      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email can't be blank") }
-    end
-
-    context "without a subject" do
-      let(:params)  { required_params.except(:subject) }
-      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Subject can't be blank") }
-    end
-
-    context "without a message" do
-      let(:params)  { required_params.except(:message) }
-      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Message can't be blank") }
-    end
-
-    context "with an invalid email" do
-      let(:params)  { required_params.merge(email: "bad-wolf") }
-      its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email is invalid") }
+    it 'fails on reCaptcha failure' do
+      described_class.any_instance.stub(:passes_captcha_or_is_logged_in?).and_return(false)
+      post :create, sufia_contact_form: required_params
+      expect(flash[:error]).to match(/You must complete the Captcha to confirm the form/)
     end
   end
 
-  describe "#after_deliver" do
-    context "with a successful email" do
-      it "calls #after_deliver" do
-        expect(controller).to receive(:after_deliver)
+  describe "while user is authenticated" do
+    before { sign_in(user) }
+
+    describe "#new" do
+      subject { response }
+      before { get :new }
+      it { is_expected.to be_success }
+    end
+
+    describe "#create" do
+      subject { flash }
+      before { post :create, sufia_contact_form: params }
+      context "with the required parameters" do
+        let(:params) { required_params }
+        its(:notice) { is_expected.to eq("Thank you for your message!") }
+      end
+
+      context "without a name" do
+        let(:params)  { required_params.except(:name) }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Name can't be blank") }
+      end
+
+      context "without an email" do
+        let(:params)  { required_params.except(:email) }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email can't be blank") }
+      end
+
+      context "without a subject" do
+        let(:params)  { required_params.except(:subject) }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Subject can't be blank") }
+      end
+
+      context "without a message" do
+        let(:params)  { required_params.except(:message) }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Message can't be blank") }
+      end
+
+      context "with an invalid email" do
+        let(:params)  { required_params.merge(email: "bad-wolf") }
+        its([:error]) { is_expected.to eq("Sorry, this message was not sent successfully. Email is invalid") }
+      end
+    end
+
+    context "when encoutering a RuntimeError" do
+      let(:logger) { double(info?: true) }
+      before do
+        allow(controller).to receive(:logger).and_return(logger)
+        allow(Sufia::ContactMailer).to receive(:contact).and_raise(RuntimeError)
+      end
+      it "is logged via Rails" do
+        expect(logger).to receive(:error).with("Contact form failed to send: #<RuntimeError: RuntimeError>")
         post :create, sufia_contact_form: required_params
       end
-    end
-    context "with an unsuccessful email" do
-      it "does not call #after_deliver" do
-        expect(controller).not_to receive(:after_deliver)
-        post :create, params: { contact_form: required_params.except(:email) }
-      end
-    end
-  end
-
-  context "when encoutering a RuntimeError" do
-    let(:logger) { double(info?: true) }
-    before do
-      allow(controller).to receive(:logger).and_return(logger)
-      allow(Sufia::ContactMailer).to receive(:contact).and_raise(RuntimeError)
-    end
-    it "is logged via Rails" do
-      expect(logger).to receive(:error).with("Contact form failed to send: #<RuntimeError: RuntimeError>")
-      post :create, sufia_contact_form: required_params
     end
   end
 end

--- a/spec/features/contact_form_spec.rb
+++ b/spec/features/contact_form_spec.rb
@@ -2,17 +2,33 @@
 require 'rails_helper'
 
 describe "Sending an email via the contact form", type: :feature do
-  before { sign_in(:user) }
+  describe "with unauthenticated user" do
+    it "shows recaptcha dialog" do
+      visit '/'
+      click_link "Contact"
+      expect(page).to have_css('div.g-recaptcha')
+    end
+  end
 
-  it "sends mail" do
-    visit '/'
-    click_link "Contact"
-    expect(page).to have_content "Contact the Scholar@UC Team"
-    fill_in "Your Name", with: "Test McPherson"
-    fill_in "Your Email", with: "archivist1@example.com"
-    fill_in "Message", with: "I am contacting you regarding ScholarSphere."
-    fill_in "Subject", with: "My Subject is Cool"
-    click_button "Send"
-    expect(page).to have_content "Thank you for your message!"
+  describe "with authenticated user" do
+    before { sign_in(:user) }
+
+    it "does not show recaptcha dialog" do
+      visit '/'
+      click_link "Contact"
+      expect(page).not_to have_css('div.g-recaptcha')
+    end
+
+    it "sends mail" do
+      visit '/'
+      click_link "Contact"
+      expect(page).to have_content "Contact the Scholar@UC Team"
+      fill_in "Your Name", with: "Test McPherson"
+      fill_in "Your Email", with: "archivist1@example.com"
+      fill_in "Message", with: "I am contacting you regarding ScholarSphere."
+      fill_in "Subject", with: "My Subject is Cool"
+      click_button "Send"
+      expect(page).to have_content "Thank you for your message!"
+    end
   end
 end


### PR DESCRIPTION
Fixes #963 

Add Recaptcha to contact form for non-authenticated users. Mostly copied from Scholar 2x. We shouldn't need to apply for a new key for captcha since the URL is not changing.

Changes proposed in this pull request:
* Add #contact_requests controller action to get recaptcha status
* Add widget that shows only for non-authenticated users
* Add specs



