### PR TITLE
Remove current_user helper from orcid/profile show partial

### DIFF
--- a/app/views/curate/people/show.html.erb
+++ b/app/views/curate/people/show.html.erb
@@ -59,9 +59,8 @@
           <% end %>
         <% end %>
       <% end %>
-
       <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for)
-                                   status_processor.call(current_user) do |on|
+                                   status_processor.call(@person.user) do |on|
                                    on.authenticated_connection do |profile| %>
                                    <dt class="attribute"><img alt="ORCID logo" src="http://orcid.org/sites/default/files/images/orcid_16x16.png" width="16" height="16" /> <%= "Orcid ID:" %></dt>
                                    <dd class="value"><%= link_to profile.orcid_profile_id, Orcid.url_for_orcid_id(profile.orcid_profile_id), { target: '_blank' } %></dd>


### PR DESCRIPTION
Fixes #1196 

Display orcid id from person object rather than current_user helper.

