### PR TITLE
Make new work visibility default to public

### DIFF
--- a/config/initializers/access_controls_visibility_monkey_patch.rb
+++ b/config/initializers/access_controls_visibility_monkey_patch.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Hydra::AccessControls
+  module Visibility
+    extend ActiveSupport::Concern
+
+    def visibility
+      if read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
+        AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      elsif read_groups.include? AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+        AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      else
+        AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #976 

Make the public option default on new work creation in the visibility widget.

The default visibility is set in Hydra Access Controls [here](https://github.com/projecthydra/hydra-head/blob/master/hydra-access-controls/app/models/concerns/hydra/access_controls/visibility.rb#L26). I added a monkey patch to set the default to public.

Changes proposed in this pull request:
* Add monkey patch to set default visibility to public on new work creation form

