### PR TITLE
Don't use clamav on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ bundler_args: --without headless debug
 
 before_install:
   - gem install bundler
-  - sudo apt-get update
-  - sudo apt-get install libclamav-dev libclamav6 clamav clamav-base clamav-daemon clamav-freshclam clamav-unofficial-sigs
-  - gem install clamav
-  - sudo freshclam  
   
 before_script:
   - "cp config/database.yml.sample config/database.yml"  


### PR DESCRIPTION
We removed the need for travis to run clamav a while back, but neglected to remove some set up from the .travis.yml that isn't needed anymore.