### PR TITLE
make rights field nonrepeatable when creating or editing works

### DIFF
--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -116,3 +116,7 @@ div.home_share_work a.contribute.text-center {
 div.input-group-btn button.btn-primary:active {
   background-color: #e00122;
 }
+
+.form-control.select.rights {
+  max-width: 40em;
+}

--- a/app/forms/curation_concerns/work_form.rb
+++ b/app/forms/curation_concerns/work_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class WorkForm < Sufia::Forms::WorkForm
     self.model_class = ::Work
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,0 +1,8 @@
+<% license_service = CurationConcerns::LicenseService.new %>
+<%= f.input :rights, as: :select,
+    collection: license_service.select_active_options,
+    include_blank: true,
+    item_helper: license_service.method(:include_current_value),
+    input_html: { class: 'rights', multiple: false } %>
+
+<%= render "curation_concerns/file_sets/rights_modal" %>


### PR DESCRIPTION
Fixes #966  ; refs #966 

Present short summary (50 characters or less)

We need the rights attributes on works to be nonrepeatable.

Changes proposed in this pull request:
* override sufia default behavior for rights field (see work_form.rb)
* override sufia partial and change input type (see _rights.html.erb)
