### PR TITLE
Default to all right reserved on license dropdown

### DIFF
--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -9,7 +9,6 @@
       <div class="col-sm-9 col-sm-offset-2">
         <%= f.input :rights, as: :select,
           collection: license_service.select_active_options,
-          include_blank: 'Use License Wizard or choose directly from the dropdown.',
           item_helper: license_service.method(:include_current_value),
           input_html: { class: 'rights rights-selector', multiple: false },
           label: false

--- a/config/authorities/licenses.yml
+++ b/config/authorities/licenses.yml
@@ -1,4 +1,7 @@
 terms:
+    - id: http://www.europeana.eu/portal/rights/rr-r.html
+      term: All rights reserved
+      active: true
     - id: http://creativecommons.org/licenses/by/3.0/us/
       term: Attribution 3.0 United States
       active: true
@@ -22,7 +25,4 @@ terms:
       active: true
     - id: http://creativecommons.org/publicdomain/zero/1.0/
       term: CC0 1.0 Universal
-      active: true
-    - id: http://www.europeana.eu/portal/rights/rr-r.html
-      term: All rights reserved
       active: true


### PR DESCRIPTION
Fixes #1087 

Defaults the license chooser dropdown box to All rights reserved
