### PR TITLE
Pin rake to same version pinned in Curate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ end
 
 gem "kaminari", "0.15.1"
 
-gem "curate", git: "https://github.com/uclibs/curate.git", ref: "74be155482366cf3bab11f86a83320abe6c7856c"
+gem "curate", git: "https://github.com/uclibs/curate.git", ref: "4effbfb366ab9a9badb6703c619cb9703098e811"
 gem 'browse-everything', git: 'https://github.com/uclibs/browse-everything.git', ref: "8c0db2a476cce08210da2a67a2c3bddf284271c7"
 gem 'kaltura'
 
@@ -62,7 +62,7 @@ end
 #change manager gem for automatic notification management, requires resque and resque-scheduler
 gem 'resque'
 gem 'resque-scheduler'
-gem 'change_manager'
+gem 'change_manager', '1.0.0'
 
 gem "bootstrap-sass"
 gem "font-awesome-sass"
@@ -102,4 +102,4 @@ gem 'omniauth-openid'
 gem 'omniauth-shibboleth'
 gem 'feedjira'
 
-gem 'rake', '10.5'
+gem 'rake', '11.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,7 +424,7 @@ GEM
       activesupport (= 4.0.13)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.5.0)
+    rake (11.2.2)
     rdf (1.1.1.1)
     rdf-rdfxml (1.0.1)
       rdf (>= 1.0)
@@ -623,7 +623,7 @@ DEPENDENCIES
   poltergeist
   quiet_assets
   rails (= 4.0.13)
-  rake (= 10.5)
+  rake (= 11.2.2)
   resque
   resque-scheduler
   rspec-html-matchers (~> 0.4)


### PR DESCRIPTION
We pinned rake to 11.2.2 in Curate and need to do it in the app as well to avoid conflicts.

