### PR TITLE
Turn off virus scanning by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "curate", git: "https://github.com/uclibs/curate.git", ref: "4effbfb366ab9a9
 gem 'browse-everything', git: 'https://github.com/uclibs/browse-everything.git', ref: "8c0db2a476cce08210da2a67a2c3bddf284271c7"
 gem 'kaltura'
 
-gem "clamav"
+#gem "clamav"
 gem "hydra-remote_identifier", github: "uclibs/hydra-remote_identifier", branch: "setting-status"
 gem "sitemap_generator"
 

--- a/config/initializers/clamav.rb
+++ b/config/initializers/clamav.rb
@@ -1,1 +1,1 @@
-ClamAV.instance.loaddb()
+ClamAV.instance.loaddb if Rails.env.production?

--- a/script/bamboo_deploy_production.sh
+++ b/script/bamboo_deploy_production.sh
@@ -12,6 +12,9 @@ cd /srv/apps/curate/curate_uc-STAGE
 chmod +x /srv/apps/curate/curate_uc-STAGE/script/*.sh
 /srv/apps/curate/curate_uc-STAGE/script/copy_config_bamboo.sh
 
+# Enable ClamAV gem
+sed -i 's/#gem "clamav"/gem "clamav"/' /srv/apps/curate/curate_uc-STAGE/Gemfile
+
 # Bundle and run migrations
 gem install --user-install bundler
 bundle install --path vendor/bundle

--- a/script/bamboo_deploy_qa.sh
+++ b/script/bamboo_deploy_qa.sh
@@ -16,6 +16,9 @@ chmod +x /srv/apps/curate/curate_uc-STAGE/script/*.sh
 rm -rf /srv/apps/curate/curate_uc-STAGE/tmp
 ln -s /mnt/temp /srv/apps/curate/curate_uc-STAGE/tmp
 
+# Enable ClamAV gem
+sed -i 's/#gem "clamav"/gem "clamav"/' /srv/apps/curate/curate_uc-STAGE/Gemfile
+
 # Bundle and run migrations
 gem install --user-install bundler
 bundle install --path vendor/bundle


### PR DESCRIPTION
Turns off clamav in our dev environments.  The gem will be re-enabled during deploy to servers.

This is just a config change.  The code and tests are already merged into Curate.

I've tested this change in our server environment.