### PR TITLE
Auto-populate creator field and switch names for proxy

### DIFF
--- a/app/assets/javascripts/set_creators.js
+++ b/app/assets/javascripts/set_creators.js
@@ -1,0 +1,88 @@
+/*
+This javascript sets the creator when a new work is created.
+
+Initially creator is set to the current user, then if the user
+chooses to submit on behalf of another user, the creator field
+is updated to switch to that user.
+*/
+
+var setCurrentUserAsCreator = function() {
+  // if the creator field is present...
+  if( $('input[id$=_creator]').length ) {
+    // and it's not collection_creator
+    if( $('input[id$=collection_creator]').length == 0) {
+      // read the current user's name from the data attribute
+      var creator = document.querySelector('#current_user').dataset.name;
+
+      // set the current user's name as the first creator
+      $('input[id$=_creator]').first().val(creator);
+    }
+  }
+}
+
+var setProxySelectionAsCreator = function() {
+  // function to check if element is visible
+  function isElementInViewport (el) {
+
+    //special bonus for those using jQuery
+    if (typeof jQuery === "function" && el instanceof jQuery) {
+        el = el[0];
+    }
+
+    var rect = el.getBoundingClientRect();
+
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
+    );
+	}
+
+  // when the *_on_behalf_of is changed...
+  $('[id$=_on_behalf_of]').change(function() {
+    var target = $('input[id$=_creator]').first();
+   
+    // check if we're on the metadata tab
+    var selected = $("a[aria-controls='metadata']").attr('aria-expanded');
+
+    // if not, select it
+    if (selected != 'true') {
+      $("a[aria-controls='metadata']").click();
+    }
+
+    // check if the creators field is in the viewport
+    var visible = isElementInViewport(target);
+
+    // if not visible, scroll to the element
+    if (visible == false) {
+      $('html, body').animate({
+        scrollTop: target.parents('div.form-group').offset().top
+      }, 250);
+    }
+
+    // grab the id of the person being selected
+    ownerId = $('[id$=_on_behalf_of] option:selected').val();
+    
+    // highlight the field
+    target.effect("highlight", {}, 1000);
+
+    if (ownerId == '') {
+      setCurrentUserAsCreator();
+    } else {
+      // gather all the email ids and the matching creator names
+      var depositorDictionary = {}
+      $('user').each(function() {
+        var email = $(this).attr('id');
+        var name = $(this).attr('data-name')
+        depositorDictionary[email] = name;
+      });
+
+      var creator = depositorDictionary[ownerId];
+      target.val(creator);
+    }
+  });
+}
+
+$(document).on('turbolinks:load', setCurrentUserAsCreator)
+$(document).on('turbolinks:load', setProxySelectionAsCreator)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,8 @@ class User < ActiveRecord::Base
   def to_s
     email
   end
+
+  def name_for_works
+    last_name + ", " + first_name unless first_name.blank? || last_name.blank?
+  end
 end

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -1,0 +1,53 @@
+<% # data attributes for creator field auto-populate %>
+<user id="current_user" data-name="<%= current_user.name_for_works %>"></user>
+<% current_user.can_make_deposits_for.each do |user| %>
+  <user id="<%= user.email %>" data-name="<%= user.name_for_works %>"></user>
+<% end %>
+
+<% # we will yield to content_for for each tab, e.g. :files_tab %>
+<% tabs ||= %w[metadata files relationships share] # default tab order %>
+<div class="row">
+  <div class="col-xs-12 col-sm-8" role="main">
+
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <% tabs.each_with_index do | tab, i | %>
+        <% if i == 0 %>
+          <li role="presentation" class="active">
+        <% else %>
+          <li role="presentation">
+        <% end %>
+            <a href="#<%= tab %>" aria-controls="<%= tab %>" role="tab" data-toggle="tab">
+              <i class="fa icon-<%= tab %>"></i> <%= t("sufia.works.edit.tab.#{tab}") %>
+            </a>
+          </li>
+      <% end %>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+      <% (tabs - ['share']).each_with_index do | tab, i | %>
+        <% if i == 0 %>
+          <div role="tabpanel" class="tab-pane active" id="<%= tab %>">
+        <% else %>
+          <div role="tabpanel" class="tab-pane" id="<%= tab %>">
+        <% end %>
+          <div class="form-tab-content">
+            <%= yield "#{tab}_tab".to_sym if content_for? "#{tab}_tab".to_sym %>
+            <%= render "form_#{tab}", f: f %>
+          </div>
+        </div>
+      <% end %>
+
+      <div role="tabpanel" class="tab-pane" id="share" data-param-key="<%= f.object.model_name.param_key %>">
+          <div class="form-tab-content">
+            <%= render "form_share", f: f %>
+          </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+    <%= render 'form_progress', f: f %>
+  </div>
+</div>

--- a/db/migrate/20161122183258_add_last_name_and_first_name_to_users.rb
+++ b/db/migrate/20161122183258_add_last_name_and_first_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddLastNameAndFirstNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012153806) do
+ActiveRecord::Schema.define(version: 20161122183258) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -360,6 +360,8 @@ ActiveRecord::Schema.define(version: 20161012153806) do
     t.string   "arkivo_subscription"
     t.binary   "zotero_token"
     t.string   "zotero_userid"
+    t.string   "first_name"
+    t.string   "last_name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -26,6 +26,8 @@ feature 'Creating a new work', js: true do
       attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/jp2_fits.xml", visible: false)
       click_link "Description" # switch tab
       fill_in('Title', with: 'My Test Work')
+      # checking for work_creator autofill, and also filling it in
+      expect(page).to have_css(".work_creator", text: user.name_for_works)
       fill_in('Creator', with: 'Test User')
       fill_in('Keyword', with: 'tests')
       select 'Attribution-ShareAlike 3.0 United States', from: 'work_rights'
@@ -56,13 +58,15 @@ feature 'Creating a new work', js: true do
 
       click_link "Description" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Creator', with: 'Test User')
+      # fill_in('Creator', with: 'Test User') // now autofilling this
+      expect(page).to have_css(".work_creator", text: user.name_for_works)
       fill_in('Keyword', with: 'tests')
       select 'Attribution-ShareAlike 3.0 United States', from: 'work_rights'
 
       choose('work_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       select(second_user.user_key, from: 'On behalf of')
+      expect(page).to have_css(".work_creator", value: second_user.name_for_works)
       check('agreement')
       click_on('Save')
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate curation_concerns:work Work`
+require 'rails_helper'
+
+describe User do
+  describe "#name_for_works" do
+    subject { described_class.new }
+
+    context "with first_name and last_name set" do
+      before do
+        subject.first_name = "Lucy"
+        subject.last_name = "Bearcat"
+      end
+
+      it "returns the name" do
+        expect(subject.name_for_works).to eq("Bearcat, Lucy")
+      end
+    end
+
+    context "with first_name blank and last_name set" do
+      before do
+        subject.last_name = "Bearcat"
+      end
+
+      it "returns the name" do
+        expect(subject.name_for_works).to eq(nil)
+      end
+    end
+
+    context "with first_name set and last_name blank" do
+      before do
+        subject.first_name = "Lucy"
+      end
+
+      it "returns the name" do
+        expect(subject.name_for_works).to eq(nil)
+      end
+    end
+
+    context "with first_name and last_name blank set" do
+      it "returns the name" do
+        expect(subject.name_for_works).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #880

Uses jquery to handle creator names in the new work creation:

* Added database migrations for first name and last name for `User`
* Added `User#name_for_works` to form the *LastName, FirstName* format
* publishes the current user as a `<user>` data attribute in the `_guts4form` partial, along with all the others users that the current user can deposit on behalf of.
* Uses jquery to read the data attribute and populate the creator on page load
* Uses jquery to detect changes to the proxy drop down on the view, updating the creator field as needed - also highlights the creator field on the change
* Spec coverage is minimal - added assertions to the new work feature tests for regular user and current user, testing that the names are set as needed. Also tested the changes to `User`.

I brought in a partial from Sufia: `_guts4form.html.erb` - I didn't separate this out into it's own commit because I anticipated the DOI PR getting merged first - it also pulls this partial into the app.