### PR TITLE
Remove FAQ about soft deletes

### DIFF
--- a/app/views/page_requests/faq.html.erb
+++ b/app/views/page_requests/faq.html.erb
@@ -23,7 +23,6 @@
         <li><a href="#faq_3456">What's restricted data?</a></li>
         <li><a href="#faq_6543">What’s the difference between delegates, editors, and groups?</a></li>
         <li><a href="#faq_1010">How do work access rights impact my DOIs?</a></li>
-        <li><a href="#faq_6789">What happens to my content when I delete a work?</a></li>
 
       </ul>
       <p>
@@ -151,13 +150,6 @@
         <br><br>
         <i>Unavailable</i> DOIs are maintained for works for which you have requested a DOI where you have deleted the work or where you have changed the access rights from <span class="label label-success">Open Access</span> to <span class="label label-warning">Open Access with Embargo</span>, <span class="label label-info"><%=t('sufia.institution_name') %></span>, or <span class="label label-important">Private</span>. A tombstone page will indicate that the work is not available because it was withdrawn from the author. If you change your work back to <span class="label label-success">Open Access</span>, the DOI will change back to <i>public</i> status.
         <br><br>
-      </blockquote>
-
-      <p><a name="faq_6789" id="faq_6789"></a>
-        What happens to my content when I delete a work?
-      </p>
-      <blockquote>
-        When you delete content from Scholar@UC it is immediately removed from public view. However, the content isn’t removed from the application for 30-days and can be recovered upon your request by contacting scholar@uc.edu. After 30-days, the content will be permanently removed from Scholar@UC. If deleted content included a Digital Object Identifier (DOI), a record of the last known metadata (tombstone) may be displayed to users attempting to access the content through the DOI.
       </blockquote>
 
     </div>


### PR DESCRIPTION
Removing the FAQ about soft deletes since we are turning that off in the next deploy.