### PR TITLE
fix typo in license-selector

### DIFF
--- a/vendor/assets/javascripts/license-selector.js
+++ b/vendor/assets/javascripts/license-selector.js
@@ -1429,7 +1429,7 @@
 	    });
 	  },
 	  CommercialUse: function() {
-	    this.question('Do you allow others to make commercial use of you work?');
+	    this.question('Do you allow others to make commercial use of your work?');
 	    this.yes(function() {
 	      this.exclude('nc');
 	      if (this.only('by')) {


### PR DESCRIPTION
Fixes #1006 

Fix typo in license selector.

Changes proposed in this pull request:
* ~you~your work

