### PR TITLE
[WIP] Add and make rights field singular on all work types

### DIFF
--- a/app/forms/curation_concerns/article_form.rb
+++ b/app/forms/curation_concerns/article_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class ArticleForm < Sufia::Forms::WorkForm
     self.model_class = ::Article
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/dataset_form.rb
+++ b/app/forms/curation_concerns/dataset_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class DatasetForm < Sufia::Forms::WorkForm
     self.model_class = ::Dataset
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class DocumentForm < Sufia::Forms::WorkForm
     self.model_class = ::Document
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class EtdForm < Sufia::Forms::WorkForm
     self.model_class = ::Etd
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/image_form.rb
+++ b/app/forms/curation_concerns/image_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class ImageForm < Sufia::Forms::WorkForm
     self.model_class = ::Image
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/student_work_form.rb
+++ b/app/forms/curation_concerns/student_work_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class StudentWorkForm < Sufia::Forms::WorkForm
     self.model_class = ::StudentWork
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/app/forms/curation_concerns/video_form.rb
+++ b/app/forms/curation_concerns/video_form.rb
@@ -5,5 +5,13 @@ module CurationConcerns
   class VideoForm < Sufia::Forms::WorkForm
     self.model_class = ::Video
     self.terms += [:resource_type]
+
+    def self.multiple?(field)
+      if field.to_sym == :rights
+        false
+      else
+        super
+      end
+    end
   end
 end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -24,6 +24,7 @@ shared_examples 'work creation' do |work_class| # snake-case work type for strin
     check('agreement')
     click_on('Save')
     expect(page).to have_content('My Test Work')
+    expect(page).to have_content('Attribution-ShareAlike 4.0 International')
     expect(page).to have_content "Your files are being processed by Scholar@UC in the background."
   end
 end
@@ -51,6 +52,7 @@ shared_examples 'proxy work creation' do |work_class|
     click_on('Save')
     expect(page).to have_content('My Test Work')
     expect(page).to have_content "Your files are being processed by Scholar@UC in the background."
+    expect(page).to have_content('Attribution-ShareAlike 4.0 International')
     click_link('Dashboard')
     click_link('Shares')
     click_link('Works Shared with Me')


### PR DESCRIPTION
Fixes #1149 

Our fix to make rights field non-repeatable needs to be applied to all work types.
This bug was presenting :rights from persisting on any save action: :create and :edit.

Related: https://github.com/projecthydra/sufia/wiki/Customizing-Metadata#making-a-default-property-non-repeatable

``` ruby
    def self.multiple?(field)
      if field.to_sym == :rights
        false
      else
        super
      end
    end
```

Changes proposed in this pull request:
* override self.multiple? for :rights on all form objects
* add quick feature spec to check if license persists on creation
