### PR TITLE
Bundle update all gems (Scholar 2.x)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,23 @@ GIT
       rest-client (~> 1.7.3)
 
 GIT
+  remote: git://github.com/uclibs/orcid.git
+  revision: 956ea6f02b8bf614e0a8425f79cb3f16b51ee99d
+  specs:
+    orcid (0.9.1)
+      devise-multi_auth (~> 0.1)
+      email_validator
+      figaro
+      hashie (= 3.4.6)
+      mappy
+      nokogiri (= 1.6.8)
+      omniauth-oauth2 (< 1.4)
+      omniauth-orcid (= 0.6)
+      railties (~> 4.0)
+      simple_form
+      virtus
+
+GIT
   remote: https://github.com/uclibs/browse-everything.git
   revision: 8c0db2a476cce08210da2a67a2c3bddf284271c7
   ref: 8c0db2a476cce08210da2a67a2c3bddf284271c7
@@ -68,21 +85,6 @@ GIT
       sufia-models (~> 3.4.0)
       virtus
 
-PATH
-  remote: ../orcid-uclibs
-  specs:
-    orcid (0.9.1)
-      devise-multi_auth (~> 0.1)
-      email_validator
-      figaro
-      mappy
-      nokogiri (= 1.6.8)
-      omniauth-oauth2 (< 1.4)
-      omniauth-orcid (= 0.6)
-      railties (~> 4.0)
-      simple_form
-      virtus
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -120,7 +122,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.17.0)
+    activerecord-import (0.17.1)
       activerecord (>= 3.2)
     activeresource (4.1.0)
       activemodel (~> 4.0)
@@ -174,7 +176,7 @@ GEM
     builder (3.1.4)
     byebug (9.0.6)
     cancan (1.6.10)
-    capybara (2.11.0)
+    capybara (2.12.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -189,7 +191,7 @@ GEM
       rails (~> 4.0.13)
       resque
       resque-scheduler
-    childprocess (0.5.9)
+    childprocess (0.6.1)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
     climate_control (0.1.0)
@@ -220,7 +222,7 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.5.0)
       devise
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     dropbox-sdk (1.6.5)
       json
     email_validator (1.6.0)
@@ -241,7 +243,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.11.0)
+    faraday_middleware (0.11.0.1)
       faraday (>= 0.7.4, < 1.0)
     fastercsv (1.5.5)
     feedjira (2.1.0)
@@ -324,7 +326,7 @@ GEM
       hydra-access-controls (= 6.4.2)
       hydra-core (= 6.4.2)
       rails (>= 3.2.6)
-    i18n (0.7.0)
+    i18n (0.8.0)
     ice_nine (0.11.2)
     jbuilder (1.5.3)
       activesupport (>= 3.0.0)
@@ -405,7 +407,7 @@ GEM
       mediashelf-loggable
       nokogiri (>= 1.4.2)
       solrizer (~> 3.1.0)
-    omniauth (1.3.2)
+    omniauth (1.4.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
     omniauth-oauth2 (1.3.1)
@@ -430,7 +432,7 @@ GEM
       cocaine (~> 0.5.0)
       mime-types
     pkg-config (1.1.7)
-    poltergeist (1.12.0)
+    poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -470,10 +472,10 @@ GEM
     rdf-xsd (1.1.2)
       rdf (~> 1.1)
     rdoc (4.3.0)
-    redis (3.3.2)
+    redis (3.3.3)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    resque (1.26.0)
+    resque (1.27.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -529,7 +531,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    rufus-scheduler (3.3.2)
+    rufus-scheduler (3.3.3)
       tzinfo
     sass (3.2.19)
     sass-rails (4.0.5)
@@ -552,7 +554,7 @@ GEM
     simple_form (3.0.4)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    sinatra (1.4.7)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
@@ -618,9 +620,9 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.6)
+    warden (1.2.7)
       rack (>= 1.0)
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xml-simple (1.1.5)
@@ -677,4 +679,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.3


### PR DESCRIPTION
activerecord-import 0.17.1 (was 0.17.0)
capybara 2.12.0 (was 2.11.0)
childprocess 0.6.1 (was 0.5.9)
diff-lcs 1.3 (was 1.2.5)
faraday_middleware 0.11.0.1 (was 0.11.0)
i18n 0.8.0 (was 0.7.0)
omniauth 1.4.1 (was 1.3.2)
orcid 0.9.1 (new)
poltergeist 1.13.0 (was 1.12.0)
redis 3.3.3 (was 3.3.2)
resque 1.27.0 (was 1.26.0)
rufus-scheduler 3.3.3 (was 3.3.2)
sinatra 1.4.8 (was 1.4.7)
warden 1.2.7 (was 1.2.6)
websocket-driver 0.6.5 (was 0.6.4)