### PR TITLE
Pin RubyGems version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ cache:
     - "travis_phantomjs"
 
 before_install:
+  - gem update --system 2.6.10
+  - gem --version
   - gem install brakeman
   - gem install bundler
   - gem install rubocop -v '0.42.0'


### PR DESCRIPTION
This change to the travis config fixes a problem getting our tests to run.  Travis needs an updated version of rubygems to get past a bundler problem.