### PR TITLE
hide orcid sign-in link and add password reset label

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,20 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Reset/Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+

--- a/spec/features/user_signin_spec.rb
+++ b/spec/features/user_signin_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'User siginin', type: :feature do
+  context 'when visiting login page' do
+    before do
+      visit user_session_path
+    end
+
+    it "shows forgot/reset pass link" do
+      expect(page).to have_content('Reset/Forgot your password')
+    end
+
+    it "does not show orcid signin link" do
+      expect(page).not_to have_content('Orcid')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1174 

<img width="219" alt="screen shot 2017-03-07 at 11 21 08 am" src="https://cloud.githubusercontent.com/assets/1069588/23666444/0bbd8196-0329-11e7-9f69-d96b0ad6174d.png">

Changes proposed in this pull request:
* Add devise override: app/views/devise/shared/_links.html.erb
* Remove login with orcid link
* Change forgot password link text to "Reset/Forgot your password?"
