### PR TITLE
Remove resource-type select from batch upload

### DIFF
--- a/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/batch_uploads_controller_behavior.rb
@@ -61,7 +61,6 @@ module Sufia
         # ActionController::Parameters are not serializable, so cast to a hash
         BatchCreateJob.perform_later(current_user,
                                      params[:title].permit!.to_h,
-                                     params[:resource_type].permit!.to_h,
                                      params[:uploaded_files],
                                      attributes_for_actor.to_h.merge!(model: klass),
                                      log)

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class BatchCreateJob < ActiveJob::Base
+  queue_as :ingest
+
+  before_enqueue do |job|
+    log = job.arguments.last
+    log.pending_job(self)
+  end
+
+  # This copies metadata from the passed in attribute to all of the works that
+  # are members of the given upload set
+  # @param [User] user
+  # @param [Hash<String => String>] titles
+  # @param [Hash<String => String>] resource_types
+  # @param [Array<String>] uploaded_files Sufia::UploadedFile IDs
+  # @param [Hash] attributes attributes to apply to all works, including :model
+  # @param [BatchCreateOperation] log
+  def perform(user, titles, uploaded_files, attributes, log)
+    log.performing!
+    titles ||= {}
+    create(user, titles, uploaded_files, attributes, log)
+  end
+
+  private
+
+    def create(user, titles, uploaded_files, attributes, log)
+      model = attributes.delete(:model) || attributes.delete('model')
+      raise ArgumentError, 'attributes must include "model" => ClassName.to_s' unless model
+      uploaded_files.each do |upload_id|
+        title = [titles[upload_id]] if titles[upload_id]
+        attributes = attributes.merge(uploaded_files: [upload_id],
+                                      title: title)
+        child_log = CurationConcerns::Operation.create!(user: user,
+                                                        operation_type: "Create Work",
+                                                        parent: log)
+        CreateWorkJob.perform_later(user, model, attributes, child_log)
+      end
+    end
+end

--- a/app/views/sufia/uploads/_js_templates.html.erb
+++ b/app/views/sufia/uploads/_js_templates.html.erb
@@ -1,0 +1,125 @@
+<!-- The template to display files available for upload -->
+<script id="template-upload" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-upload fade">
+        <td>
+            <span class="preview"></span>
+        </td>
+        <td>
+            <p class="name">{%=file.name%}</p>
+            <strong class="error text-danger"></strong>
+        </td>
+        <td>
+            <p class="size">Processing...</p>
+            <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-success" style="width:0%;"></div></div>
+        </td>
+        <td>
+            {% if (!i && !o.options.autoUpload) { %}
+                <button class="btn btn-primary start" disabled>
+                    <i class="glyphicon glyphicon-upload"></i>
+                    <span>Start</span>
+                </button>
+            {% } %}
+            {% if (!i) { %}
+                <button class="btn btn-warning cancel">
+                    <i class="glyphicon glyphicon-ban-circle"></i>
+                    <span>Cancel</span>
+                </button>
+            {% } %}
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- function used by the following template -->
+<script type="text/javascript">
+  function setAllResourceTypes(resourceTypeId) {
+    var firstResourceType = $("#resource_type_" + resourceTypeId.toString())[0];
+    var selected_options = [];
+    for (var i = 0; i < firstResourceType.length; i++) {
+      if (firstResourceType.options[i].selected) {
+        selected_options.push(firstResourceType.options[i].value);
+      }
+    }
+    $(".resource_type_dropdown").each(function(index, element) {
+      for(var i=0; i< this.length; i++) {
+        this.options[i].selected =
+          $.inArray(this.options[i].value, selected_options) > -1 ? true : false;
+      }
+    });
+  }
+</script>
+
+<!-- The template to display files available for download -->
+<script id="batch-template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+        <td>
+          <div class="row">
+            <div class="col-sm-6 name">
+                <span>{%=file.name%}</span>
+                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+            </div>
+            <div class="col-sm-6">
+              {% if (file.error) { %}
+                  <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+              {% } %}
+              <span class="size">{%=o.formatFileSize(file.size)%}</span>
+              <button class="btn btn-danger delete pull-right" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                  <i class="glyphicon glyphicon-trash"></i>
+                  <span>Delete</span>
+              </button>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-sm-12 form-horizontal">
+              <div class="form-group">
+                <label for="title_{%=file.id%}" class="col-sm-5 control-label">Display label</label>
+                <div class="col-sm-7">
+                  <input type="text" class="form-control" name="title[{%=file.id%}]" id="title_{%=file.id%}" value="{%=file.name%}">
+                </div>
+              </div>
+            </div>
+          </div>
+        </td>
+    </tr>
+{% } %}
+</script>
+
+<!-- Simpler display of files available for download. Originally from curation_concerns/base/_form_files -->
+<!-- TODO: further consolidate with template-download above -->
+<script id="template-download" type="text/x-tmpl">
+{% for (var i=0, file; file=o.files[i]; i++) { %}
+    <tr class="template-download fade">
+        <td>
+            <span class="preview">
+                {% if (file.thumbnailUrl) { %}
+                    <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" data-gallery><img src="{%=file.thumbnailUrl%}"></a>
+                {% } %}
+            </span>
+        </td>
+        <td>
+            <p class="name">
+                {% if (file.url) { %}
+                    <a href="{%=file.url%}" title="{%=file.name%}" download="{%=file.name%}" {%=file.thumbnailUrl?'data-gallery':''%}>{%=file.name%}</a>
+                {% } else { %}
+                    <span>{%=file.name%}</span>
+                {% } %}
+                <input type="hidden" name="uploaded_files[]" value="{%=file.id%}">
+            </p>
+            {% if (file.error) { %}
+                <div><span class="label label-danger">Error</span> {%=file.error%}</div>
+            {% } %}
+        </td>
+        <td>
+            <span class="size">{%=o.formatFileSize(file.size)%}</span>
+        </td>
+        <td>
+            <button class="btn btn-danger delete" data-type="{%=file.deleteType%}" data-url="{%=file.deleteUrl%}"{% if (file.deleteWithCredentials) { %} data-xhr-fields='{"withCredentials":true}'{% } %}>
+                <i class="glyphicon glyphicon-trash"></i>
+                <span>Delete</span>
+            </button>
+        </td>
+    </tr>
+{% } %}
+</script>

--- a/spec/factories/operations.rb
+++ b/spec/factories/operations.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :operation, class: CurationConcerns::Operation do
+    operation_type "Test operation"
+
+    trait :failing do
+      status CurationConcerns::Operation::FAILURE
+    end
+
+    trait :pending do
+      status CurationConcerns::Operation::PENDING
+    end
+
+    trait :successful do
+      status CurationConcerns::Operation::SUCCESS
+    end
+
+    factory :batch_create_operation, class: Sufia::BatchCreateOperation do
+      operation_type "Batch Create"
+    end
+  end
+end

--- a/spec/jobs/batch_create_job_spec.rb
+++ b/spec/jobs/batch_create_job_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe BatchCreateJob do
+  let(:user) { create(:user) }
+  let(:log)  { create(:batch_create_operation, user: user) }
+
+  before do
+    allow(CharacterizeJob).to receive(:perform_later)
+    allow(CurationConcerns.config.callback).to receive(:run)
+    allow(CurationConcerns.config.callback).to receive(:set?).with(:after_batch_create_success).and_return(true)
+    allow(CurationConcerns.config.callback).to receive(:set?).with(:after_batch_create_failure).and_return(true)
+  end
+
+  describe "#perform" do
+    let(:upload1) { Sufia::UploadedFile.create(user: user, file: File.open(fixture_path + '/world.png')) }
+    let(:upload2) { Sufia::UploadedFile.create(user: user, file: File.open(fixture_path + '/image.jp2')) }
+    let(:title)          { { upload1.id.to_s => 'File One', upload2.id.to_s => 'File Two' } }
+    let(:metadata)       { { keyword: [], model: 'GenericWork' } }
+    let(:uploaded_files) { [upload1.id.to_s, upload2.id.to_s] }
+    # let(:errors) { double(full_messages: "It's broke!") }
+    let(:work)   { build(:generic_work) }
+    let(:actor)  { double(curation_concern: work) }
+
+    subject do
+      described_class.perform_later(user,
+                                    title,
+                                    uploaded_files,
+                                    metadata,
+                                    log)
+    end
+
+    it "updates work metadata" do
+      expect(CurationConcerns::CurationConcern).to receive(:actor).with(an_instance_of(GenericWork), user).and_return(actor).twice
+      expect(actor).to receive(:create).with(keyword: [], title: ['File One'], uploaded_files: ['1']).and_return(true)
+      expect(actor).to receive(:create).with(keyword: [], title: ['File Two'], uploaded_files: ['2']).and_return(true)
+      expect(CurationConcerns.config.callback).to receive(:run).with(:after_batch_create_success, user)
+      subject
+      expect(log.status).to eq 'pending'
+      expect(log.reload.status).to eq 'success'
+    end
+
+    context "when permissions_attributes are passed" do
+      let(:permissions) { { 'permissions_attributes' => [{ 'type' => 'group', 'name' => 'public', 'access' => 'read' }] } }
+      let(:metadata) { super().merge(permissions) }
+      it "sets the groups" do
+        subject
+        expect(GenericWork.last.read_groups).to include "public"
+      end
+    end
+
+    context "when visibility is passed" do
+      let(:metadata) { super().merge('visibility' => 'open') }
+      it "sets public read access" do
+        subject
+        expect(GenericWork.last.reload.read_groups).to eq ['public']
+      end
+    end
+
+    context "when user does not have permission to edit all of the works" do
+      it "sends the failure message" do
+        expect(CurationConcerns::CurationConcern).to receive(:actor).and_return(actor).twice
+        expect(actor).to receive(:create).and_return(true, false)
+        expect(CurationConcerns.config.callback).to receive(:run).with(:after_batch_create_failure, user)
+        subject
+        expect(log.reload.status).to eq 'failure'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1123 

Remove :resource_type attribute and form select from batch creation form.

Changes proposed in this pull request:
* Add batch_create_job sufia override
* Override form js to remove resource_type select element
* Add specs
