### PR TITLE
Add proxy help statement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,10 +458,6 @@ GEM
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    kaminari-actionview (1.0.1)
-      actionview
-      kaminari-core (= 1.0.1)
-    kaminari-core (1.0.1)
     kaminari_route_prefix (0.0.2)
       kaminari (~> 0.16)
     ldp (0.6.4)

--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -154,3 +154,7 @@ div.profile a.btn-primary {
 .icon-doi {
   @extend .fa-link;
 }
+
+#user-edit-proxy {
+  margin-top: 30px;
+}

--- a/app/views/dashboard/_index_partials/_proxy_rights.html.erb
+++ b/app/views/dashboard/_index_partials/_proxy_rights.html.erb
@@ -1,0 +1,28 @@
+<div class="clearfix proxy-rights">
+<div class="row">
+  <div class="col-xs-12">
+   <%= t("sufia.dashboard.help_statement_html") %>
+  </div>
+</div>
+<div class="row">
+  <div class="col-xs-6 proxy-search">
+    <h4><%= t("sufia.dashboard.authorize_proxies") %></h4>
+    <label class="sr-only" for="user"><%= t("sufia.dashboard.proxy_user") %></label>
+    <%= hidden_field_tag :user, nil, data: { grantor: current_user.to_param } %>
+  </div>
+
+  <div class="col-xs-6">
+    <h4><%= t("sufia.dashboard.current_proxies") %></h4>
+    <table class="table table-condensed table-striped" id="authorizedProxies">
+      <tbody>
+      <% user.can_receive_deposits_from.each do |depositor| %>
+          <tr><td class="depositor-name"><%= depositor.name %></td>
+            <td><%= link_to(sufia.user_depositor_path(user, depositor), method: :delete, class: "remove-proxy-button") do %>
+                  <i class="glyphicon glyphicon-remove"></i><% end %>
+            </td></tr>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+</div>

--- a/app/views/users/_edit_primary.html.erb
+++ b/app/views/users/_edit_primary.html.erb
@@ -118,8 +118,11 @@
   <%= f.button '<i class="glyphicon glyphicon-save"></i> Save Profile'.html_safe, type: 'submit', class: "btn btn-primary" %>
 <% end %>
 <div class='row'>
-  <div class='pull-left'>
+  <div id="user-edit-proxy" class='pull-left panel panel-default'>
+    <div class="panel-heading">Manage Proxies</div>
+    <div class="panel-body">
     <%= render 'dashboard/_index_partials/proxy_rights', user: @user %>
+    </div>
   </div>
 </div>
 <div class="row orcid-section">

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -10,6 +10,7 @@ en:
     footer:
       copyright_html: "<strong>Copyright &copy; University of Cincinnati</strong> Licensed under the Apache License, Version 2.0"
     dashboard:
+      help_statement_html:      "<strong>Please Note:</strong> Your proxies can do anything on your behalf in Scholar@UC. Be selective in who you give proxy access. Proxy accounts in Scholar@UC work very similar to <a href=\"https://support.google.com/mail/answer/138350?hl=en\">delegate accounts in Gmail</a>. If you authorize a proxy they can view, edit, or delete all of your existing works and files. Proxies can also create new works and upload files on your behalf. The proxy relationship can be revoked by the owner at any time. Use work-specific editors for more fine-grained access control."
       view_collections:         "View My Collections"
       create_collection:        "Create Collection"
       view_files:               "View My Files"

--- a/spec/features/display_dashboard_spec.rb
+++ b/spec/features/display_dashboard_spec.rb
@@ -27,5 +27,10 @@ describe "The Dashboard", type: :feature do
       expect(page).to have_content "My Highlights"
       expect(page).to have_content "Works Shared with Me"
     end
+
+    it "shows proxy information" do
+      expect(page).to have_content "Manage Proxies"
+      expect(page).to have_content "Please Note: Your proxies can do anything on your behalf in Scholar@UC."
+    end
   end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -34,6 +34,13 @@ describe "User Profile", type: :feature do
       expect(page).to have_field('Blog')
     end
 
+    it 'renders manage proxies partial' do
+      visit profile_path
+      click_link('Edit Profile', match: :first)
+      expect(page).to have_content('Manage Proxies')
+      expect(page).to have_content("Please Note: Your proxies can do anything on your behalf in Scholar@UC.")
+    end
+
     it 'renders ORCID connector' do
       visit profile_path
       click_link('Edit Profile', match: :first)


### PR DESCRIPTION
Fixes #1173 

Add proxy help statement.

Changes proposed in this pull request:
* Add sufia override: app/views/dashboard/_index_partials/proxy_rights.html.erb
* Add sufia local with help message
* Add panel around proxy control in user edit view

![screen shot 2017-03-08 at 10 01 39 am](https://cloud.githubusercontent.com/assets/1069588/23709088/4544031e-03e6-11e7-8f33-e5fc7df80e3e.png)
--------
<img width="1086" alt="screen shot 2017-03-08 at 7 54 46 pm" src="https://cloud.githubusercontent.com/assets/1069588/23731821/adf61b8e-043d-11e7-8fd5-72f3e9fcd0f7.png">
