### PR TITLE
Seed admin role and user for dev

### DIFF
--- a/config/role_map.yml
+++ b/config/role_map.yml
@@ -1,7 +1,8 @@
 development:
   archivist:
     - archivist1@example.com
-
+  admin:
+    - admin@example.com
 test:
   archivist:
     - archivist1@example.com

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,22 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+
+class AddInitialObjects < ActiveRecord::Migration
+
+  def self.create_admin_role(id)
+    admin = Role.create(name: "admin")
+    admin.users << User.find(id)
+    admin.save
+  end
+
+  def self.create_admin_account
+    rando_pass = Devise.friendly_token.first(8)
+    user = User.create email: 'admin@example.com', password: rando_pass
+    puts "\n\n\t\t*** ADMIN USER PASS: #{rando_pass} ***\n\n"
+    user.save
+    user.id
+  end
+
+  create_admin_role(create_admin_account)
+
+end


### PR DESCRIPTION
Fixes #959 

Seeds an admin role and user on rake db:reset/setup/etc. 

Changes proposed in this pull request:
* Add admin role and 'admin@example.com' account to config/role.yml (I think this enables the admin dashboard view)
* seed admin role and admin@example.com account on db:setup
* db:seed migration outputs rando password to shell on account generation

