### PR TITLE
[WIP] Selects first value of date_created when editing.

### DIFF
--- a/app/forms/curation_concerns/article_form.rb
+++ b/app/forms/curation_concerns/article_form.rb
@@ -28,6 +28,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -38,5 +39,10 @@ module CurationConcerns
     def description
       super.first || ""
     end
+
+    def date_created
+      super.first || ""
+    end
+
   end
 end

--- a/app/forms/curation_concerns/dataset_form.rb
+++ b/app/forms/curation_concerns/dataset_form.rb
@@ -26,6 +26,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -34,6 +35,10 @@ module CurationConcerns
     end
 
     def description
+      super.first || ""
+    end
+
+    def date_created
       super.first || ""
     end
   end

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -26,6 +26,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -34,6 +35,10 @@ module CurationConcerns
     end
 
     def description
+      super.first || ""
+    end
+
+    def date_created
       super.first || ""
     end
   end

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -27,6 +27,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -35,6 +36,10 @@ module CurationConcerns
     end
 
     def description
+      super.first || ""
+    end
+
+    def date_created
       super.first || ""
     end
   end

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -26,6 +26,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -34,6 +35,10 @@ module CurationConcerns
     end
 
     def description
+      super.first || ""
+    end
+
+    def date_created
       super.first || ""
     end
   end

--- a/app/forms/curation_concerns/image_form.rb
+++ b/app/forms/curation_concerns/image_form.rb
@@ -8,6 +8,7 @@ module CurationConcerns
     self.terms -= [:keyword, :source, :contributor]
     self.required_fields = [:title, :creator, :description, :rights]
 
+
     def secondary_terms
       [:date_created, :alternate_title, :genre, :subject, :geo_subject,
        :time_period, :language, :bibliographic_citation,
@@ -26,6 +27,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -36,5 +38,10 @@ module CurationConcerns
     def description
       super.first || ""
     end
+
+    def date_created
+      super.first || ""
+    end
+
   end
 end

--- a/app/forms/curation_concerns/student_work_form.rb
+++ b/app/forms/curation_concerns/student_work_form.rb
@@ -27,6 +27,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -37,5 +38,10 @@ module CurationConcerns
     def description
       super.first || ""
     end
-  end
+  
+    def date_created
+      super.first || ""
+    end
+
+   end
 end

--- a/app/forms/curation_concerns/video_form.rb
+++ b/app/forms/curation_concerns/video_form.rb
@@ -27,6 +27,7 @@ module CurationConcerns
       attrs = super
       attrs[:title] = Array(attrs[:title]) if attrs[:title]
       attrs[:description] = Array(attrs[:description]) if attrs[:description]
+      attrs[:date_created] = Array(attrs[:date_created]) if attrs[:date_created]
       attrs
     end
 
@@ -37,5 +38,10 @@ module CurationConcerns
     def description
       super.first || ""
     end
+
+    def date_created
+      super.first || ""
+    end
+ 
   end
 end


### PR DESCRIPTION
Fixes #1206

Present short summary (50 characters or less)

The forms need to treat the date_created as scalar verses multi-valued.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

Changes proposed in this pull request:
* 
* 
* 
