### PR TITLE
DOI minting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,3 +140,7 @@ RSpec/LeadingSubject:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/features/*'
+    - 'spec/support/shared/*'
+
+RSpec/SubjectStub:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem 'flipflop', '2.3.0'
 gem 'hydra-role-management'
 gem 'orcid', github: 'uclibs/orcid'
 
+gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch: 'setting-status'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.7.1'
 # Use sqlite3 as the database for Active Record
@@ -67,6 +69,8 @@ gem 'devise'
 gem 'devise-guests', '~> 0.5'
 gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
 group :development, :test do
+  gem 'vcr'
+  gem 'webmock'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'rspec-activemodel-mocks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,15 @@ GIT
       rails (~> 4.0)
 
 GIT
+  remote: git://github.com/uclibs/hydra-remote_identifier.git
+  revision: bbc060d2d054fd31225321d385cfcfd8d6e5b253
+  branch: setting-status
+  specs:
+    hydra-remote_identifier (0.6.8)
+      activesupport (>= 3.2.13, < 5.0)
+      rest-client (~> 1.7.3)
+
+GIT
   remote: git://github.com/uclibs/orcid.git
   revision: 956ea6f02b8bf614e0a8425f79cb3f16b51ee99d
   specs:
@@ -223,6 +232,8 @@ GEM
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     curation_concerns (1.7.5)
       active-fedora (>= 10.3.0.rc1)
       active_attr
@@ -318,11 +329,11 @@ GEM
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
       railties (>= 3.0.0)
-    faraday (0.10.1)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.8.0)
       ruby-progressbar
-    ffi (1.9.17)
+    ffi (1.9.18)
     figaro (1.1.1)
       thor (~> 0.14)
     flipflop (2.3.0)
@@ -358,6 +369,7 @@ GEM
       tilt
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
+    hashdiff (0.3.2)
     hashie (3.4.6)
     highcharts-rails (5.0.7)
       railties (>= 3.1)
@@ -412,7 +424,7 @@ GEM
       blacklight
       bootstrap_form
       cancancan
-    hydra-works (0.15.0)
+    hydra-works (0.16.0)
       hydra-derivatives (~> 3.0)
       hydra-file_characterization (~> 0.3, >= 0.3.3)
       hydra-pcdm (>= 0.9)
@@ -445,6 +457,10 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    kaminari-actionview (1.0.1)
+      actionview
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     kaminari_route_prefix (0.0.2)
       kaminari (~> 0.16)
     ldp (0.6.4)
@@ -474,9 +490,7 @@ GEM
     mappy (0.1.0)
       activesupport
     memoist (0.15.0)
-    mime-types (3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types (2.99.3)
     mimemagic (0.3.2)
     mini_magick (4.6.1)
     mini_portile2 (2.1.0)
@@ -486,13 +500,14 @@ GEM
     multipart-post (2.0.0)
     nest (2.1.0)
       redic
+    netrc (0.11.0)
     noid (0.9.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     oauth (0.5.1)
-    oauth2 (1.3.0)
-      faraday (>= 0.8, < 0.11)
+    oauth2 (1.3.1)
+      faraday (>= 0.8, < 0.12)
       jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -603,6 +618,9 @@ GEM
       uber (< 0.2.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rest-client (1.7.3)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     retriable (3.0.1)
     rsolr (1.1.2)
       builder (>= 2.1.2)
@@ -645,6 +663,7 @@ GEM
       oauth2
     ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
+    safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -730,9 +749,10 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (3.1.2)
+    uglifier (3.1.3)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.3)
+    vcr (3.0.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -745,6 +765,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
@@ -772,6 +796,7 @@ DEPENDENCIES
   factory_girl_rails
   fcrepo_wrapper
   flipflop (= 2.3.0)
+  hydra-remote_identifier!
   hydra-role-management
   jbuilder (~> 2.0)
   jquery-rails
@@ -795,7 +820,9 @@ DEPENDENCIES
   sufia!
   turbolinks
   uglifier (>= 1.3.0)
+  vcr
   web-console (~> 2.0)
+  webmock
 
 BUNDLED WITH
    1.14.5

--- a/app/actors/curation_concerns/actors/article_actor.rb
+++ b/app/actors/curation_concerns/actors/article_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class ArticleActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/dataset_actor.rb
+++ b/app/actors/curation_concerns/actors/dataset_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class DatasetActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/document_actor.rb
+++ b/app/actors/curation_concerns/actors/document_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class DocumentActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/etd_actor.rb
+++ b/app/actors/curation_concerns/actors/etd_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class EtdActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/generic_work_actor.rb
+++ b/app/actors/curation_concerns/actors/generic_work_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class GenericWorkActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/image_actor.rb
+++ b/app/actors/curation_concerns/actors/image_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class ImageActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/student_work_actor.rb
+++ b/app/actors/curation_concerns/actors/student_work_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class StudentWorkActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/actors/curation_concerns/actors/video_actor.rb
+++ b/app/actors/curation_concerns/actors/video_actor.rb
@@ -4,6 +4,14 @@
 module CurationConcerns
   module Actors
     class VideoActor < CurationConcerns::Actors::BaseActor
+      private
+
+        def save
+          curation_concern.extend(RemotelyIdentifiedByDoi::MintingBehavior)
+          curation_concern.apply_doi_assignment_strategy do |*|
+            curation_concern.save
+          end
+        end
     end
   end
 end

--- a/app/assets/javascripts/toggle_publisher_requirement.js
+++ b/app/assets/javascripts/toggle_publisher_requirement.js
@@ -1,0 +1,89 @@
+var togglePublisherRequirement = function() {
+  // When the DOI form is changed
+  $('.set-doi').change(function() {
+    var target = $("div[class*='form-group'][class*='publisher']")
+    var label = target.children().filter("label");
+    var input = target.children().filter("ul").children().children().first();
+    var mint_doi_checked = $("#mint-doi").is(':checked');
+
+    function add_requirement_notice() {
+      var target = $('#mint-doi').siblings().first();
+      var notice = '<span id="publisher-label" class="label label-info">Please add a publisher on the Descriptions tab </span>';
+
+      function need_to_add_notice() {
+        var field = $('input[class*=publisher]').first();
+
+        // if the notice isn't there, and the publisher is blank, we need to add it
+        if ( ($('#publisher-warning').length == 0) && (field.val() == "") ) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      if (need_to_add_notice()) {
+        target.after(notice);
+      }
+    }
+
+    function add_and_remove_field(target) {
+      // add and remove a publisher field to trigger the save work requirements tracking
+      // if we want to stop doing this, we need to override the following:
+      // sufia/app/assets/javascripts/sufia/save_work/save_work_control.es6
+      // so that this.formChanged() gets called when the DOI form is updated
+
+      var field = $('input[class*=publisher]').last()
+
+      if (field.val() == "") {
+        //if publisher is blank - fill it, add the field, remove it, empty it
+        // fill it
+        field.val("Test");
+
+        // click add
+        target.children().filter("button").click();
+        // click remove
+        var new_field = $('input[class*=publisher]').last();
+        var button = new_field.next().children();
+        button.click();
+
+        // empty the field
+        field.val("");
+      } else {
+        // if publisher is not blank, add the field, remove it
+        // click add
+        target.children().filter("button").click();
+        // click remove
+        var new_field = $('input[class*=publisher]').last();
+        var button = new_field.next().children();
+        button.click();
+      }
+    }
+
+    if (mint_doi_checked) {
+      add_requirement_notice(target);
+
+      // If we want one, add the things
+      target.switchClass("optional", "required");
+      label.switchClass("optional", "required");
+      label.html("Publisher <span class='label label-info required-tag'>required</span>");
+      input.switchClass("optional", "required");
+      input.attr("required", "required");
+      input.attr("aria-required", "true");
+
+      add_and_remove_field(target);
+    } else {
+      // If we don't want one, remove the things
+      target.switchClass("optional", "required");
+      label.switchClass("optional", "required");
+      label.html("Publisher");
+      input.switchClass("optional", "required");
+      input.removeAttr("required");
+      input.removeAttr("aria-required");
+
+      // add and remove a publisher field to trigger the save work requirements tracking
+      add_and_remove_field(target);
+    }
+  });
+}
+
+$(document).on('turbolinks:load', togglePublisherRequirement)

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -150,3 +150,7 @@ div.profile a.btn-primary {
 .orcid-section {
   padding-top: 20px;
 }
+
+.icon-doi {
+  @extend .fa-link;
+}

--- a/app/forms/curation_concerns/article_form.rb
+++ b/app/forms/curation_concerns/article_form.rb
@@ -5,19 +5,34 @@ module CurationConcerns
   class ArticleForm < Sufia::Forms::WorkForm
     self.model_class = ::Article
 
-    self.terms += [:resource_type, :alternate_title, :journal_title, :issn, :time_period, :required_software, :note, :geo_subject]
-    self.terms -= [:keyword, :source]
-    self.required_fields = [:title, :creator, :description, :rights]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(resource_type alternate_title journal_title issn time_period required_software note geo_subject)
 
-    def secondary_terms
-      [:date_created, :alternate_title, :journal_title,
-       :issn, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title journal_title
+         issn subject geo_subject time_period
+         language bibliographic_citation
+         required_software note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/dataset_form.rb
+++ b/app/forms/curation_concerns/dataset_form.rb
@@ -4,24 +4,42 @@
 module CurationConcerns
   class DatasetForm < Sufia::Forms::WorkForm
     self.model_class = ::Dataset
-    self.terms += [:resource_type, :alternate_title, :time_period, :required_software, :note]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :required_software, :rights]
 
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(resource_type alternate_title time_period
+                     required_software note geo_subject)
+
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description required_software rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
+    end
+
+    ## Overriding secondary terms to establish custom field order
     def secondary_terms
-      [:date_created, :alternate_title, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :note]
+      %i(date_created alternate_title subject
+         geo_subject time_period language
+         bibliographic_citation
+         note)
     end
 
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super
       end
     end
 
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.model_attributes(_)
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -4,18 +4,36 @@
 module CurationConcerns
   class DocumentForm < Sufia::Forms::WorkForm
     self.model_class = ::Document
-    self.terms += [:resource_type, :alternate_title, :genre, :time_period, :required_software, :note]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :rights]
 
-    def secondary_terms
-      [:date_created, :alternate_title, :genre, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(resource_type alternate_title genre
+                     time_period required_software note geo_subject)
+
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title subject
+         geo_subject time_period language
+         bibliographic_citation required_software
+         note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -5,18 +5,36 @@ module CurationConcerns
   class EtdForm < Sufia::Forms::WorkForm
     self.model_class = ::Etd
 
-    self.terms += [:resource_type, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :advisor, :rights]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(resource_type alternate_title genre
+                     time_period required_software note
+                     degree advisor geo_subject)
 
-    def secondary_terms
-      [:degree, :date_created, :alternate_title, :genre, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description advisor rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(degree date_created alternate_title
+         genre subject geo_subject time_period
+         language bibliographic_citation required_software
+         note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -4,18 +4,36 @@
 module CurationConcerns
   class GenericWorkForm < Sufia::Forms::WorkForm
     self.model_class = ::GenericWork
-    self.terms += [:alternate_title, :time_period, :required_software, :note]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :rights]
 
-    def secondary_terms
-      [:date_created, :alternate_title, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(alternate_title time_period required_software
+                     note geo_subject)
+
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title
+         subject geo_subject time_period
+         language bibliographic_citation
+         required_software note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/image_form.rb
+++ b/app/forms/curation_concerns/image_form.rb
@@ -4,18 +4,36 @@
 module CurationConcerns
   class ImageForm < Sufia::Forms::WorkForm
     self.model_class = ::Image
-    self.terms += [:resource_type, :alternate_title, :genre, :time_period, :required_software, :note]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :rights]
 
-    def secondary_terms
-      [:date_created, :alternate_title, :genre, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(alternate_title genre time_period
+                     required_software note geo_subject)
+
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + [:publisher]
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title genre
+         subject geo_subject time_period
+         language bibliographic_citation
+         required_software note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/student_work_form.rb
+++ b/app/forms/curation_concerns/student_work_form.rb
@@ -5,18 +5,36 @@ module CurationConcerns
   class StudentWorkForm < Sufia::Forms::WorkForm
     self.model_class = ::StudentWork
 
-    self.terms += [:resource_type, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :advisor, :rights]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(alternate_title genre time_period
+                     required_software note degree
+                     advisor geo_subject)
 
-    def secondary_terms
-      [:degree, :date_created, :alternate_title, :genre, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description advisor rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + %i(degree publisher)
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title genre
+         subject geo_subject time_period
+         language bibliographic_citation
+         required_software note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/forms/curation_concerns/video_form.rb
+++ b/app/forms/curation_concerns/video_form.rb
@@ -5,18 +5,34 @@ module CurationConcerns
   class VideoForm < Sufia::Forms::WorkForm
     self.model_class = ::Video
 
-    self.terms += [:resource_type, :alternate_title, :time_period, :required_software, :note]
-    self.terms -= [:keyword, :source, :contributor]
-    self.required_fields = [:title, :creator, :description, :rights]
+    ## Adding custom descriptive metadata terms
+    self.terms += %i(resource_type alternate_title time_period
+                     required_software note geo_subject)
 
-    def secondary_terms
-      [:date_created, :alternate_title, :subject, :geo_subject,
-       :time_period, :language, :bibliographic_citation,
-       :required_software, :note]
+    ## Adding terms needed for the special DOI form tab
+    self.terms += %i(doi doi_assignment_strategy existing_identifier)
+
+    ## Removing terms that we don't use
+    self.terms -= %i(keyword source contributor)
+
+    ## Setting custom required fields
+    self.required_fields = %i(title creator description rights)
+
+    ## Adding above the fold on the form without making this required
+    def primary_terms
+      required_fields + %i(publisher)
     end
 
+    ## Overriding secondary terms to establish custom field order
+    def secondary_terms
+      %i(date_created alternate_title subject
+         geo_subject time_period language
+         bibliographic_citation required_software note)
+    end
+
+    ## Gymnastics to allow repeatble fields to behave as non-repeatable
     def self.multiple?(field)
-      if [:title, :description, :rights, :date_created].include? field.to_sym
+      if %i(title description rights date_created).include? field.to_sym
         false
       else
         super

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,6 +5,8 @@ class Article < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Article'
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/concerns/remotely_identified_by_doi.rb
+++ b/app/models/concerns/remotely_identified_by_doi.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+module RemotelyIdentifiedByDoi
+  NOT_NOW = 'not_now'
+  ALREADY_GOT_ONE = 'already_got_one'
+
+  # What does it mean to be remotely assignable; Exposing the attributes
+  module Attributes
+    extend ActiveSupport::Concern
+    included do
+      property :doi, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#managedDOI'), multiple: false do |index|
+        index.as :stored_searchable
+      end
+
+      property :identifier_url, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#doiManagementURI'), multiple: false
+      property :existing_identifier, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#unmanagedDOI'), multiple: false
+
+      validates :publisher, presence: { message: 'is required for remote DOI minting', if: :remote_doi_assignment_strategy? }
+
+      attr_accessor :doi_assignment_strategy
+      attr_writer :doi_remote_service
+
+      def doi_status
+        if visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+          "public"
+        elsif locally_managed_remote_identifier?
+          "unavailable"
+        else
+          "reserved"
+        end
+      end
+
+      def locally_managed_remote_identifier?
+        return true unless identifier_url.nil?
+        false
+      end
+
+      protected
+
+      def doi_remote_service
+        @doi_remote_service ||= Hydra::RemoteIdentifier.remote_service(:doi)
+      end
+
+      def remote_doi_assignment_strategy?
+        doi_assignment_strategy.to_s == doi_remote_service.accessor_name.to_s
+      end
+    end
+  end
+
+  module MintingBehavior
+    def apply_doi_assignment_strategy(&perform_persistence_block)
+      if respond_to?(:doi_assignment_strategy) && respond_to?(:identifier_url)
+        if identifier_url.nil?
+          perform_strategy(&perform_persistence_block)
+        else
+          yield(self) && identifier_request
+        end
+
+      else
+        yield(self)
+      end
+    end
+
+    private
+
+      def perform_strategy(&perform_persistence_block)
+        no_doi_assignment_strategy_given(&perform_persistence_block) ||
+          not_now(&perform_persistence_block) ||
+          update_identifier_locally(&perform_persistence_block) ||
+          request_remote_minting_for(&perform_persistence_block)
+      end
+
+      def request_remote_minting_for
+        return false unless remote_doi_assignment_strategy?
+        # Before we make a potentially expensive call
+        # hand off control back to the caller.
+        # I'm doing this because I want a chance to persist the object first
+        yield(self) && identifier_request
+      end
+
+      def identifier_request
+        doi_remote_service.mint(self)
+      end
+
+      def update_identifier_locally
+        return false unless doi_assignment_strategy == RemotelyIdentifiedByDoi::ALREADY_GOT_ONE
+        # I'm doing this because before I persist, I want to update the
+        # identifier
+        self.doi = existing_identifier
+        yield(self)
+      end
+
+      def no_doi_assignment_strategy_given
+        return false unless doi_assignment_strategy.blank?
+        yield(self)
+      end
+
+      def not_now
+        return false unless doi_assignment_strategy.to_s == RemotelyIdentifiedByDoi::NOT_NOW
+        yield(self)
+      end
+  end
+end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -5,6 +5,8 @@ class Dataset < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Dataset'
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,6 +5,8 @@ class Document < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Document'
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -5,6 +5,8 @@ class Etd < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Etd'
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -5,7 +5,10 @@ class GenericWork < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Generic Work'
+
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -5,7 +5,10 @@ class Image < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Image'
+
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -70,10 +70,11 @@ class SolrDocument
   end
 
   # Added for Document and Image work types
-
   def genre
     self[Solrizer.solr_name('genre')]
   end
 
-  # Added for Image work type
+  def doi
+    self[Solrizer.solr_name('doi')]
+  end
 end

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -6,6 +6,8 @@ class StudentWork < ActiveFedora::Base
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
   self.human_readable_type = 'Student Work'
+  include RemotelyIdentifiedByDoi::Attributes
+
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -5,7 +5,10 @@ class Video < ActiveFedora::Base
   include ::CurationConcerns::WorkBehavior
   include ::CurationConcerns::BasicMetadata
   include Sufia::WorkBehavior
+  include RemotelyIdentifiedByDoi::Attributes
+
   self.human_readable_type = 'Video'
+
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/presenters/article_presenter.rb
+++ b/app/presenters/article_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ArticlePresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :journal_title, :issn, :time_period, :required_software, :note, :geo_subject, to: :solr_document
+  delegate :alternate_title, :journal_title, :issn, :time_period, :required_software, :note, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/dataset_presenter.rb
+++ b/app/presenters/dataset_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class DatasetPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class DocumentPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class EtdPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class GenericWorkPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ImagePresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, to: :solr_document
+  delegate :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, :doi, to: :solr_document
 end

--- a/app/presenters/student_work_presenter.rb
+++ b/app/presenters/student_work_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class StudentWorkPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/video_presenter.rb
+++ b/app/presenters/video_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class VideoPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, to: :solr_document
+  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/views/curation_concerns/base/_doi.html.erb
+++ b/app/views/curation_concerns/base/_doi.html.erb
@@ -1,0 +1,10 @@
+<h2>DOI</h2>
+
+<p>
+  <%- remote_service = Hydra::RemoteIdentifier.remote_service(:doi) -%>
+  <strong><%= link_to presenter.doi.first, remote_service.remote_uri_for(presenter.doi.first).to_s %></strong>
+</p>
+
+<p>
+  This <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> link is the best way for others to cite your work.
+</p>

--- a/app/views/curation_concerns/base/_form_doi.html.erb
+++ b/app/views/curation_concerns/base/_form_doi.html.erb
@@ -1,0 +1,65 @@
+<%- remote_service = Hydra::RemoteIdentifier.remote_service(:doi) -%>
+    <%- if curation_concern.doi.present? -%>
+      <div class="form-group doi">
+        <h2>DOI</h2>
+
+        <p>
+          This work has a <abbr title="Digital Object Identifier">DOI</abbr>.
+        </p>
+
+        <p>
+          <strong><%= link_to curation_concern.doi, remote_service.remote_uri_for(curation_concern.doi).to_s %></strong>
+        </p>
+
+        <p>
+          This <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> link is the best way for others to cite your work.
+        </p>
+      </div>
+
+    <%- else -%>
+
+      <div class="form-group set-doi">
+        <h2>Assign a DOI</h2>
+
+        <p>
+          A <abbr title="Digital Object Identifier" data-placement="right">DOI</abbr> is a permanent link to your work.
+          It&rsquo;s an easy way for other people to cite your work.
+        </p>
+
+        <p>
+          Want more information on <abbr title="Digital Object Identifier">DOI</abbr>s?
+          Here&rsquo;s a <a href="http://simple.wikipedia.org/wiki/Doi" target="_blank">brief summary</a> and the <a href="http://www.doi.org/faq.html" target="_blank">DOI FAQ</a>.
+        </p>
+
+        <div class="control-group">
+
+          <%- if remote_service.registered?(curation_concern) -%>
+            <label class="radio">
+              <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" id="mint-doi" value="<%= remote_service.accessor_name %>" <% if curation_concern.doi_assignment_strategy == remote_service.accessor_name.to_s %> checked="true"<% end %> />
+              <span class="label-text">
+                Yes, I would like to create a <abbr title="Digital Object Identifier">DOI</abbr> for this <%= curation_concern.human_readable_type %>.
+              </span>
+            </label>
+          <%- end -%>
+
+          <label class="radio">
+            <input type="radio" name="<%= f.object_name %>[doi_assignment_strategy]" id="no-doi" value="<%= RemotelyIdentifiedByDoi::ALREADY_GOT_ONE %>" <% if curation_concern.doi_assignment_strategy == RemotelyIdentifiedByDoi::ALREADY_GOT_ONE %> checked="true"<% end %> />
+            <span class="label-text">
+              Yes, I already have one that I want to use: <%= render_edit_field_partial(:existing_identifier, f: f) %>
+            </span>
+          </label>
+
+          <label class="radio">
+            <input type="radio" checked name="<%= f.object_name %>[doi_assignment_strategy]" id="not-now" value="<%= RemotelyIdentifiedByDoi::NOT_NOW %>" <% if curation_concern.doi_assignment_strategy == RemotelyIdentifiedByDoi::NOT_NOW %> checked="true"<% end %> />
+            <span class="label-text">
+              Not now&hellip;<em>but maybe later.</em>
+            </span>
+          </label>
+
+          <p>
+            The <em>Publisher</em> field must be set if you request a DOI.
+          </p>
+
+        </div>
+      </div>
+    <%- end -%>

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% # we will yield to content_for for each tab, e.g. :files_tab %>
-<% tabs ||= %w[metadata files relationships share] # default tab order %>
+<% tabs ||= %w[metadata doi files relationships share] # default tab order %>
 <div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
 

--- a/app/views/curation_concerns/base/show.html.erb
+++ b/app/views/curation_concerns/base/show.html.erb
@@ -1,0 +1,30 @@
+<% provide :page_title, @presenter.page_title %>
+<div itemscope itemtype="http://schema.org/CreativeWork" class="row">
+  <div class="col-xs-12">
+    <header>
+      <%= render 'work_title', presenter: @presenter %>
+    </header>
+  </div>
+  <div class="col-sm-8">
+    <%= render 'work_description', presenter: @presenter %>
+    <%= render 'relationships', presenter: @presenter %>
+    <%= render 'doi', presenter: @presenter unless @presenter.doi.nil? %>
+    <%= render 'metadata', presenter: @presenter %>
+  </div>
+  <div class="col-sm-4">
+    <%= render "show_actions", presenter: @presenter %>
+    Last modified: <%= @presenter.date_modified %>
+    <%= render 'representative_media', presenter: @presenter %>
+    <%= render 'social_media' %>
+    <%= render 'citations', presenter: @presenter %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-12">
+    <%= render 'items', presenter: @presenter %>
+    <%# TODO: we may consider adding these partials in the future %>
+    <%#= render 'sharing_with', presenter: @presenter %>
+    <%#= render 'user_activity', presenter: @presenter %>
+  </div>
+</div>

--- a/app/views/records/edit_fields/_existing_identifier.html.erb
+++ b/app/views/records/edit_fields/_existing_identifier.html.erb
@@ -1,0 +1,3 @@
+<%= f.input key,
+  label: false
+%>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module ScholarUc
     config.active_record.raise_in_transactional_callbacks = true
 
     config.exceptions_app = self.routes
+
+    config.application_root_url = 'http://localhost:3000'
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/config/initializers/hydra_remote_identifier_config.rb
+++ b/config/initializers/hydra_remote_identifier_config.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# Register and configure remote identifiers for persisted objects
+Hydra::RemoteIdentifier.configure do |config|
+  doi_credentials = Psych.load_file(Rails.root.join("config/doi.yml").to_s).fetch(Rails.env)
+  config.remote_service(:doi, doi_credentials) do |doi|
+    doi.register(Article, Dataset, Document, Etd, Image, GenericWork, StudentWork, Video) do |map|
+      map.target { |obj| Scholar.permanent_url_for(obj) }
+      map.status :doi_status
+      map.creator :creator
+      map.title :title
+      map.publisher { |o| Array(o.publisher).join("; ") }
+      map.publicationyear { |o| o.date_uploaded.year }
+      map.identifier_url :identifier_url
+      # Make sure that this method both sets the identifier and persists the change!
+      map.set_identifier do |o, value|
+        o.doi = value.fetch(:identifier)
+        o.identifier_url = value.fetch(:identifier_url)
+        o.save
+      end
+    end
+  end
+end

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -17,8 +17,10 @@ en:
     works:
       new:
         after_create_html: "Any uploaded files are being processed by %{application_name} in the background. The metadata and access controls you specified are being applied. Files will be marked <span class=\"label label-danger\" title=\"Private\">Private</span> until this process is complete (shouldn't take too long, hang in there!). You may need to refresh this page to see these updates."
+      edit:
+        tab:
+          doi: "DOI"
     brought_to_you_by_html:  "Brought to you by the <a href=\"http://libraries.uc.edu/\">University of Cincinnati Libraries</a> and <a href=\"http://ucit.uc.edu/\">UC Information Technologies</a>."
     made_possible_by_html: "Made possible by the <a href=\"http://projecthydra.org\">Hydra</a> project."
     terms_of_use_html: "<a class=\"a\" href=\"/terms\">Terms of Use</a>"
     non_discrimination_notice_html: "<a href=\"http://uc.edu/about/policies/non-discrimination.html\">Notice of Non-Discrimination</a>"
- 

--- a/lib/scholar.rb
+++ b/lib/scholar.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Scholar
+  delegate :application_root_url, to: :configuration
+
+  def self.permanent_url_for(object)
+    File.join(Rails.configuration.application_root_url, 'show', object.id)
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :article, aliases: [:private_article], class: 'Article' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_article do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_article do
+      read_groups ["registered"]
+    end
+
+    factory :article_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/datasets.rb
+++ b/spec/factories/datasets.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :dataset, aliases: [:private_dataset], class: 'Dataset' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_dataset do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_dataset do
+      read_groups ["registered"]
+    end
+
+    factory :dataset_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :document, aliases: [:private_document], class: 'Document' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_document do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_document do
+      read_groups ["registered"]
+    end
+
+    factory :document_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :etd, aliases: [:private_etd], class: 'Etd' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_etd do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_etd do
+      read_groups ["registered"]
+    end
+
+    factory :etd_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # taken from sufia 7.1
 FactoryGirl.define do
-  factory :work, aliases: [:generic_work, :private_generic_work], class: 'GenericWork' do
+  factory :generic_work, aliases: [:work, :private_generic_work], class: 'GenericWork' do
     transient do
       user { FactoryGirl.create(:user) }
     end
@@ -21,7 +21,7 @@ FactoryGirl.define do
       read_groups ["registered"]
     end
 
-    factory :work_with_one_file do
+    factory :generic_work_with_one_file do
       before(:create) do |work, evaluator|
         work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
       end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :image, aliases: [:private_image], class: 'Image' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_image do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_image do
+      read_groups ["registered"]
+    end
+
+    factory :image_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/student_works.rb
+++ b/spec/factories/student_works.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :student_work, aliases: [:private_student_work], class: 'StudentWork' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_student_work do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_student_work do
+      read_groups ["registered"]
+    end
+
+    factory :student_work_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :video, aliases: [:private_video], class: 'Video' do
+    transient do
+      user { FactoryGirl.create(:user) }
+    end
+
+    title ["Test title"]
+    visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+
+    after(:build) do |work, evaluator|
+      work.apply_depositor_metadata(evaluator.user.user_key)
+    end
+
+    factory :public_video do
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+
+    factory :registered_video do
+      read_groups ["registered"]
+    end
+
+    factory :video_with_one_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+      end
+    end
+  end
+end

--- a/spec/features/doi_request_spec.rb
+++ b/spec/features/doi_request_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+feature 'DOIs', type: :feature, js: true do
+  it_behaves_like 'doi request', GenericWork
+  it_behaves_like 'doi request', Article
+  it_behaves_like 'doi request', Image
+  it_behaves_like 'doi request', Document
+  it_behaves_like 'doi request', Dataset
+  it_behaves_like 'doi request', Video
+  it_behaves_like 'doi request', Etd
+  it_behaves_like 'doi request', StudentWork
+end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 shared_examples 'edit work' do |work_class|
+  let(:user) { FactoryGirl.create(:user) }
   let(:work) { FactoryGirl.build(:work, user: user) }
   let(:work_type) { work_class.name.underscore }
   let(:edit_path) { "concern/#{work_type}s/#{work.id}/edit" }
@@ -25,6 +26,5 @@ shared_examples 'edit work' do |work_class|
 end
 
 feature 'Editing a work', type: :feature do
-  let(:user) { FactoryGirl.create(:user) }
   it_behaves_like 'edit work', GenericWork
 end

--- a/spec/features/permalinks_spec.rb
+++ b/spec/features/permalinks_spec.rb
@@ -8,7 +8,7 @@ describe 'permalinks' do
 
   describe 'concerns' do
     let(:work_type) { "generic_work" }
-    let(:work) { create(:work_with_one_file, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"], user: user) }
+    let(:work) { create(:generic_work_with_one_file, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"], user: user) }
     let(:user) { create(:user) }
     let(:work_path) { "/concern/#{work_type}s/#{work.id}" }
     let(:file_path) { "/concern/parent/#{work.id}/file_sets/#{work.file_sets.first.id}" }

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 shared_examples 'submission form with form#fileupload' do |work_class|
   let(:work_type) { work_class.name.underscore }
-  let(:work) { create(:work_with_one_file, title: ["Magnificent splendor"], source: ["The Internet"], user: user) }
+  let(:work) { create("#{work_type}_with_one_file".to_sym, title: ["Magnificent splendor"], source: ["The Internet"], based_near: ["USA"], user: user) }
   let(:user) { create(:user) }
   let(:work_path) { "/concern/#{work_type}s/#{work.id}" }
 

--- a/spec/fixtures/vcr_cassettes/remotely_identified_doi_mint_work.yml
+++ b/spec/fixtures/vcr_cassettes/remotely_identified_doi_mint_work.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ezid.cdlib.org/shoulder/doi:10.5072/FK2
+    body:
+      encoding: UTF-8
+      string: |-
+        _target: http://localhost/show/3t94g081v
+        datacite.creator: John Doe
+        datacite.title: A Title
+        datacite.publisher: An Interesting Chap!
+        datacite.publicationyear: 2013
+    headers:
+      Accept:
+      - '*/*; q=0.5, application/xml'
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '183'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Tue, 05 Nov 2013 21:27:49 GMT
+      Server:
+      - Apache/2.2.17 (Unix) DAV/2 mod_wsgi/3.3 Python/2.7 mod_ssl/2.2.17 OpenSSL/0.9.8o
+      Vary:
+      - Cookie
+      Set-Cookie:
+      - sessionid=c6a6f7211ad23050d4e16a195f43b201; Path=/ezid/
+      Content-Length:
+      - '53'
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: 'success: doi:10.5072/FK2HX1QVR | ark:/b5072/fk2hx1qvr'
+    http_version: 
+  recorded_at: Tue, 05 Nov 2013 21:27:52 GMT
+recorded_with: VCR 2.8.0

--- a/spec/forms/curation_concerns/article_form_spec.rb
+++ b/spec/forms/curation_concerns/article_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::ArticleForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/dataset_form_spec.rb
+++ b/spec/forms/curation_concerns/dataset_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::DatasetForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :required_software, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :required_software, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/document_form_spec.rb
+++ b/spec/forms/curation_concerns/document_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::DocumentForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/etd_form_spec.rb
+++ b/spec/forms/curation_concerns/etd_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::EtdForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::GenericWorkForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/image_form_spec.rb
+++ b/spec/forms/curation_concerns/image_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::ImageForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/student_work_form_spec.rb
+++ b/spec/forms/curation_concerns/student_work_form_spec.rb
@@ -14,14 +14,14 @@ describe CurationConcerns::StudentWorkForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights, :degree, :publisher] }
   end
 
   describe "#secondary_terms" do
     subject { form.secondary_terms }
     it do
-      is_expected.to include(:date_created, :alternate_title, :degree,
-                             :subject, :geo_subject,
+      is_expected.to include(:date_created, :alternate_title,
+                             :genre, :subject, :geo_subject,
                              :time_period, :language, :bibliographic_citation,
                              :required_software, :note)
     end

--- a/spec/forms/curation_concerns/video_form_spec.rb
+++ b/spec/forms/curation_concerns/video_form_spec.rb
@@ -14,7 +14,7 @@ describe CurationConcerns::VideoForm do
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/lib/scholar_spec.rb
+++ b/spec/lib/scholar_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Scholar do
+  let(:curation_concern) { double(id: "abc123") }
+
+  context '#permanent_url_for' do
+    it {
+      expect(described_class.permanent_url_for(curation_concern)).to eq(File.join(Rails.configuration.application_root_url, "/show/#{curation_concern.id}"))
+    }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -104,4 +104,6 @@ describe Article do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -102,4 +102,6 @@ describe Dataset do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -102,4 +102,6 @@ describe Document do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -104,4 +104,6 @@ describe Etd do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -102,4 +102,6 @@ describe GenericWork do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -102,4 +102,6 @@ describe Image do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -104,4 +104,6 @@ describe StudentWork do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -102,4 +102,6 @@ describe Video do
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
   end
+
+  it_behaves_like 'is remotely identifiable by doi'
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ require 'capybara/poltergeist'
 require 'support/features'
 include Warden::Test::Helpers
 
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+
 Capybara.register_driver :poltergeist do |app|
   Capybara::Poltergeist::Driver.new(app, timeout: 180)
 end
@@ -126,4 +128,11 @@ RSpec.configure do |config|
       page.driver.resize_window_to(handle, 2000, 2000)
     end
   end
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+  c.allow_http_connections_when_no_cassette = true
 end

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+shared_examples 'doi request' do |work_class|
+  let(:user) { create(:user) }
+  let(:work_without_doi) do
+    create("#{work_class.to_s.underscore}_with_one_file".to_sym,
+           title: ["Magnificent splendor"],
+           source: ["The Internet"],
+           based_near: ["USA"],
+           visibility: "open",
+           user: user)
+  end
+
+  let(:work_with_doi) do
+    create("#{work_class.to_s.underscore}_with_one_file".to_sym,
+           title: ["Magnificent splendor"],
+           source: ["The Internet"],
+           based_near: ["USA"],
+           doi: "doi:1234foo",
+           visibility: "open",
+           user: user)
+  end
+
+  let(:work_label) { work_class.name.underscore }
+  let(:work_text) { work_class.name.titlecase }
+
+  before do
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
+  context 'creating a work' do
+    before do
+      login_as user
+      visit new_polymorphic_path(work_class)
+    end
+
+    it 'displays the request option in the work edit form' do
+      click_link "DOI" # switch tab
+      expect(page).to have_content "Yes, I would like to create a DOI for this #{work_text}."
+      expect(page).to have_content "Not now…but maybe later."
+    end
+
+    it 'mints a DOI for the work' do
+      click_link "DOI" # switch tab
+      choose('mint-doi')
+      click_link "Files" # switch tab
+      attach_file("files[]", Rails.root + "spec/fixtures/world.png", visible: false)
+      click_link "Metadata" # switch tab
+      fill_in('Title', with: 'My Test Work')
+      creator_element = find(:css, "input.#{work_label}_creator")
+      creator_element.set("Test User")
+      description_element = find_by_id("#{work_label}_description")
+      description_element.set("Test description")
+      fill_in('Required Software', with: "database thingy") if work_class == Dataset
+      fill_in('Adviso', with: "Advisor Name") if [Etd, StudentWork].include?(work_class)
+      select 'Attribution-ShareAlike 4.0 International', from: "#{work_label}_rights"
+      fill_in('Publisher', with: 'tests')
+      choose("#{work_label}_visibility_open")
+      check('agreement')
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content('doi:10.5072/FK2')
+    end
+  end
+
+  context 'viewing a work' do
+    context 'without setting a doi' do
+      before { visit polymorphic_path(work_without_doi) }
+
+      it 'does not display the DOI partial on the show page' do
+        expect(page).to have_no_content("DOI")
+      end
+    end
+
+    context 'setting a doi' do
+      before { visit polymorphic_path(work_with_doi) }
+
+      it 'displays the DOI partial on the show page' do
+        expect(page).to have_css("h2", text: "DOI")
+        expect(page).to have_content(work_with_doi.doi)
+      end
+    end
+  end
+
+  context 'editing a work' do
+    context 'without a doi' do
+      before do
+        login_as user
+        visit edit_polymorphic_path(work_without_doi)
+      end
+
+      it 'displays the request option in the work edit form' do
+        click_link "DOI" # switch tab
+        expect(page).to have_content("Yes, I would like to create a DOI for this #{work_text}")
+      end
+    end
+
+    context 'with a doi' do
+      before do
+        login_as user
+        visit edit_polymorphic_path(work_with_doi)
+      end
+
+      it 'displays the DOI in the work edit form' do
+        click_link "DOI" # switch tab
+        expect(page).to have_content(work_with_doi.doi)
+      end
+    end
+  end
+
+  it "displays a warning label if you haven't set a publisher", js: true do
+    login_as user
+    visit new_polymorphic_path(work_class)
+    click_link "DOI" # switch tab
+    choose('mint-doi')
+
+    expect(page).to have_css("#publisher-label")
+  end
+
+  it "doesn't display a warning label if you have set a publisher", js: true do
+    login_as user
+    visit new_polymorphic_path(work_class)
+    fill_in('Publisher', with: 'tests')
+    click_link "DOI" # switch tab
+    choose('mint-doi')
+
+    expect(page).to have_no_css("#publisher-label")
+  end
+end

--- a/spec/support/shared/is_remotely_identifiable_by_doi.rb
+++ b/spec/support/shared/is_remotely_identifiable_by_doi.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+shared_examples 'is remotely identifiable by doi' do
+  describe '#locally_managed_remote_identifier?' do
+    let(:work) { FactoryGirl.build(described_class.to_s.underscore.to_sym) }
+
+    context 'when #identifier_url is set' do
+      before { work.stub(:identifier_url).and_return("http://example.org") }
+      it 'is true' do
+        expect(work.locally_managed_remote_identifier?).to eq(true)
+      end
+    end
+
+    context 'when #identifier_url is not set' do
+      before { work.stub(:identifier_url).and_return(nil) }
+      it 'is false' do
+        expect(work.locally_managed_remote_identifier?).to eq(false)
+      end
+    end
+  end
+
+  describe '#doi_status' do
+    let(:work) { FactoryGirl.build(described_class.to_s.underscore.to_sym) }
+
+    context 'when the work is public' do
+      before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
+        it 'is "public"' do
+          expect(work.doi_status).to eq("public")
+        end
+      end
+
+      context 'and a DOI has not already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
+        it 'is "public"' do
+          expect(work.doi_status).to eq("public")
+        end
+      end
+    end
+
+    context 'when the work is embargoed' do
+      before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) }
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
+        it 'is "unavailable"' do
+          expect(work.doi_status).to eq("unavailable")
+        end
+      end
+
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
+        it 'is "reserved"' do
+          expect(work.doi_status).to eq("reserved")
+        end
+      end
+    end
+
+    context 'when the work is authenticated' do
+      before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
+        it 'is "unavailable"' do
+          expect(work.doi_status).to eq("unavailable")
+        end
+      end
+
+      context 'and a DOI has not already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
+        it 'is "reserved"' do
+          expect(work.doi_status).to eq("reserved")
+        end
+      end
+    end
+
+    context 'when the work is restricted' do
+      before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
+        it 'is "unavailable"' do
+          expect(work.doi_status).to eq("unavailable")
+        end
+      end
+
+      context 'and a DOI has already been minted' do
+        before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
+        it 'is "reserved"' do
+          expect(work.doi_status).to eq("reserved")
+        end
+      end
+    end
+  end
+
+  context "doi minting" do
+    subject { described_class.new }
+
+    it { should respond_to(:doi) }
+    it { should respond_to(:doi=) }
+    it { should respond_to(:existing_identifier) }
+    it { should respond_to(:existing_identifier=) }
+    it { should respond_to(:doi_assignment_strategy=) }
+    it { should respond_to(:doi_assignment_strategy) }
+    it { should respond_to(:identifier_url) }
+    it { should respond_to(:identifier_url=) }
+
+    context 'with valid attributes' do
+      let(:attributes) {
+        {
+          publisher: ['An Interesting Chap!'],
+          id: "3t94g081v",
+          date_uploaded: Date.parse('2013-01-30'),
+          date_modified: Date.parse('2013-01-30'),
+          title: ["A Title"]
+        }
+      }
+
+      it 'mints!' do
+        work = build(:work, attributes: attributes)
+        work.stub(:save).and_return(true)
+        VCR.use_cassette "remotely_identified_doi_mint_work" do
+          expect {
+            Hydra::RemoteIdentifier.mint(:doi, work)
+          }.to change(work, :doi).from(nil)
+        end
+      end
+    end
+
+    context 'with invalid attributes' do
+      subject { build(:work, attributes: attributes) }
+      let(:attributes) { { publisher: [] } }
+      it 'fails validation' do
+        expect(subject).to receive(:remote_doi_assignment_strategy?).and_return(true)
+        expect(subject).not_to be_valid
+        expect(subject.errors[:publisher]).to eq(["is required for remote DOI minting"])
+      end
+    end
+
+    describe 'MintingBehavior' do
+      shared_examples 'minting behavior returning value' do
+        it 'returns the returning value' do
+          expect(subject.apply_doi_assignment_strategy(&perform_persistence_block)).to eq(returning_value)
+        end
+      end
+      subject { described_class.new.tap { |m| m.extend RemotelyIdentifiedByDoi::MintingBehavior } }
+      let(:returning_value) { true }
+      let(:perform_persistence_block) { ->(*) { returning_value } }
+
+      context 'with indentifier_url attribute set' do
+        let(:identifier_request) { double }
+        before do
+          subject.stub(:identifier_url) { 'http://example.org' }
+        end
+
+        it 'calls #identifier_request' do
+          expect(subject).to receive(:identifier_request)
+          subject.apply_doi_assignment_strategy(&perform_persistence_block)
+        end
+      end
+
+      context 'with doi_assignment_strategy accessor' do
+        let(:doi_assignment_strategy) { nil }
+
+        context '#apply_doi_assignment_strategy' do
+          let(:accessor_name) { 'mint_doi' }
+          let(:existing_identifier) { 'abc' }
+          let(:doi_remote_service) { double(accessor_name: accessor_name) }
+          before do
+            subject.existing_identifier = existing_identifier
+            subject.doi_assignment_strategy = doi_assignment_strategy
+            subject.doi_remote_service = doi_remote_service
+          end
+
+          context 'with explicit identifier specified' do
+            it_behaves_like 'minting behavior returning value'
+
+            let(:doi_assignment_strategy) { 'already_got_one' }
+            it 'allows explicit assignment of doi' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.to change(subject, :doi).from(nil).to(existing_identifier)
+            end
+
+            it 'yields the subject' do
+              expect { |b| subject.apply_doi_assignment_strategy(&b) }.to yield_with_args(subject)
+            end
+
+            it 'does not set doi attribute' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.not_to change(subject, :identifier_url)
+            end
+          end
+
+          context 'with not now specified' do
+            it_behaves_like 'minting behavior returning value'
+
+            let(:doi_assignment_strategy) { 'not_now' }
+
+            it 'returns the returning value' do
+              expect(subject.apply_doi_assignment_strategy(&perform_persistence_block)).to eq(returning_value)
+            end
+
+            it 'does not update doi' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.not_to change(subject, :doi).from(nil)
+            end
+
+            it 'yields the subject' do
+              expect { |b| subject.apply_doi_assignment_strategy(&b) }.to yield_with_args(subject)
+            end
+
+            it 'does not set identifier_url attribute' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.not_to change(subject, :identifier_url)
+            end
+          end
+
+          context 'with request for minting' do
+            let(:doi_assignment_strategy) { accessor_name }
+            context 'with valid save' do
+              before do
+                doi_remote_service.should_receive(:mint).with(subject).and_return(true)
+              end
+              it_behaves_like 'minting behavior returning value'
+              let(:returning_value) { true }
+              it 'requests a minting' do
+                expect {
+                  subject.apply_doi_assignment_strategy(&perform_persistence_block)
+                }.not_to change(subject, :doi).from(nil)
+              end
+              ## These specs are odd - the real spec is the before block above
+              it 'sets identifier_url attribute' do
+                expect {
+                  subject.apply_doi_assignment_strategy(&perform_persistence_block)
+                }.not_to change(subject, :identifier_url)
+              end
+            end
+
+            context 'with invalid save' do
+              it_behaves_like 'minting behavior returning value'
+              let(:returning_value) { false }
+              it 'does not request a minting if the perform_persistence_block failed' do
+                expect {
+                  subject.apply_doi_assignment_strategy(&perform_persistence_block)
+                }.not_to change(subject, :doi).from(nil)
+              end
+              it 'does not set identifier_url attribute' do
+                expect {
+                  subject.apply_doi_assignment_strategy(&perform_persistence_block)
+                }.not_to change(subject, :identifier_url)
+              end
+            end
+          end
+        end
+
+        context 'without doi_assignment_strategy accessor' do
+          it_behaves_like 'minting behavior returning value'
+
+          it 'yields the subject' do
+            expect { |b| subject.apply_doi_assignment_strategy(&b) }.to yield_with_args(subject)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #877 

Ports work from Curate to implement DOI minting.

* Major model additions implemented via the `concerns` pattern, to ease the addition to future works.
* Major model tests are implemented via `shared examples`, to ease addition of multiple work types.

