### PR TITLE
Add fields to profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /log/*
 !/log/.keep
 /tmp
+
+# Ignore avatars
+/public/system/avatars/

--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -38,4 +38,10 @@ module Sufia::UsersControllerBehavior
     def user_work_count(user)
       CurationConcerns::WorkRelation.new.where(DepositSearchBuilder.depositor_field => user.user_key).count
     end
+
+    def user_params
+      params.require(:user).permit(:first_name, :last_name, :avatar, :facebook_handle, :twitter_handle, :title,
+                                   :googleplus_handle, :linkedin_handle, :remove_avatar, :orcid, :department,
+                                   :blog, :alternate_phone_number, :alternate_email, :uc_affiliation, :website, :telephone)
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,4 +31,13 @@ class User < ActiveRecord::Base
   def name_for_works
     last_name + ", " + first_name unless first_name.blank? || last_name.blank?
   end
+
+  def name
+    return "#{first_name} #{last_name}" unless first_name.blank? || last_name.blank?
+    user_key
+  end
+
+  def display_name
+    name
+  end
 end

--- a/app/views/users/_edit_primary.html.erb
+++ b/app/views/users/_edit_primary.html.erb
@@ -1,69 +1,134 @@
 <%= form_for @user, url: sufia.profile_path(@user.to_param), html: {multipart: true, class: 'form-horizontal' } do |f| %>
-  <div class="form-group">
-    <%= f.label :avatar, '<i class="glyphicon glyphicon-camera"></i> Change picture'.html_safe, class: "col-xs-4 control-label" %>
-    <div class="col-xs-8">
-      <%= image_tag @user.avatar.url(:thumb) if @user.avatar? %>
-      <%= f.file_field :avatar %>
-      <%= f.hidden_field :avatar_cache %>
-      <span class="help-block">JPG, GIF, or PNG (less than 2MB)</span>
+<div class="row">
+  <div class="col-sm-5">
+    <div class="form-group">
+      <%= f.label :avatar, '<i class="glyphicon glyphicon-camera"></i> Change picture'.html_safe, class: "col-xs-4 control-label" %>
+      <div class="col-xs-8">
+        <%= image_tag @user.avatar.url(:thumb) if @user.avatar? %>
+        <%= f.file_field :avatar %>
+        <%= f.hidden_field :avatar_cache %>
+        <span class="help-block">JPG, GIF, or PNG (less than 2MB)</span>
 
-      <div class="checkbox">
-        <%= f.label :remove_avatar do %>
-          <%= f.check_box :remove_avatar %>
-          Delete picture
-          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="If you would like to remove your picture entirely, check the box and save your profile." data-original-title="Delete Picture"><i class="glyphicon glyphicon-question-sign"></i></a>
-        <% end %>
+        <div class="checkbox">
+          <%= f.label :remove_avatar do %>
+            <%= f.check_box :remove_avatar %>
+            Delete picture
+            <a href="#" id="delete_picture_help" data-toggle="popover" data-content="If you would like to remove your picture entirely, check the box and save your profile." data-original-title="Delete Picture"><i class="glyphicon glyphicon-question-sign"></i></a>
+          <% end %>
+        </div>
+        <div class="checkbox">
+          <%= f.label :update_directory do %>
+            <%= f.check_box :update_directory %>
+            Refresh directory info
+            <a href="#" id="refresh_directory_help" data-toggle="popover" data-content="The information displayed in your profile comes from <%=institution_name %>'s central directory (LDAP) and is cached by <%=application_name %>.  If you have updated that information and don't see those changes in your <%=application_name %> profile, check the box and save your profile." data-original-title="Refresh Directory Info"><i class="glyphicon glyphicon-question-sign"></i></a>
+          <% end %>
+        </div>
       </div>
-      <div class="checkbox">
-        <%= f.label :update_directory do %>
-          <%= f.check_box :update_directory %>
-          Refresh directory info
-          <a href="#" id="refresh_directory_help" data-toggle="popover" data-content="The information displayed in your profile comes from <%=institution_name %>'s central directory (LDAP) and is cached by <%=application_name %>.  If you have updated that information and don't see those changes in your <%=application_name %> profile, check the box and save your profile." data-original-title="Refresh Directory Info"><i class="glyphicon glyphicon-question-sign"></i></a>
-        <% end %>
+    </div><!-- .form-group -->
+  </div><!-- col -->
+</div><!-- row -->
+
+<div class="row">
+  <div class="col-md-5"> <!-- identity -->
+    <div class="form-group">
+      <%= f.label :first_name, 'First name', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :first_name, class: "form-control" %>
+         <span id="helpBlock" class="help-block">(include any middle names or initials here, if desired)</span>
       </div>
-    </div>
-  </div><!-- .form-group -->
+    </div><!-- .form-group -->
 
-  <% if Sufia.config.arkivo_api %>
-    <%= render partial: 'zotero', locals: { f: f, user: @user } %>
-  <% end %>
+    <div class="form-group">
+      <%= f.label :last_name, 'Last name', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :last_name, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
 
-  <div class="form-group">
-    <%= f.label :twitter_handle, '<i class="fa fa-twitter"></i> Twitter Handle'.html_safe, class: 'col-xs-4 control-label' %>
-    <div class="col-xs-8">
-       <%= f.text_field :twitter_handle, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
+    <div class="form-group">
+      <%= f.label :title, 'Job title', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :title, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
 
-  <div class="form-group">
-    <%= f.label :facebook_handle, '<i class="fa fa-facebook"></i> Facebook Handle'.html_safe, class: 'col-xs-4 control-label' %>
-    <div class="col-xs-8">
-       <%= f.text_field :facebook_handle, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
+    <div class="form-group">
+      <%= f.label :department, 'Department', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :department, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
 
-  <div class="form-group">
-    <%= f.label :googleplus_handle, '<i class="fa fa-google-plus"></i> Google+ Handle'.html_safe, class: 'col-xs-4 control-label' %>
-    <div class="col-xs-8">
-       <%= f.text_field :googleplus_handle, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
+    <div class="form-group">
+      <%= f.label :uc_affiliation, 'UC affiliation', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :uc_affiliation, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
 
-  <%= render 'trophy_edit', trophies: @trophies %>
+    </div><!-- col -->
 
+    <div class="col-md-5"> <!-- contact -->
+
+    <div class="form-group">
+      <%= f.label :email, 'Email', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :email, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <div class="form-group">
+      <%= f.label :alternate_email, 'Alternate email', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :alternate_email, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <div class="form-group">
+      <%= f.label :telephone, 'Campus phone number', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :telephone, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <div class="form-group">
+      <%= f.label :alternate_phone_number, 'Alternate phone number', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :alternate_phone_number, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <div class="form-group">
+      <%= f.label :website, 'Personal webpage', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :website, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <div class="form-group">
+      <%= f.label :blog, 'Blog', class: 'col-xs-4 control-label' %>
+      <div class="col-xs-8">
+         <%= f.text_field :blog, class: "form-control" %>
+      </div>
+    </div><!-- .form-group -->
+
+    <%= render 'trophy_edit', trophies: @trophies %>
+  </div><!-- col -->
+</div><!-- row -->
   <%= f.button '<i class="glyphicon glyphicon-save"></i> Save Profile'.html_safe, type: 'submit', class: "btn btn-primary" %>
 <% end %>
-
-<%= render 'dashboard/_index_partials/proxy_rights', user: @user %>
-
-<div class="orcid-section">
-  <div class="well">
+<div class='row'>
+  <div class='pull-left'>
+    <%= render 'dashboard/_index_partials/proxy_rights', user: @user %>
+  </div>
+</div>
+<div class="row orcid-section">
+  <div class="col-md-5 well">
     <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
       <% status_processor.call(current_user) do |on| %>
-          <% on.authenticated_connection do |profile| %>
-          <% end %>
-    <% end %>
+        <% on.authenticated_connection do |profile| %>
+        <% end %>
+      <% end %>
     <%= render partial: 'orcid/profile_connections/orcid_connector', locals: {default_search_text: current_user.name } %>
   </div>
 </div>
-

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -40,12 +40,12 @@
     <dd><%= user.chat_id %></dd>
   <% end %>
 
-  <% if user.website %>
+  <% if user.website.present? %>
     <dt><i class="glyphicon glyphicon-globe"></i> Website(s)</dt>
     <dd><%= iconify_auto_link(user.website) %></dd>
   <% end %>
 
-  <% if user.title %>
+  <% if user.title.present? %>
     <dt>Title</dt>
     <dd><%= user.title %></dd>
   <% end %>
@@ -55,7 +55,7 @@
     <dd><%= user.admin_area %></dd>
   <% end %>
 
-  <% if user.department %>
+  <% if user.department.present? %>
     <dt>Department</dt>
     <dd><%= user.department %></dd>
   <% end %>
@@ -75,7 +75,7 @@
     <dd><%= user.affiliation %></dd>
   <% end %>
 
-  <% if user.telephone %>
+  <% if user.telephone.present? %>
     <dt><i class="glyphicon glyphicon-earphone"></i> Telephone</dt>
     <dd><%= link_to_telephone(user) %></dd>
   <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,8 @@
+<h1 class="col-sm-12">Edit Profile</h1>
+<div class="col-xs-12 col-sm-12 profile">
+  <%= render 'edit_primary' %>
+</div>
+
+<div class="col-xs-12 col-sm-offset-1 col-sm-6 profile">
+  <%= render 'edit_secondary' %>
+</div>

--- a/db/migrate/20170207170926_add_fields_to_user.rb
+++ b/db/migrate/20170207170926_add_fields_to_user.rb
@@ -1,0 +1,8 @@
+class AddFieldsToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :alternate_phone_number, :string
+    add_column :users, :blog, :string
+    add_column :users, :uc_affiliation, :string
+    add_column :users, :alternate_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118174508) do
+ActiveRecord::Schema.define(version: 20170207170926) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -583,6 +583,10 @@ ActiveRecord::Schema.define(version: 20170118174508) do
     t.string   "zotero_userid"
     t.string   "first_name"
     t.string   "last_name"
+    t.string   "alternate_phone_number"
+    t.string   "blog"
+    t.string   "uc_affiliation"
+    t.string   "alternate_email"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/features/proxy_spec.rb
+++ b/spec/features/proxy_spec.rb
@@ -13,7 +13,7 @@ describe 'proxy', type: :feature do
       click_link "Edit Your Profile"
       expect(first("td.depositor-name")).to be_nil
       create_proxy_using_partial(second_user)
-      expect(page).to have_css('td.depositor-name', text: second_user.user_key)
+      expect(page).to have_css('td.depositor-name', text: second_user.name)
     end
   end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -15,6 +15,24 @@ describe "User Profile", type: :feature do
       expect(page).to have_content('Edit Your Profile')
       expect(page).to have_content('View Contributors')
     end
+  end
+
+  context 'when editing user' do
+    it 'renders identity and contact fields' do
+      visit profile_path
+      click_link('Edit Your Profile', match: :first)
+      expect(page).to have_field('First name', with: user.first_name)
+      expect(page).to have_field('Last name', with: user.last_name)
+      expect(page).to have_field('Job title')
+      expect(page).to have_field('Department')
+      expect(page).to have_field('UC affiliation')
+      expect(page).to have_field('Email', with: user.email)
+      expect(page).to have_field('Alternate email')
+      expect(page).to have_field('Campus phone number')
+      expect(page).to have_field('Alternate phone number')
+      expect(page).to have_field('Personal webpage')
+      expect(page).to have_field('Blog')
+    end
 
     it 'renders ORCID connector' do
       visit profile_path
@@ -74,10 +92,10 @@ describe "User Profile", type: :feature do
     it 'page should be editable' do
       visit profile_path
       click_link 'Edit Your Profile'
-      fill_in 'user_twitter_handle', with: 'curatorOfData'
+      fill_in 'Campus phone number', with: '513-867-5309'
       click_button 'Save Profile'
       expect(page).to have_content 'Your profile has been updated'
-      expect(page).to have_link('curatorOfData', href: 'http://twitter.com/curatorOfData')
+      expect(page).to have_link('513-867-5309', href: 'wtai://wp/mc;513-867-5309')
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,4 +44,50 @@ describe User do
       end
     end
   end
+
+  shared_examples "user with name:" do |attrib|
+    describe "#name_for_works" do
+      subject { described_class.new }
+
+      context "with first_name and last_name set" do
+        before do
+          subject.first_name = "Lucy"
+          subject.last_name = "Bearcat"
+        end
+
+        it "returns the name" do
+          expect(subject.send(attrib)).to eq("Lucy Bearcat")
+        end
+      end
+
+      context "with first_name blank and last_name set" do
+        before do
+          subject.last_name = "Bearcat"
+        end
+
+        it "returns the name" do
+          expect(subject.send(attrib)).to eq(subject.user_key)
+        end
+      end
+
+      context "with first_name set and last_name blank" do
+        before do
+          subject.first_name = "Lucy"
+        end
+
+        it "returns the name" do
+          expect(subject.send(attrib)).to eq(subject.user_key)
+        end
+      end
+
+      context "with first_name and last_name blank set" do
+        it "returns the name" do
+          expect(subject.send(attrib)).to eq(subject.user_key)
+        end
+      end
+    end
+  end
+
+  it_behaves_like "user with name:", :display_name
+  it_behaves_like "user with name:", :name
 end


### PR DESCRIPTION
Fixes #879 

Add user attributes, form-fields, and layout tweaks to line up with profile views on curate.

Changes proposed in this pull request:
* Add attributes :alternate_phone_number, :blog, :uc_affiliation, and :alternate_email to User.
* Add/hide sufia profile fields to conform to curate profile.
* Override sufia profile view partials for 2-column edit form.
* Add associated specs.

![screencapture-localhost-3000-users-crowesn-gmail-dot-com-edit-1486565248283](https://cloud.githubusercontent.com/assets/1069588/22742753/ee13907a-ede5-11e6-929e-da17f62ca74d.png)

