### PR TITLE
Add browse-everything

### DIFF
--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -1,0 +1,14 @@
+#
+# To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
+# The file_system provider can be a path to any directory on the server where your application is running.
+#
+---
+ dropbox:
+   :app_key: bamboo_browse_everything_dropbox_id
+   :app_secret: bamboo_browse_everything_dropbox_secret
+ box:
+   :client_id: bamboo_browse_everything_box_id
+   :client_secret: bamboo_browse_everything_box_secret
+ google_drive:
+   :client_id: bamboo_browse_everything_gdrive_id
+   :client_secret: bamboo_browse_everything_gdrive_secret

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
+  mount BrowseEverything::Engine => '/browse'
   Hydra::BatchEdit.add_routes(self)
   mount Qa::Engine => '/authorities'
 

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -20,6 +20,7 @@ feature 'Creating a new work', js: true do
     it 'create a new work' do
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
+      expect(page).to have_content "Browse cloud files" # with browse-everything enabled
       # expect(page).to have_content "Add folder"  -- only works in Chrome
       attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
       attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/jp2_fits.xml", visible: false)


### PR DESCRIPTION
Fixes #988 

Enable cloud file upload via browse-everything gem.

Changes proposed in this pull request:
* run browse-everything generator
* Add line to create-work spec to look for cloud button

