### PR TITLE
Reinstate Google Analytics tracker on master

### DIFF
--- a/app/views/_analytics.html.erb
+++ b/app/views/_analytics.html.erb
@@ -1,0 +1,9 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-55594569-1', 'auto');
+  ga('send', 'pageview');
+</script>


### PR DESCRIPTION
This is a special PR that merges a commit directly into the (2.x) master branch.

Back when we made all of our Scholar 2.x/3.0 Github branch changes, we accidentally included an old commit from the 2.x-stable branch into master that shouldn't be there.  The commit removed our Google Analytics tracker from our 2.x-stable branch, but we wanted to keep in master (for production).  However the commit got copied into master and we lost our analytics tracker during our last deploy.

So this commit simply puts the tracker (view) directly back into our master branch without adding it to 2.x-stable.