### PR TITLE
Add dataset help notice

### DIFF
--- a/app/controllers/curation_concerns/datasets_controller.rb
+++ b/app/controllers/curation_concerns/datasets_controller.rb
@@ -10,5 +10,10 @@ module CurationConcerns
     include Scholar::WorksControllerBehavior
 
     self.curation_concern_type = Dataset
+
+    def new
+      super
+      flash[:notice] = "If you would like guidance on submitting a dataset, please read the #{view_context.link_to 'Documenting Data', '/documenting_data', target: '_blank'} help page."
+    end
   end
 end

--- a/spec/controllers/curation_concerns/datasets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/datasets_controller_spec.rb
@@ -4,7 +4,16 @@
 require 'rails_helper'
 
 RSpec.describe CurationConcerns::DatasetsController do
-  it "has tests" do
-    skip "Add your tests here"
+  let(:user) { FactoryGirl.create(:user) }
+
+  before do
+    sign_in user
+  end
+
+  describe '#new' do
+    it "sets flash message with help text" do
+      get :new
+      expect(flash[:notice]).to match('If you would like guidance on submitting a dataset, please read the <a target=\"_blank\" href=\"/documenting_data\">Documenting Data</a> help page.')
+    end
   end
 end


### PR DESCRIPTION
Fixes #1161 

set flash notice with help info specific to dataset worktype

Changes proposed in this pull request:
* dataset controller override with flash_notice
* add controller test for flash notice

<img width="1151" alt="screen shot 2017-02-23 at 11 27 00 am" src="https://cloud.githubusercontent.com/assets/1069588/23268371/831435fe-f9bb-11e6-8607-6030f8d2d193.png">

