### PR TITLE
Log exception details and notify before rendering 404

### DIFF
--- a/app/controllers/contact_requests_controller.rb
+++ b/app/controllers/contact_requests_controller.rb
@@ -14,10 +14,11 @@ class ContactRequestsController < ApplicationController
   def create
     @name = params[:name]
     @email = params[:email]
-    @comments = params[:comments]
+    @comments = "Message: #{ params[:comments] }"
+    @subject = "#{t('sufia.product_name')}: Contact Form Submission"
 
     if passes_catcha_or_is_logged_in?
-      NotificationMailer.notify(@name,@email,@comments).deliver
+      NotificationMailer.notify(@name,@email,@subject,@comments).deliver
       redirect_to catalog_index_path, notice: SUCCESS_NOTICE
     else
       flash.now[:notice] = FAIL_NOTICE

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,18 +1,18 @@
 class NotificationMailer < ActionMailer::Base
 
-  def notify(name,email,comments)
+  def notify(name,email,subject,comments)
     mail(from: sender_email(email),
          to: recipients_list,
-         subject: "#{t('sufia.product_name')}: Contact Form Submission",
+         subject: subject,
          body: prepare_body(name, email, comments))
   end
 
   private
 
   def prepare_body(name, email, comments)
-    body = "From: #{name}\n\n"
-    body += "Email: #{email}\n\n"
-    body += "Message: #{comments}\n"
+    body = name.blank? ? '' : "From: #{name}\n\n"
+    body += email.blank? ? '' : "Email: #{email}\n\n"
+    body += "#{comments}\n"
     body
   end
 
@@ -27,8 +27,7 @@ class NotificationMailer < ActionMailer::Base
   end
 
   def default_sender
-    @sender ||= YAML.load(File.open(File.join(Rails.root, "config/smtp_config.yml")))
-    return @sender[Rails.env]["smtp_user_name"]
+    "scholar@uc.edu"
   end
 end
 

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'Rescued exception' do
+  before do
+    Rails.application.config.consider_all_requests_local = false
+    Rails.application.config.action_dispatch.show_exceptions = true
+    load "application_controller.rb"
+  end
+
+  after do
+    Rails.application.config.consider_all_requests_local = true
+    Rails.application.config.action_dispatch.show_exceptions = false
+    load "application_controller.rb"
+  end
+
+  it 'logs a detailed error message' do
+    expect(Rails.logger).to receive(:error).with(/Rescued exception/)
+    visit edit_curation_concern_article_path(id: 'invalid')
+  end
+
+  it 'sends a notification alert' do
+    visit edit_curation_concern_article_path(id: 'invalid')
+    email = ActionMailer::Base.deliveries.last
+    expect(email.to).to eq(["scholar@uc.edu"])
+    expect(email.from).to eq(["scholar@uc.edu"])
+    expect(email.subject).to eq("Scholar@UC: Exception Alert")
+    expect(email.body.raw_source).to include("Rescued exception")
+  end
+
+  it 'renders the 404 page' do
+    visit edit_curation_concern_article_path(id: 'invalid')
+    expect(page.status_code).to eq(404)
+  end
+end


### PR DESCRIPTION
Fixes #417 

When running in production mode, any application exceptions will be logged with detailed errors, the params, path, and current user.  The same details get emailed to scholar@uc.edu.

Note: I had to tweak the NotificationMailer so it can handle exception emails as well as contact emails.  It didn't make sense to create a new mailer controller just for exception notifications.
