### PR TITLE
Add the ability to connect and disconnect to an ORCID - DON'T MERGE YET

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.0.0'
 
+gem 'orcid', :github => 'uclibs/orcid'
+
+gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
+
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 
@@ -50,6 +54,7 @@ gem "kaminari", "0.15.1"
 gem "curate", git: "https://github.com/uclibs/curate.git", ref: "74be155482366cf3bab11f86a83320abe6c7856c"
 gem 'browse-everything', git: 'https://github.com/uclibs/browse-everything.git', ref: "8c0db2a476cce08210da2a67a2c3bddf284271c7"
 gem 'kaltura'
+
 
 gem "clamav"
 gem "hydra-remote_identifier", github: "uclibs/hydra-remote_identifier", branch: "setting-status"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: git://github.com/uclibs/devise-multi_auth.git
+  revision: 7835adee2f3f9d84dd876aea15a91ef47e155d3b
+  specs:
+    devise-multi_auth (0.2.0)
+      devise (~> 3.2)
+      omniauth (~> 1.2)
+      rails (~> 4.0)
+
+GIT
   remote: git://github.com/uclibs/hydra-remote_identifier.git
   revision: c757c798eda1bc6d2bd847d308cf09ae36cef90b
   branch: setting-status
@@ -8,9 +17,24 @@ GIT
       rest-client (~> 1.7.3)
 
 GIT
+  remote: git://github.com/uclibs/orcid.git
+  revision: 58d072b0b7f12814cffdc7982d630eca328cdbae
+  specs:
+    orcid (0.9.1)
+      devise-multi_auth (~> 0.1)
+      email_validator
+      figaro
+      mappy
+      omniauth-oauth2 (< 1.4)
+      omniauth-orcid (= 0.6)
+      railties (~> 4.0)
+      simple_form
+      virtus
+
+GIT
   remote: https://github.com/uclibs/browse-everything.git
-  revision: f240725e6ca10434df18820203bd7a386a6f2b97
-  branch: base/kaltura
+  revision: 8c0db2a476cce08210da2a67a2c3bddf284271c7
+  ref: 8c0db2a476cce08210da2a67a2c3bddf284271c7
   specs:
     browse-everything (0.9.1)
       bootstrap-sass
@@ -27,8 +51,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: 1494b223ead31521cc922bad9643c448c5efaa0f
-  ref: 1494b223ead31521cc922bad9643c448c5efaa0f
+  revision: 74be155482366cf3bab11f86a83320abe6c7856c
+  ref: 74be155482366cf3bab11f86a83320abe6c7856c
   specs:
     curate (0.6.6)
       active_attr
@@ -95,7 +119,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.16.1)
+    activerecord-import (0.16.2)
       activerecord (>= 3.2)
     activeresource (4.1.0)
       activemodel (~> 4.0)
@@ -108,7 +132,8 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
     acts_as_follower (0.2.1)
-    addressable (2.4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (4.0.2)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
@@ -144,10 +169,11 @@ GEM
       activesupport
       rack
     breadcrumbs_on_rails (3.0.1)
-    browser (2.2.0)
+    browser (2.3.0)
     builder (3.1.4)
+    byebug (9.0.6)
     cancan (1.6.10)
-    capybara (2.10.1)
+    capybara (2.10.2)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -167,7 +193,6 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    clamav (0.4.1)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cliver (0.3.2)
@@ -182,7 +207,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.10.0)
+    coffee-script-source (1.11.1)
     daemons (1.2.4)
     debug_inspector (0.0.2)
     deprecation (1.0.0)
@@ -200,6 +225,8 @@ GEM
     diff-lcs (1.2.5)
     dropbox-sdk (1.6.5)
       json
+    email_validator (1.6.0)
+      activemodel
     equalizer (0.0.11)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
@@ -216,8 +243,8 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
     fastercsv (1.5.5)
     feedjira (2.0.0)
       faraday (~> 0.9)
@@ -225,6 +252,8 @@ GEM
       loofah (~> 2.0)
       sax-machine (~> 1.0)
     ffi (1.9.14)
+    figaro (1.1.1)
+      thor (~> 0.14)
     font-awesome-rails (4.2.0.0)
       railties (>= 3.2, < 5.0)
     font-awesome-sass (4.7.0)
@@ -333,6 +362,8 @@ GEM
       carrierwave (>= 0.5.8)
       foreigner (>= 0.9.1)
       rails (> 3.0.0)
+    mappy (0.1.0)
+      activesupport
     marc (1.0.0)
       scrub_rb (>= 1.0.1, < 2)
       unf
@@ -349,7 +380,6 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    mysql2 (0.3.20)
     nest (1.1.2)
       redis
     netrc (0.11.0)
@@ -378,9 +408,15 @@ GEM
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
+    omniauth-oauth2 (1.3.1)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
+    omniauth-orcid (0.6)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
     omniauth-shibboleth (1.2.1)
       omniauth (>= 1.0.0)
     openseadragon (0.1.0)
@@ -397,6 +433,7 @@ GEM
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
+    public_suffix (2.0.4)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.5.5)
@@ -431,9 +468,8 @@ GEM
       rdf-xsd (>= 1.0)
     rdf-xsd (1.1.2)
       rdf (~> 1.1)
-    rdoc (4.2.2)
-      json (~> 1.4)
-    redis (3.3.1)
+    rdoc (4.3.0)
+    redis (3.3.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.26.0)
@@ -492,7 +528,8 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rufus-scheduler (3.2.2)
+    rufus-scheduler (3.3.0)
+      tzinfo
     sass (3.2.19)
     sass-rails (4.0.5)
       railties (>= 4.0.0, < 5.0)
@@ -560,7 +597,7 @@ GEM
       resque (~> 1.23)
       resque-pool (= 0.3.0)
       zipruby (= 0.3.6)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tilt (1.4.1)
     trollop (1.16.2)
@@ -568,7 +605,7 @@ GEM
       coffee-rails
     tzinfo (0.3.52)
     uber (0.0.15)
-    uglifier (3.0.3)
+    uglifier (3.0.4)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
@@ -598,13 +635,14 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   browse-everything!
+  byebug
   capybara (~> 2.1)
   change_manager
-  clamav
   coffee-rails (~> 4.0.0)
   curate!
   devise
   devise-guests (~> 0.3)
+  devise-multi_auth!
   exception_notification
   factory_girl_rails (~> 4.2.0)
   feedjira
@@ -616,10 +654,10 @@ DEPENDENCIES
   jquery-rails
   kaltura
   kaminari (= 0.15.1)
-  mysql2 (= 0.3.20)
   omniauth-openid
   omniauth-shibboleth
   openseadragon (= 0.1.0)
+  orcid!
   poltergeist
   quiet_assets
   rails (= 4.0.13)
@@ -637,4 +675,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -9,6 +9,13 @@ class CallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  SUCCESS_NOTICE = "You have successfully connected with your Orcid account"
+  def orcid
+    omni = request.env["omniauth.auth"]
+    Devise::MultiAuth.capture_successful_external_authentication(current_user, omni)
+    redirect_to landing_page, notice: SUCCESS_NOTICE
+  end
+
   private
 
   def get_shibboleth_attributes

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,14 +1,19 @@
 require Curate::Engine.root.join('app/controllers/registrations_controller.rb')
 class RegistrationsController
-
+SUCCESS_NOTICE = "You have been disconnected from your orcid account."
   def update(&block)
-    if current_user.provider == "shibboleth"
+    if current_user.provider == 'shibboleth'
       shibboleth_user_is_updating_their_user_registration(&block)
     elsif current_user.manager?
       manager_is_updating_a_user_registration(&block)
     else
       current_user_is_updating_their_user_registration(&block)
     end
+  end
+
+  def disconnect_orcid
+    Orcid.disconnect_user_and_orcid_profile(current_user)
+    redirect_to catalog_index_path, notice: SUCCESS_NOTICE
   end
 
   protected
@@ -20,5 +25,4 @@ class RegistrationsController
     update_status = resource.update_without_password(account_update_params)
     handle_update_response(update_status: update_status, skip_signin: false, &block)
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
 
     devise :database_authenticatable, :registerable,
-           :recoverable, :rememberable, :trackable, :validatable,
-           :omniauthable, :omniauth_providers => [:shibboleth]
+           :recoverable, :rememberable, :trackable, :validatable, :omniauthable, :omniauth_providers => [:orcid, :shibboleth]
 
             # Method added by Blacklight; Blacklight uses #to_s on your
             # user class to get a user-displayable login/identifier for

--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -47,6 +47,8 @@
       <%= render partial: 'profile_image', locals: {person: @person} %>
     </div>
 
+
+
     <dl class="person-attribtues <%= dom_class(@person) %>">
 
       <% @person.terms_for_display.reject{|attribute| (attribute == :last_name) || (attribute == :first_name) || (attribute == :name) || (attribute == :title)}.each do |attribute_name| %>
@@ -56,6 +58,14 @@
             <dd class="value"><%= auto_link_without_protocols(value) %></dd>
           <% end %>
         <% end %>
+      <% end %>
+
+      <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for)
+                                   status_processor.call(current_user) do |on|
+                                   on.authenticated_connection do |profile| %>
+                                   <dt class="attribute"><%= "Orcid ID:" %></dt>
+                                   <dd class="value"><%= link_to profile.orcid_profile_id, Orcid.url_for_orcid_id(profile.orcid_profile_id), { target: '_blank' } %></dd>
+      <% end %>
       <% end %>
 
     </dl>

--- a/app/views/orcid/profile_connections/_authenticated_connection.html.erb
+++ b/app/views/orcid/profile_connections/_authenticated_connection.html.erb
@@ -1,0 +1,4 @@
+<div class="authenticated-connection">
+  <%= t('orcid.views.authenticated_connection', orcid_profile_url: Orcid.url_for_orcid_id(authenticated_connection.orcid_profile_id), orcid_profile_id: authenticated_connection.orcid_profile_id).html_safe %>
+  <%= link_to "Disconnect from Orcid", disconnect_orcid_path, class: 'btn btn-primary', data: { confirm: "Are you sure you want to disconnect your orcid? (You can re-connect later)"} %>
+</div>

--- a/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
+++ b/app/views/orcid/profile_connections/_options_to_connect_orcid_profile.html.erb
@@ -1,0 +1,17 @@
+<% profile_connection = Orcid::ProfileConnection.new %>
+<% default_search_text = '' unless defined?(default_search_text) %>
+<div class="options-to-connect-orcid-profile">
+  <p>
+    <%= link_to t('orcid/profile_connection.look_up_your_existing_orcid', scope: 'helpers.label'), orcid.new_profile_connection_path(profile_connection:{text: default_search_text}) %>
+  </p>
+  <p>
+  <%= form_for(profile_connection, as: :profile_connection, url: orcid.profile_connections_path, method: :post) do |f| %>
+    <%# Note the `scope: 'helpers.label'` option is the default for the label, but I want to call those specifically out %>
+    <%= f.label :orcid_profile_id, t('orcid/profile_connection.orcid_profile_id', scope: 'helpers.label') %>
+    <%= f.text_field :orcid_profile_id, class:"orcid-input" %>
+    <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">
+      <span class="orcid-connect"><%= t('orcid/profile_connection.connect_button_text', scope: 'helpers.label') %></span>
+    </button>
+  <% end %>
+  </p>
+</div>

--- a/app/views/orcid/profile_connections/_orcid_connector.html.erb
+++ b/app/views/orcid/profile_connections/_orcid_connector.html.erb
@@ -1,0 +1,22 @@
+<% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
+<div class='orcid-connector'>
+  <br/>
+  <% status_processor.call(current_user) do |on|%>
+    <% on.profile_request_in_error do |pending_request| %>
+      <%= render partial: 'orcid/profile_connections/profile_request_in_error', object: pending_request %>
+    <% end %>
+    <% on.profile_request_pending do |pending_request| %>
+      <%= render partial: 'orcid/profile_connections/profile_request_pending', object: pending_request %>
+    <% end %>
+    <% on.authenticated_connection do |profile| %>
+      <%= render partial: 'orcid/profile_connections/authenticated_connection', object: profile %>
+    <% end %>
+    <% on.pending_connection do |profile| %>
+      <%= render partial: 'orcid/profile_connections/pending_connection', object: profile %>
+    <% end %>
+    <% on.unknown do %>
+      <% defined?(default_search_text) || default_search_text = '' %>
+      <%= render template: 'orcid/profile_connections/_options_to_connect_orcid_profile', locals: { default_search_text: default_search_text } %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/registrations/edit.html.erb
+++ b/app/views/registrations/edit.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_header do %>
+  <h1>Account Details</h1>
+<% end %>
+
+<legend>Orcid</legend>
+<div class="orcid-section">
+  <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
+    <% status_processor.call(current_user) do |on| %>
+        <% on.authenticated_connection do |profile| %>
+        <% end %>
+  <% end %>
+  
+  <% if defined?(Orcid) %>
+      <%= render partial: 'orcid/profile_connections/orcid_connector', locals: {default_search_text: current_user.name } %>
+  <% end %>
+</div>
+
+<%= simple_form_for(resource, :as => resource_name, :url => user_registration_path, :html => { :method => :put }) do |f| %>
+
+  <%= f.hidden_field :id %>
+
+  <% if f.error_notification -%>
+    <div class="alert alert-error fade in">
+      <strong>Wait don't go!</strong> There was a problem with your submission. Please review the errors below:
+      <a class="close" data-dismiss="alert" href="#">&times;</a>
+    </div>
+  <% end -%>
+
+  <%= render partial: 'registrations/form_attributes', locals: {f: f} %>
+
+  <%= render partial: 'registrations/form_password_management', locals: {f: f} %>
+
+  <div class="row">
+    <div class="span12 form-actions">
+      <%= f.submit class: 'btn btn-primary', value: 'Update Account' %>
+      <%= link_to 'Cancel', person_path(current_user.person), class: 'btn btn-link' %>
+    </div>
+  </div>
+
+<% end %>

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,0 +1,2 @@
+ORCID_APP_ID: bamboo_orcid_id
+ORCID_APP_SECRET: bamboo_orcid_secret

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ CurateApp::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  #config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = false
 
   # Needed for Exception_Notification in Development
   # config.action_mailer.delivery_method = :sendmail

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,17 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+        config.omniauth(:orcid, Orcid.provider.id, Orcid.provider.secret,
+                        scope: Orcid.provider.authentication_scope,
+                        member: true,
+                        sandbox: true,
+                        client_options: {
+                          site: Orcid.provider.site_url,
+                          authorize_url: Orcid.provider.authorize_url,
+                          token_url: Orcid.provider.token_url
+                        }
+                        )
+      
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/initializers/orcid_initializer.rb
+++ b/config/initializers/orcid_initializer.rb
@@ -1,0 +1,18 @@
+Orcid.configure do |config|
+  # # Configure your Orcid Client Application. See URL below for more
+  # # information
+  # # http://support.orcid.org/knowledgebase/articles/116739-register-a-client-application
+  # config.provider.id = "Your app's Orcid Client ID"
+  # config.provider.secret = "Your app's Orcid Client Secret"
+
+
+  # # Configure how your applications models will be mapped to an Orcid Work so
+  # # that your application can append the work to an Orcid Profile.
+  # config.register_mapping_to_orcid_work(
+  #   :article,
+  #   [
+  #     [:title, :title],
+  #     [lambda{|article| article.publishers.join("; ")}, :publishers]
+  #   ]
+  # )
+end

--- a/config/locales/orcid.en.yml
+++ b/config/locales/orcid.en.yml
@@ -1,0 +1,60 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+en:
+  orcid:
+    requests:
+      messages:
+        existing_request_not_found: "Unable to find an existing orcid Profile request. Go ahead and create one."
+        existing_request: "You have already submitted an ORCID Profile request."
+        previously_connected_profile: "You have already connected to an ORCID Profile (%{orcid_profile_id})."
+        profile_request_created: "Your ORCID profile request has been submitted. Check your email for more information from ORCID."
+        profile_request_created: "Your ORCID profile request has been submitted. Check your email for more information from ORCID."
+        profile_request_destroyed: "Your ORCID profile request has been cancelled."
+    connections:
+      messages:
+        profile_connection_not_found: "Unable to find an existing ORCID Profile connection."
+        verified_profile_connection_exists: "You have already connected and verified your ORCID Profile (%{orcid_profile_id})."
+    verbose_name: Open Researcher and Contributor ID (ORCID)
+    views:
+      profile_connections:
+        fieldsets:
+          search_orcid_profiles: "Search ORCID Profiles"
+          select_an_orcid_profile: "Select an ORCID Profile"
+        buttons:
+          search: 'Search'
+      authenticated_connection: "<p>Your ORCID (<a class='orcid-profile-id' href='%{orcid_profile_url}'>%{orcid_profile_id}</a>) has been authenticated for this application.</p>"
+      profile_request_pending: "<p>We are processing your ORCID Profile Request. It was submitted <time datetime='%{datetime}'>%{time_ago_in_words}</time> ago.</p>"
+      pending_connection: >
+        <p>You have an ORCID (<a class="orcid-profile-id" href="%{orcid_profile_url}">%{orcid_profile_id}</a>).</p>
+        <p>However, your ORCID has not been verified by this system. There are a few possibilities:</p>
+        <ul>
+          <li>You may not have claimed your ORCID. <a class="find-out-more" href="http://support.orcid.org/knowledgebase/articles/164480-creating-claiming-new-records">Find out more about claiming your ORCID.</a></li>
+          <li>You have claimed your ORCID, but have not used it to <a class="signin-via-orcid" href="%{application_orcid_authorization_href}">%{application_orcid_authorization_text}</a>.</li>
+        </ul>
+  helpers:
+    label:
+      orcid/profile_connection:
+        orcid_profile_id: "Enter your existing ORCID (####-####-####-####)"
+        create_an_orcid: Create an ORCID
+        look_up_your_existing_orcid: Look up your existing ORCID
+        connect_button_text: Connect
+        profile_request_destroy: Cancel your ORCID request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,20 @@
 CurateApp::Application.routes.draw do
+  mount Orcid::Engine => "/orcid"
   #root 'catalog#index'
   root 'page_requests#view_presentation'
   Blacklight.add_routes(self)
   HydraHead.add_routes(self)
-    devise_for :users, controllers: { sessions: :sessions, registrations: :registrations, omniauth_callbacks: "callbacks" }
+    devise_for :users, controllers: { sessions: :sessions, registrations: :registrations, omniauth_callbacks: 'callbacks' }
 
 
   namespace :admin do
   #constraints Sufia::ResqueAdmin do
      mount Resque::Server, :at => 'queues'
   #end
+  end
+
+  devise_scope :user do
+    match "disconnect_orcid" => "registrations#disconnect_orcid", via: :get, as: "disconnect_orcid"
   end
 
   devise_scope :users do

--- a/db/migrate/20160816182902_create_authentications.devise_multi_auth.rb
+++ b/db/migrate/20160816182902_create_authentications.devise_multi_auth.rb
@@ -1,0 +1,15 @@
+# This migration comes from devise_multi_auth (originally 20140204141526)
+class CreateAuthentications < ActiveRecord::Migration
+  def change
+    create_table :devise_multi_auth_authentications do |t|
+      t.integer :user_id, index: true, null: false
+      t.string :provider, null: false
+      t.string :uid, null: false
+      t.string :access_token
+      t.string :refresh_token
+      t.timestamp :expires_at, index: true
+      t.timestamps
+    end
+    add_index :devise_multi_auth_authentications, [:provider, :uid], unique: true
+  end
+end

--- a/db/migrate/20160816182938_create_orcid_profile_requests.orcid.rb
+++ b/db/migrate/20160816182938_create_orcid_profile_requests.orcid.rb
@@ -1,0 +1,13 @@
+# This migration comes from orcid (originally 20140205185338)
+class CreateOrcidProfileRequests < ActiveRecord::Migration
+  def change
+    create_table :orcid_profile_requests do |t|
+      t.integer :user_id, unique: true, index: true, null: false
+      t.string :given_names, null: false
+      t.string :family_name, null: false
+      t.string :primary_email, null: false
+      t.string :orcid_profile_id, unique: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20160816182939_update_orcid_profile_requests.orcid.rb
+++ b/db/migrate/20160816182939_update_orcid_profile_requests.orcid.rb
@@ -1,0 +1,7 @@
+# This migration comes from orcid (originally 20140205185339)
+class UpdateOrcidProfileRequests < ActiveRecord::Migration
+  def change
+    add_column :orcid_profile_requests, :response_text, :text
+    add_column :orcid_profile_requests, :response_status, :string, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420192850) do
+ActiveRecord::Schema.define(version: 20160816182939) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",     null: false
@@ -51,6 +51,19 @@ ActiveRecord::Schema.define(version: 20160420192850) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
+
+  create_table "devise_multi_auth_authentications", force: true do |t|
+    t.integer  "user_id",       null: false
+    t.string   "provider",      null: false
+    t.string   "uid",           null: false
+    t.string   "access_token"
+    t.string   "refresh_token"
+    t.datetime "expires_at"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "devise_multi_auth_authentications", ["provider", "uid"], name: "index_devise_multi_auth_authentications_on_provider_and_uid", unique: true
 
   create_table "domain_terms", force: true do |t|
     t.string "model"
@@ -138,6 +151,18 @@ ActiveRecord::Schema.define(version: 20160420192850) do
   end
 
   add_index "notifications", ["conversation_id"], name: "index_notifications_on_conversation_id"
+
+  create_table "orcid_profile_requests", force: true do |t|
+    t.integer  "user_id",          null: false
+    t.string   "given_names",      null: false
+    t.string   "family_name",      null: false
+    t.string   "primary_email",    null: false
+    t.string   "orcid_profile_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.text     "response_text"
+    t.string   "response_status"
+  end
 
   create_table "proxy_deposit_rights", force: true do |t|
     t.integer  "grantor_id"


### PR DESCRIPTION
Fixes #600 

Adds a widget to the profile edit page that allows a user to connect (and disconnect) their existing orcid ID to Scholar.

Changes proposed in this pull request:
* Adds a small partial to the profile edit page that contains controls to connect to orcid
* Displays ya users' Orcid ID under their profile avatar on the profile show page

