### PR TITLE
Add virus scanning capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+#gem 'clamav'
+
 group :development, :test do
   gem 'brakeman', :require => false
 end

--- a/app/controllers/curation_concerns/works_controller.rb
+++ b/app/controllers/curation_concerns/works_controller.rb
@@ -15,5 +15,37 @@ module CurationConcerns
       super
       curation_concern.read_groups = ["public"]
     end
+
+    def create
+      super
+    rescue ActiveFedora::RecordInvalid # virus detected
+      remove_infected_file_sets
+      report_virus_found
+      redirect_to main_app.curation_concerns_work_path(id: curation_concern.id)
+    end
+
+    def update
+      super
+    rescue ActiveFedora::RecordInvalid # virus detected
+      remove_infected_file_sets
+      report_virus_found
+      redirect_to main_app.curation_concerns_work_path(id: curation_concern.id)
+    end
+
+    private
+
+      def remove_infected_file_sets
+        curation_concern.reload
+        curation_concern.file_sets.each do |file_set|
+          file_set.destroy if file_set.files.blank?
+        end
+      end
+
+      def report_virus_found
+        logger.warn "File discarded from work #{curation_concern.id} because a virus was detected"
+        flash[:error] = "A virus was detected in a file you uploaded. "\
+                        "No new files were attached to your work. "\
+                        "Please review your files and re-attach"
+      end
   end
 end

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-ClamAV.instance.loaddb if defined? ClamAV
+ClamAV.instance.loaddb if Rails.env.production?

--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'New work with an infected file', js: true do
+  let(:user) { FactoryGirl.create(:user) }
+  before do
+    allow(CharacterizeJob).to receive(:perform_later)
+    allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
+    login_as user
+    visit new_curation_concerns_work_path
+  end
+
+  it 'creates the work and drops the files' do
+    click_link "Files" # switch tab
+    expect(page).to have_content "Add files"
+    attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
+    click_link "Description" # switch tab
+    fill_in('Title', with: 'My Infected Work')
+    fill_in('Creator', with: 'Test User')
+    fill_in('Keyword', with: 'tests')
+    select 'Attribution-ShareAlike 3.0 United States', from: 'work_rights'
+    choose('work_visibility_open')
+    check('agreement')
+    click_on('Save')
+    expect(page).to have_content('My Infected Work')
+    expect(page).to have_content('A virus was detected in a file you uploaded.')
+  end
+end


### PR DESCRIPTION
Fixes #952 

The clamav gem is commented out in this commit because we don't want virus scanning turned on in our development environments.  We can use Bamboo to uncomment the gem when we deploy.

To test this in your local environment:
1. Download a file that that contains a virus test string (found here: https://www.eicar.org/download/eicar.com.txt)
1. Log in and create a work with the virus text file attached.  Scholar should allow the virus file to be uploaded because virus scanning is disabled.
1. Quit the app
1. Enable virus scanning:
    1. Edit the Gemfile and uncomment the clamav gem and save
    1. Edit config/initializers/clamav.rb and remove `if Rails.env.production?` and save
1. bundle install
1. start the app
1. Log in and create a work with the virus text file attached.  Scholar should create the work, but drop all files and flash a message that a virus was detected.