### PR TITLE
Show only contributors and non-admins on /users

### DIFF
--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -5,4 +5,37 @@ module Sufia::UsersControllerBehavior
     @presenter = Sufia::UserProfilePresenter.new(@user, current_ability)
     @permalinks_presenter = PermalinksPresenter.new(sufia.profile_path)
   end
+
+  protected
+
+    def base_query
+      filter_users_page(filter_unless_user_is_admin(exclude_admin_users_and_non_owners))
+    end
+
+    def filter_users_page(query)
+      return [nil] unless request.env['PATH_INFO'] == '/users'
+      query
+    end
+
+    def filter_unless_user_is_admin(query)
+      return [nil] if current_user.present? && current_user.admin?
+      query
+    end
+
+    def exclude_admin_users_and_non_owners
+      query = ''
+      appending = false
+      base = User.all
+      base.each do |user|
+        next unless user.admin? || user_work_count(user) < 1
+        query += " and " if appending
+        query += "id <> #{user.id}"
+        appending = true
+      end
+      query
+    end
+
+    def user_work_count(user)
+      CurationConcerns::WorkRelation.new.where(DepositSearchBuilder.depositor_field => user.user_key).count
+    end
 end

--- a/app/views/users/_left_sidebar.html.erb
+++ b/app/views/users/_left_sidebar.html.erb
@@ -1,0 +1,4 @@
+<%= render @user %>
+
+<br />
+<a class="btn btn-primary" href="<%= sufia.profiles_path %>"><i class="glyphicon glyphicon-globe"></i> View Contributors</a>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <%= form_tag sufia.profiles_path, method: :get, class: "form-search" do %>
+    <label class="sr-only" for="user_search">Search Contributors</label>
+    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search Contributors", size: '30', type: "search", id: "user_search" %>
+    <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:uq, :sort, :qt, :page, :utf8)) %>
+    <button type="submit" class="btn btn-primary" id="user_submit"> 
+      <i class="glyphicon glyphicon-search"></i> Go
+    </button>
+  <% end %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,32 @@
+<div id="search">
+  <%= render partial: 'search_form' %>
+  <h1><%= application_name %> Contributors</h1>
+</div>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Avatar</th>
+            <th class="sorts"><i id="name" class="<%=params[:sort].blank? ? 'caret up' : params[:sort]== "name desc" ? 'caret' : params[:sort]== "name" ? 'caret up' : ''%>"></i> User Name</th>
+            <th class="sorts"><i id="login" class="<%=params[:sort]== "login desc" ? 'caret' : params[:sort]== "login" ? 'caret up' : ''%>"></i> User Id</th>
+            <th class="sorts"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> Department</th>
+            <th>Works Created</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% @users.each do |user| %>
+            <tr>
+              <td><%= link_to sufia.profile_path(user) do %>
+                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+                  <% end %>
+              </td>
+               <td><%= link_to user.name, sufia.profile_path(user) %></td>
+               <td><%= link_to user.user_key, sufia.profile_path(user) %></td>
+               <td><%= user.department %></td>
+               <td><%= number_of_works(user) %></td>
+            </tr>
+         <% end %>
+    </tbody>
+</table>
+<div class="pager">
+  <%= paginate @users, theme: 'blacklight', route_set: sufia %>
+</div>


### PR DESCRIPTION
Fixes #1049 
Fixes #1050

1) Changes all references on the /users page and profile pages from "Users" to "Contributors"

2) When visiting /users, users that are admins or users that do not own works are hidden from display.

3) If the current user is an admin, that user will see ALL users when visiting /users.  No users will be hidden.

To solve this I reopened Sufia's users_controller_behavior.rb and overrode the `base_query` method.  That method was originally empty and is intended to be overridden.  It's the best way to make our changes without breaking something in the future.