### PR TITLE
Implements title_sort in catalog and dashboard

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -12,6 +12,10 @@ class CatalogController < ApplicationController
     solr_name('system_create', :stored_sortable, type: :date)
   end
 
+  def self.title_field
+    solr_name('sort_title', :stored_sortable, type: :string)
+  end
+
   def self.modified_field
     solr_name('system_modified', :stored_sortable, type: :date)
   end
@@ -271,6 +275,8 @@ class CatalogController < ApplicationController
     config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
     config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
     config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{title_field} asc", label: "title A-Z"
+    config.add_sort_field "#{title_field} desc", label: "title Z-A"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/indexers/curation_concerns/collection_indexer.rb
+++ b/app/indexers/curation_concerns/collection_indexer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module CurationConcerns
+  class CollectionIndexer < Hydra::PCDM::CollectionIndexer
+    include IndexesThumbnails
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+        # Makes Collections show under the "Collections" tab
+        Solrizer.set_field(solr_doc, 'generic_type', 'Collection', :facetable)
+        # Index the size of the collection in bytes
+        solr_doc[Solrizer.solr_name(:bytes, STORED_LONG)] = object.bytes
+        solr_doc['thumbnail_path_ss'] = thumbnail_path
+        Solrizer.insert_field(solr_doc, 'sort_title', sortable_title(object.title.first), :stored_sortable) if object.title && !object.title.empty?
+
+        object.in_collections.each do |col|
+          (solr_doc['member_of_collection_ids_ssim'] ||= []) << col.id
+          (solr_doc['member_of_collections_ssim'] ||= []) << col.first_title
+        end
+      end
+    end
+
+    private
+
+      def sortable_title(title)
+        unless title.nil?
+          cleaned_title = title.sub(/^\s+/i, "") # remove leading spaces
+          cleaned_title.gsub!(/[^\w\s]/, "") # remove punctuation; preserve spaces and A-z 0-9
+          cleaned_title.gsub!(/\s{2,}/, " ") # remove multiple spaces
+          cleaned_title.sub!(/^(a |an |the )/i, "") # remove leading english articles
+          cleaned_title.upcase! # upcase everything
+          add_leading_zeros_to cleaned_title
+        end
+      end
+
+      def add_leading_zeros_to(title)
+        leading_number = title.match(/^\d+/)
+        return title if leading_number.nil?
+        title.sub(/^\d+/, leading_number[0].rjust(20, "0"))
+      end
+  end
+end

--- a/app/indexers/sufia/work_indexer.rb
+++ b/app/indexers/sufia/work_indexer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Sufia
+  class WorkIndexer < CurationConcerns::WorkIndexer
+    self.thumbnail_path_service = Sufia::WorkThumbnailPathService
+    def generate_solr_document
+      super.tap do |solr_doc|
+        # This enables us to return a Work when we have a FileSet that matches
+        # the search query.  While at the same time allowing us not to return Collections
+        # when a work in the collection matches the query.
+        solr_doc[Solrizer.solr_name('file_set_ids', :symbol)] = solr_doc[Solrizer.solr_name('member_ids', :symbol)]
+        solr_doc[Solrizer.solr_name('resource_type', :facetable)] = object.resource_type
+
+        admin_set_label = object.admin_set.to_s
+        solr_doc[Solrizer.solr_name('admin_set', :facetable)] = admin_set_label
+        solr_doc[Solrizer.solr_name('admin_set', :stored_searchable)] = admin_set_label
+        Solrizer.insert_field(solr_doc, 'sort_title', sortable_title(object.title.first), :stored_sortable) if object.title && !object.title.empty?
+      end
+    end
+
+    private
+
+      def sortable_title(title)
+        unless title.nil?
+          cleaned_title = title.sub(/^\s+/i, "") # remove leading spaces
+          cleaned_title.gsub!(/[^\w\s]/, "") # remove punctuation; preserve spaces and A-z 0-9
+          cleaned_title.gsub!(/\s{2,}/, " ") # remove multiple spaces
+          cleaned_title.sub!(/^(a |an |the )/i, "") # remove leading english articles
+          cleaned_title.upcase! # upcase everything
+          add_leading_zeros_to cleaned_title
+        end
+      end
+
+      def add_leading_zeros_to(title)
+        leading_number = title.match(/^\d+/)
+        return title if leading_number.nil?
+        title.sub(/^\d+/, leading_number[0].rjust(20, "0"))
+      end
+  end
+end

--- a/spec/features/sort_dashboard_spec.rb
+++ b/spec/features/sort_dashboard_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'dashboard works sorting', type: :feature do
+  let(:user) { FactoryGirl.create(:user) }
+
+  let!(:work1) { create(:work, title: ["Alpha Kong"], user: user) }
+  let!(:work2) { create(:work, title: ["Zeta Kong"], user: user) }
+
+  before do
+    sign_in user
+    visit "/dashboard/works"
+  end
+
+  it "allows changing sort order" do
+    find(:xpath, "//select[@id='sort']/option[contains(., 'title')][contains(@value, 'asc')]") \
+      .select_option
+    click_button('Refresh')
+    expect(page).to have_css("#document_#{work1.id}")
+    expect(page).to have_css("#document_#{work2.id}")
+    expect(page.body.index("id=\"document_#{work1.id}")).to be < page.body.index("id=\"document_#{work2.id}")
+
+    find(:xpath, "//select[@id='sort']/option[contains(., 'title')][contains(@value, 'desc')]") \
+      .select_option
+    click_button('Refresh')
+    expect(page).to have_css("#document_#{work1.id}")
+    expect(page).to have_css("#document_#{work2.id}")
+    expect(page.body.index("id=\"document_#{work2.id}")).to be < page.body.index("id=\"document_#{work1.id}")
+  end
+end

--- a/spec/indexers/curation_concerns/collection_indexer_spec.rb
+++ b/spec/indexers/curation_concerns/collection_indexer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe CurationConcerns::CollectionIndexer do
+  let(:indexer) { described_class.new(collection) }
+  let(:collection) { build(:collection) }
+  let(:col1id) { 'col1' }
+  let(:col2id) { 'col2' }
+  let(:col1title) { 'col1 title' }
+  let(:col2title) { 'col2 title' }
+  let(:col1) { double('collection') }
+  let(:col2) { double('collection') }
+
+  describe "#generate_solr_document" do
+    before do
+      allow(collection).to receive(:bytes).and_return(1000)
+      allow(collection).to receive(:in_collections).and_return([col1, col2])
+      allow(col1).to receive(:id).and_return(col1id)
+      allow(col2).to receive(:id).and_return(col2id)
+      allow(col1).to receive(:first_title).and_return(col1title)
+      allow(col2).to receive(:first_title).and_return(col2title)
+
+      allow(CurationConcerns::ThumbnailPathService).to receive(:call).and_return("/downloads/1234?file=thumbnail")
+    end
+
+    subject { indexer.generate_solr_document }
+
+    it "has required fields" do
+      expect(subject.fetch('generic_type_sim')).to eq ["Collection"]
+      expect(subject.fetch('bytes_lts')).to eq(1000)
+      expect(subject.fetch('thumbnail_path_ss')).to eq "/downloads/1234?file=thumbnail"
+      expect(subject.fetch('member_of_collection_ids_ssim')).to eq [col1id, col2id]
+      expect(subject.fetch('member_of_collections_ssim')).to eq [col1title, col2title]
+    end
+
+    it "removes leading spaces" do
+      collection.stub(:title).and_return ["  I start with a space"]
+      expect(subject.fetch('sort_title_ssi')).to eq("I START WITH A SPACE")
+    end
+
+    it "removes leading articles" do
+      collection.stub(:title).and_return(["The the is first"])
+      expect(subject.fetch('sort_title_ssi')).to eq("THE IS FIRST")
+    end
+
+    it "removes non alphanumeric characters" do
+      collection.stub(:title).and_return(["Title* 30! Sure& $has$ a &lot& of ^^^punctuation!!!!"])
+      expect(subject.fetch('sort_title_ssi')).to eq("TITLE 30 SURE HAS A LOT OF PUNCTUATION")
+    end
+
+    it "removes double spaces" do
+      collection.stub(:title).and_return(["This  title has      extra   spaces"])
+      expect(subject.fetch('sort_title_ssi')).to eq("THIS TITLE HAS EXTRA SPACES")
+    end
+
+    it "upcases everything" do
+      collection.stub(:title).and_return(["i should be uppercase"])
+      expect(subject.fetch('sort_title_ssi')).to eq("I SHOULD BE UPPERCASE")
+    end
+
+    it "adds leading 0s as needed" do
+      collection.stub(:title).and_return(["1) Is the first title"])
+      expect(subject.fetch('sort_title_ssi')).to eq("00000000000000000001 IS THE FIRST TITLE")
+    end
+  end
+end

--- a/spec/indexers/sufia/work_indexer_spec.rb
+++ b/spec/indexers/sufia/work_indexer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Sufia::WorkIndexer do
+  let(:indexer) { described_class.new(work) }
+  let(:work1title) { 'work1 title' }
+  let(:work2title) { 'work2 title' }
+
+  describe "#generate_solr_document" do
+    let(:work) { FactoryGirl.build(:generic_work) }
+    subject(:document) { indexer.generate_solr_document }
+
+    it "removes leading spaces" do
+      work.stub(:title).and_return(["  I start with a space"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("I START WITH A SPACE")
+    end
+
+    it "removes leading articles" do
+      work.stub(:title).and_return(["The the is first"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("THE IS FIRST")
+    end
+
+    it "removes non alphanumeric characters" do
+      work.stub(:title).and_return(["Title* 30! Sure& $has$ a &lot& of ^^^punctuation!!!!"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("TITLE 30 SURE HAS A LOT OF PUNCTUATION")
+    end
+
+    it "removes double spaces" do
+      work.stub(:title).and_return(["This  title has      extra   spaces"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("THIS TITLE HAS EXTRA SPACES")
+    end
+
+    it "upcases everything" do
+      work.stub(:title).and_return(["i should be uppercase"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("I SHOULD BE UPPERCASE")
+    end
+
+    it "adds leading 0s as needed" do
+      work.stub(:title).and_return(["1) Is the first title"])
+      expect(work.to_solr["sort_title_ssi"]).to eq("00000000000000000001 IS THE FIRST TITLE")
+    end
+  end
+end


### PR DESCRIPTION
Fixes #989 

Present short summary (50 characters or less)

Implements overwrites of the collection and work indexers to include a new solr field that will only select the first value from the title array and compare them for the catalog sort.

