### PR TITLE
Set field display in catalog index view

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,31 +66,8 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
-    config.add_index_field solr_name("alternate_title", :stored_searchable), label: "Alternate Title"
     config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field solr_name("subject", :stored_searchable), label: "Subject", itemprop: 'about', link_to_search: solr_name("subject", :facetable)
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)
-    config.add_index_field solr_name("contributor", :stored_searchable), label: "Contributor", itemprop: 'contributor', link_to_search: solr_name("contributor", :facetable)
-    config.add_index_field solr_name("proxy_depositor", :symbol), label: "Depositor", helper_method: :link_to_profile
-    config.add_index_field solr_name("depositor"), label: "Owner", helper_method: :link_to_profile
-    config.add_index_field solr_name("publisher", :stored_searchable), label: "Publisher", itemprop: 'publisher', link_to_search: solr_name("publisher", :facetable)
-    config.add_index_field solr_name("geo_subject", :stored_searchable), label: "Geographic Subject", itemprop: 'contentLocation', link_to_search: solr_name("based_near", :facetable)
-    config.add_index_field solr_name("language", :stored_searchable), label: "Language", itemprop: 'inLanguage', link_to_search: solr_name("language", :facetable)
-    config.add_index_field solr_name("date_uploaded", :stored_sortable, type: :date), label: "Date Uploaded", itemprop: 'datePublished'
-    config.add_index_field solr_name("date_modified", :stored_sortable, type: :date), label: "Date Modified", itemprop: 'dateModified'
-    config.add_index_field solr_name("date_created", :stored_searchable), label: "Date Created", itemprop: 'dateCreated'
-    config.add_index_field solr_name("rights", :stored_searchable), label: "Rights", helper_method: :rights_statement_links
-    config.add_index_field solr_name("resource_type", :stored_searchable), label: "Resource Type", link_to_search: solr_name("resource_type", :facetable)
-    config.add_index_field solr_name("file_format", :stored_searchable), label: "File Format", link_to_search: solr_name("file_format", :facetable)
-    config.add_index_field solr_name("identifier", :stored_searchable), label: "Identifier", helper_method: :index_field_link, field_name: 'identifier'
-    config.add_index_field solr_name("journal_title", :stored_searchable), label: "Journal Title"
-    config.add_index_field solr_name("issn", :stored_searchable), label: "ISSN"
-    config.add_index_field solr_name("time_period", :stored_searchable), label: "Time Period"
-    config.add_index_field solr_name("required_software", :stored_searchable), label: "Required Software"
-    config.add_index_field solr_name("note", :stored_searchable), label: "Note"
-    config.add_index_field solr_name("genre", :stored_searchable), label: "Genre"
-    config.add_index_field solr_name("degree", :stored_searchable), label: "Degree"
-    config.add_index_field solr_name("advisor", :stored_searchable), label: "Advisor"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -9,14 +9,14 @@ describe 'catalog searching', type: :feature do
 
   context 'with works and collections' do
     let!(:jills_work) do
-      FactoryGirl.create(:public_work, title: ["Jill's Research"], keyword: ['jills_keyword', 'shared_keyword'])
+      FactoryGirl.create(:public_work, title: ["Jill's Research"], description: ["Jill's abstract"], keyword: ['jills_keyword', 'shared_keyword'])
     end
 
     let!(:jacks_work) do
-      FactoryGirl.create(:public_work, title: ["Jack's Research"], keyword: ['jacks_keyword', 'shared_keyword'])
+      FactoryGirl.create(:public_work, title: ["Jack's Research"], description: ["Jack's abstract"], keyword: ['jacks_keyword', 'shared_keyword'])
     end
 
-    let!(:collection) { FactoryGirl.create(:public_collection, keyword: ['collection_keyword', 'shared_keyword']) }
+    let!(:collection) { FactoryGirl.create(:public_collection, title: ["Jack and Jill's collection"], description: ["This is a collection"], keyword: ['collection_keyword', 'shared_keyword']) }
 
     it 'performing a search' do
       within('#search-form-header') do
@@ -26,8 +26,14 @@ describe 'catalog searching', type: :feature do
 
       expect(page).to have_content('Search Results')
       expect(page).to have_content(jills_work.title.first)
+      expect(page).to have_content(jills_work.description.first)
+      expect(page).to have_content(jills_work.creator.first)
       expect(page).to have_content(jacks_work.title.first)
+      expect(page).to have_content(jacks_work.description.first)
+      expect(page).to have_content(jacks_work.creator.first)
       expect(page).to have_content(collection.title.first)
+      expect(page).to have_content(collection.description.first)
+      expect(page).to have_content(collection.creator.first)
     end
   end
 end


### PR DESCRIPTION
Fixes #1179 

Set catalog index to show only :title, :creator, and :description for for titles and collections.

Changes proposed in this pull request:
* Override default fields
* Update specs
