### PR TITLE
Add search bar override with browse button

### DIFF
--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,10 @@
 <%= form_tag search_form_action, method: :get, id: "search-form-header", role: "search" do %>
   <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+ 
+  <div class="col-xs-4 col-sm-3 col-lg-2">
+    <%= link_to 'Browse', main_app.search_catalog_path, class: 'btn btn-primary nav-btn navbar-left' %>
+  </div>
+
   <div class="input-group">
 
     <label class="sr-only" for="search-field-header"><%= t("sufia.search.form.q.label") %></label>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_tag search_form_action, method: :get, id: "search-form-header", role: "search" do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <div class="input-group">
+
+    <label class="sr-only" for="search-field-header"><%= t("sufia.search.form.q.label") %></label>
+    <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("sufia.search.form.q.placeholder") %>
+
+    <div class="input-group-btn">
+      <button type="submit" class="btn btn-primary" id="search-submit-header">
+        <%= t('sufia.search.button.html') %>
+      </button>
+      <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+        <span data-search-element="label"><%= t("sufia.search.form.option.all.label_long") %></span>
+        <span class="caret"></span>
+      </button>
+
+      <ul class="dropdown-menu pull-right">
+        <li>
+          <%= link_to t("sufia.search.form.option.all.label_long"), "#",
+              data: { "search-option" => main_app.search_catalog_path, "search-label" => t("sufia.search.form.option.all.label_short") } %>
+        </li>
+
+        <% if current_user %>
+          <li>
+            <%= link_to t("sufia.search.form.option.my_works.label_long"), "#",
+                data: { "search-option" => sufia.dashboard_works_path, "search-label" => t("sufia.search.form.option.my_works.label_short") } %>
+          </li>
+          <li>
+            <%= link_to t("sufia.search.form.option.my_collections.label_long"), "#",
+                data: { "search-option" => sufia.dashboard_collections_path, "search-label" => t("sufia.search.form.option.my_collections.label_short") } %>
+          </li>
+          <li>
+            <%= link_to t("sufia.search.form.option.my_shares.label_long"), "#",
+                data: { "search-option" => sufia.dashboard_shares_path, "search-label" => t("sufia.search.form.option.my_shares.label_short") } %>
+          </li>
+        <% end %>
+
+      </ul>
+    </div><!-- /.input-group-btn -->
+
+  </div><!-- /.input-group -->
+<% end %>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -63,5 +63,10 @@ describe 'searching' do
         expect(page).not_to have_content("My Shares")
       end
     end
+
+    it "displays browse button" do
+      visit '/'
+      expect(page).to have_link("Browse", href: main_app.search_catalog_path)
+    end
   end
 end


### PR DESCRIPTION
Fixes #987 

Add browse button to search field group, pointing to catalog-view.

Changes proposed in this pull request:
* Add browse button
* Add feature test

<img width="1146" alt="screen shot 2016-11-16 at 1 42 18 pm" src="https://cloud.githubusercontent.com/assets/1069588/20360665/9c20f278-ac02-11e6-8862-9d537e336084.png">
---
<img width="1145" alt="screen shot 2016-11-16 at 1 42 33 pm" src="https://cloud.githubusercontent.com/assets/1069588/20360664/9c208734-ac02-11e6-9670-04101a328b79.png">

