### PR TITLE
install sidekiq and configs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -109,6 +109,10 @@ Style/RedundantSelf:
     - 'config/application.rb'
     - 'config/environments/test.rb'
 
+Style/DoubleNegation:
+  Exclude:
+    - 'config/environments/development.rb'
+
 Rails:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
+gem 'sidekiq'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,8 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.4)
+    connection_pool (2.2.1)
     coveralls (0.8.19)
       json (>= 1.8, < 3)
       simplecov (~> 0.12.0)
@@ -548,6 +549,8 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 4.2.0, < 6.0)
     rack (1.6.5)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -682,6 +685,11 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sidekiq (4.2.9)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -814,6 +822,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   selenium-webdriver
   shoulda-matchers (~> 3.1)
+  sidekiq
   solr_wrapper (>= 0.13)
   spring
   sqlite3

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = !!Sidekiq.server?
 
   # Do not eager load code on boot.
   config.eager_load = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,4 +77,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,8 @@ Rails.application.configure do
 
   config.exceptions_app = self.routes
 
+  config.active_job.queue_adapter = :inline
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'sidekiq/web'
 Rails.application.routes.draw do
   mount Orcid::Engine => "/orcid"
   mount BrowseEverything::Engine => '/browse'
@@ -6,6 +7,10 @@ Rails.application.routes.draw do
   mount Qa::Engine => '/authorities'
 
   mount Blacklight::Engine => '/'
+
+  authenticate :user, ->(u) { u.admin? } do
+    mount Sidekiq::Web => '/sidekiq'
+  end
 
   concern :searchable, Blacklight::Routes::Searchable.new
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+---
+:queues:
+  - default
+  - ingest
+  - event


### PR DESCRIPTION
Fixes #1039 

Decided to change the queueing backend from resque to Sidekiq as per Sufia's wiki documentation: https://github.com/projecthydra/sufia/wiki/Using-Resque-with-Sufia#note
Changes proposed in this pull request:
* Installing Sidekiq
* Running specs with jobs inline to avoid issues around RSpec.

To test:
* Create user in the application with email of `admin@example.com`. Admin users should be able to access sidekiq web panel at `/sidekiq` non admin users and unregistered users should not be able to access the panel.