### PR TITLE
Pin down gems for stability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,13 +25,13 @@ gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
 # gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
-gem 'jquery-rails'
+gem 'jquery-rails', '3.1.4'
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks', '2.5.3'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 1.2'
+gem 'jbuilder', '1.5.3'
 
 group :doc do
   # bundle exec rake doc:rails generates the API under doc/api.
@@ -55,58 +55,58 @@ gem "kaminari", "0.15.1"
 
 gem "curate", git: "https://github.com/uclibs/curate.git", ref: "82447c79ce82036316dcba55af6343b906626c01"
 gem 'browse-everything', git: 'https://github.com/uclibs/browse-everything.git', ref: "8c0db2a476cce08210da2a67a2c3bddf284271c7"
-gem 'kaltura'
+gem 'kaltura', '0.1.1'
 
 
 #gem "clamav"
 gem "hydra-remote_identifier", github: "uclibs/hydra-remote_identifier", branch: "setting-status"
-gem "sitemap_generator"
+gem "sitemap_generator", '5.2.0'
 
 group :production do
-  gem 'exception_notification'
+  gem 'exception_notification', '4.2.1'
 end
 
 #change manager gem for automatic notification management, requires resque and resque-scheduler
-gem 'resque'
-gem 'resque-scheduler'
-gem 'change_manager'
+gem 'resque', '1.26.0'
+gem 'resque-scheduler', '4.3.0'
+gem 'change_manager', '1.0.0'
 
-gem "bootstrap-sass"
-gem "font-awesome-sass"
+gem "bootstrap-sass", '2.3.2.2'
+gem "font-awesome-sass", '4.7.0'
 gem "font-awesome-rails", "4.2.0.0"
 
-gem "devise"
-gem "devise-guests", "~> 0.3"
+gem "devise", '3.2.4'
+gem "devise-guests", "0.5.0"
 
 gem 'openseadragon', '0.1.0'
 
 group :development, :test do
-  gem 'sqlite3'
-  gem "jettywrapper", '~> 1.8.3'
+  gem 'sqlite3', '1.3.13'
+  gem "jettywrapper", '1.8.3'
   # gem 'debugger'
 end
 
 group :development do
-  gem "better_errors"
-  gem "binding_of_caller"
-  gem "quiet_assets"
+  gem "better_errors", "2.1.1"
+  gem "binding_of_caller", "0.7.2"
+  gem "quiet_assets", "1.1.0"
   # gem 'capistrano'
 end
 
 group :test do
-  gem 'factory_girl_rails', '~>4.2.0'
-  gem 'poltergeist'
-  gem 'rspec-html-matchers', '~>0.4'
-  gem 'rspec-rails', '~>2.14.0'
-  gem 'capybara', "~> 2.1"
-  gem 'show_me_the_cookies'
+  gem 'factory_girl_rails', '4.2.0'
+  gem 'poltergeist', '1.13.0'
+  gem 'rspec-html-matchers', '0.5.0'
+  gem 'rspec-rails', '~>2.14.2'
+  gem 'capybara', "2.12.0"
+  gem 'show_me_the_cookies', '3.1.0'
 #  gem 'vcr'
 #  gem 'webmock'
 #  gem 'database_cleaner', '< 1.1.0'
 end
 
-gem 'omniauth-openid'
-gem 'omniauth-shibboleth'
-gem 'feedjira'
+gem 'omniauth-openid', '1.0.1'
+gem 'omniauth-shibboleth', '1.2.1'
+gem 'feedjira', '2.1.0'
 
 gem 'rake', '11.2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     extlib (0.9.16)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.2.1)
+    factory_girl_rails (4.2.0)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
     faraday (0.10.1)
@@ -475,7 +475,7 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    resque (1.27.0)
+    resque (1.26.0)
       mono_logger (~> 1.0)
       multi_json (~> 1.0)
       redis-namespace (~> 1.3)
@@ -634,47 +634,47 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  better_errors
-  binding_of_caller
-  bootstrap-sass
+  better_errors (= 2.1.1)
+  binding_of_caller (= 0.7.2)
+  bootstrap-sass (= 2.3.2.2)
   browse-everything!
   byebug
-  capybara (~> 2.1)
-  change_manager
+  capybara (= 2.12.0)
+  change_manager (= 1.0.0)
   coffee-rails (~> 4.0.0)
   curate!
-  devise
-  devise-guests (~> 0.3)
+  devise (= 3.2.4)
+  devise-guests (= 0.5.0)
   devise-multi_auth!
-  exception_notification
-  factory_girl_rails (~> 4.2.0)
-  feedjira
+  exception_notification (= 4.2.1)
+  factory_girl_rails (= 4.2.0)
+  feedjira (= 2.1.0)
   font-awesome-rails (= 4.2.0.0)
-  font-awesome-sass
+  font-awesome-sass (= 4.7.0)
   hydra-remote_identifier!
-  jbuilder (~> 1.2)
-  jettywrapper (~> 1.8.3)
-  jquery-rails
-  kaltura
+  jbuilder (= 1.5.3)
+  jettywrapper (= 1.8.3)
+  jquery-rails (= 3.1.4)
+  kaltura (= 0.1.1)
   kaminari (= 0.15.1)
   mysql2 (= 0.3.20)
-  omniauth-openid
-  omniauth-shibboleth
+  omniauth-openid (= 1.0.1)
+  omniauth-shibboleth (= 1.2.1)
   openseadragon (= 0.1.0)
   orcid!
-  poltergeist
-  quiet_assets
+  poltergeist (= 1.13.0)
+  quiet_assets (= 1.1.0)
   rails (= 4.0.13)
   rake (= 11.2.2)
-  resque
-  resque-scheduler
-  rspec-html-matchers (~> 0.4)
-  rspec-rails (~> 2.14.0)
+  resque (= 1.26.0)
+  resque-scheduler (= 4.3.0)
+  rspec-html-matchers (= 0.5.0)
+  rspec-rails (~> 2.14.2)
   sass-rails (~> 4.0.0)
   sdoc
-  show_me_the_cookies
-  sitemap_generator
-  sqlite3
+  show_me_the_cookies (= 3.1.0)
+  sitemap_generator (= 5.2.0)
+  sqlite3 (= 1.3.13)
   turbolinks (= 2.5.3)
   uglifier (>= 1.3.0)
 


### PR DESCRIPTION
A recent resque gem update caused a problem for Scholar 2.x.  In addition to pinning resque back to its previous version, I've also pinned most of the rest of the gems in the Gemfile to the versions currently specified in the Gemfile.lock.

This should provide some stability for us since our 2.x deploys will be few and far between going forward.