### PR TITLE
Update to Sufia 7.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'sufia', git: 'https://github.com/projecthydra/sufia.git', tag: 'v7.3.0.rc2'
-gem 'flipflop', '2.3.0'
+gem 'sufia', '7.3.0'
+gem 'curation_concerns', '1.7.6'
+gem 'active-fedora', '11.1.5'
 
 #repository manager
 gem 'hydra-role-management'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,42 +34,6 @@ GIT
       virtus
 
 GIT
-  remote: https://github.com/projecthydra/sufia.git
-  revision: d5f4d883cc24d9165ca434bb0a02a79a07810900
-  tag: v7.3.0.rc2
-  specs:
-    sufia (7.3.0.rc2)
-      almond-rails (~> 0.0.1)
-      blacklight (~> 6.6)
-      blacklight-gallery (~> 0.7)
-      browse-everything (>= 0.10.3)
-      carrierwave (~> 0.9)
-      curation_concerns (~> 1.7.5)
-      daemons (~> 1.1)
-      flipflop (~> 2.3)
-      flot-rails (~> 0.0.6)
-      font-awesome-rails (~> 4.2)
-      hydra-batch-edit (~> 2.0)
-      hydra-head (>= 10.4.0)
-      jquery-datatables-rails (~> 3.4.0)
-      jquery-ui-rails (~> 5.0)
-      json-schema
-      legato (~> 0.3)
-      mailboxer (~> 0.12)
-      nest (~> 2.0)
-      oauth
-      oauth2 (~> 1.2)
-      posix-spawn
-      qa (~> 0.8)
-      rdf-rdfxml
-      redis-namespace (~> 1.5.2)
-      select2-rails (~> 3.5.9)
-      signet
-      tinymce-rails (~> 4.1)
-      tinymce-rails-imageupload (~> 4.0.16.beta)
-      yaml_db (~> 0.2)
-
-GIT
   remote: https://github.com/uclibs/browse-everything.git
   revision: be25819f14d485768698d27a3a35deaa7f60d5c7
   ref: be25819f14d485768698d27a3a35deaa7f60d5c7
@@ -112,7 +76,7 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    active-fedora (11.1.4)
+    active-fedora (11.1.5)
       active-triples (~> 0.11.0)
       activemodel (>= 4.2, < 6)
       activesupport (>= 4.2.4, < 6)
@@ -142,7 +106,7 @@ GEM
       activemodel (= 4.2.7.1)
       activesupport (= 4.2.7.1)
       arel (~> 6.0)
-    activerecord-import (0.17.1)
+    activerecord-import (0.17.2)
       activerecord (>= 3.2)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
@@ -156,17 +120,17 @@ GEM
       rails (>= 4.2, < 6)
     arel (6.0.4)
     ast (2.3.0)
-    autoprefixer-rails (6.7.6)
+    autoprefixer-rails (6.7.7.1)
       execjs
     awesome_nested_set (3.1.1)
       activerecord (>= 4.0.0, < 5.1)
-    aws-sdk (2.8.7)
-      aws-sdk-resources (= 2.8.7)
-    aws-sdk-core (2.8.7)
+    aws-sdk (2.8.9)
+      aws-sdk-resources (= 2.8.9)
+    aws-sdk-core (2.8.9)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.8.7)
-      aws-sdk-core (= 2.8.7)
+    aws-sdk-resources (2.8.9)
+      aws-sdk-core (= 2.8.9)
     aws-sigv4 (1.0.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
@@ -206,7 +170,7 @@ GEM
     builder (3.2.3)
     byebug (9.0.6)
     cancancan (1.16.0)
-    capybara (2.12.1)
+    capybara (2.13.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -221,7 +185,7 @@ GEM
       mimemagic (>= 0.3.0)
     childprocess (0.6.2)
       ffi (~> 1.0, >= 1.0.11)
-    clipboard-rails (1.6.0)
+    clipboard-rails (1.6.1)
     cliver (0.3.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -232,7 +196,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
     coveralls (0.8.19)
       json (>= 1.8, < 3)
@@ -242,7 +206,7 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    curation_concerns (1.7.5)
+    curation_concerns (1.7.6)
       active-fedora (>= 10.3.0.rc1)
       active_attr
       active_fedora-noid (~> 2.0.0.beta5)
@@ -449,7 +413,7 @@ GEM
       jquery-rails
       railties (>= 3.1)
       sass-rails
-    jquery-rails (4.2.2)
+    jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -533,14 +497,14 @@ GEM
     omniauth-orcid (0.6)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
-    openseadragon (0.3.2)
+    openseadragon (0.3.3)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
     os (0.9.6)
     parser (2.4.0.0)
       ast (~> 2.2)
     pkg-config (1.1.7)
-    poltergeist (1.13.0)
+    poltergeist (1.14.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -588,7 +552,7 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     rb-readline (0.5.4)
-    rdf (2.2.3)
+    rdf (2.2.5)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-aggregate-repo (2.1.0)
@@ -685,13 +649,13 @@ GEM
       rdoc (~> 4.0)
     select2-rails (3.5.10)
       thor (~> 0.14)
-    selenium-webdriver (3.2.2)
+    selenium-webdriver (3.3.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    sidekiq (4.2.9)
+    sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -715,7 +679,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (4.4.1)
-    solr_wrapper (0.21.0)
+    solr_wrapper (0.22.0)
       faraday
       ruby-progressbar
       rubyzip
@@ -740,15 +704,46 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
     stomp (1.4.3)
+    sufia (7.3.0)
+      almond-rails (~> 0.0.1)
+      blacklight (~> 6.6, < 6.8.0)
+      blacklight-gallery (~> 0.7)
+      browse-everything (>= 0.10.3)
+      carrierwave (~> 0.9)
+      curation_concerns (~> 1.7.6)
+      daemons (~> 1.1)
+      flipflop (~> 2.3)
+      flot-rails (~> 0.0.6)
+      font-awesome-rails (~> 4.2)
+      hydra-batch-edit (~> 2.0)
+      hydra-head (>= 10.4.0)
+      hydra-works (~> 0.16)
+      jquery-datatables-rails (~> 3.4.0)
+      jquery-ui-rails (~> 5.0)
+      json-schema
+      legato (~> 0.3)
+      mailboxer (~> 0.12)
+      nest (~> 2.0)
+      oauth
+      oauth2 (~> 1.2)
+      posix-spawn
+      qa (~> 0.8)
+      rdf-rdfxml
+      redis-namespace (~> 1.5.2)
+      select2-rails (~> 3.5.9)
+      signet
+      tinymce-rails (~> 4.1)
+      tinymce-rails-imageupload (~> 4.0.16.beta)
+      yaml_db (~> 0.2)
     sxp (1.0.0)
       rdf (~> 2.0)
     term-ansicolor (1.4.0)
       tins (~> 1.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.6)
+    tilt (2.0.7)
     tins (1.13.2)
-    tinymce-rails (4.5.3)
+    tinymce-rails (4.5.5)
       railties (>= 3.1.1)
     tinymce-rails-imageupload (4.0.17.beta)
       railties (>= 3.2, < 6)
@@ -763,7 +758,7 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    uglifier (3.1.3)
+    uglifier (3.1.9)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.3)
     vcr (3.0.3)
@@ -798,19 +793,20 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active-fedora (= 11.1.5)
   brakeman
   browse-everything!
   byebug
   capybara
   coffee-rails (~> 4.1.0)
   coveralls
+  curation_concerns (= 1.7.6)
   database_cleaner
   devise
   devise-guests (~> 0.5)
   devise-multi_auth!
   factory_girl_rails
   fcrepo_wrapper
-  flipflop (= 2.3.0)
   hydra-remote_identifier!
   hydra-role-management
   jbuilder (~> 2.0)
@@ -834,7 +830,7 @@ DEPENDENCIES
   solr_wrapper (>= 0.13)
   spring
   sqlite3
-  sufia!
+  sufia (= 7.3.0)
   turbolinks
   uglifier (>= 1.3.0)
   vcr

--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% # we will yield to content_for for each tab, e.g. :files_tab %>
-<% tabs ||= %w[metadata doi files relationships share] # default tab order %>
+<% tabs ||= %w[metadata doi files relationships] # default tab order %>
 <div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
 
@@ -22,6 +22,12 @@
             </a>
           </li>
       <% end %>
+
+      <li role="presentation" id="tab-share" class="hidden">
+        <a href="#share" aria-controls="share" role="tab" data-toggle="tab">
+          <i class="fa icon-share"></i> <%= t("sufia.works.form.tab.share") %>
+        </a>
+      </li>
     </ul>
 
     <!-- Tab panes -->

--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -4,6 +4,7 @@
             "name": "default",
             "label": "Default workflow",
             "description": "A single submission step, default workflow",
+            "allows_access_grant": false,
             "actions": [
                 {
                     "name": "deposit",

--- a/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
+++ b/db/migrate/20170308175556_add_allows_access_grant_to_workflow.rb
@@ -1,0 +1,5 @@
+class AddAllowsAccessGrantToWorkflow < ActiveRecord::Migration
+  def change
+    add_column :sipity_workflows, :allows_access_grant, :boolean
+  end
+end

--- a/db/migrate/20170317141521_permission_template_change_column_workflow_name.rb
+++ b/db/migrate/20170317141521_permission_template_change_column_workflow_name.rb
@@ -1,0 +1,5 @@
+class PermissionTemplateChangeColumnWorkflowName < ActiveRecord::Migration
+  def change
+    change_column_null :permission_templates, :workflow_name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170314130926) do
+ActiveRecord::Schema.define(version: 20170321160926) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -239,7 +239,7 @@ ActiveRecord::Schema.define(version: 20170314130926) do
   create_table "permission_templates", force: :cascade do |t|
     t.string   "admin_set_id"
     t.string   "visibility"
-    t.string   "workflow_name"
+    t.string   "workflow_name",  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date     "release_date"
@@ -484,11 +484,12 @@ ActiveRecord::Schema.define(version: 20170314130926) do
   add_index "sipity_workflow_states", ["workflow_id", "name"], name: "sipity_type_state_aggregate", unique: true
 
   create_table "sipity_workflows", force: :cascade do |t|
-    t.string   "name",        null: false
+    t.string   "name",                null: false
     t.string   "label"
     t.text     "description"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.boolean  "allows_access_grant"
   end
 
   add_index "sipity_workflows", ["name"], name: "index_sipity_workflows_on_name", unique: true

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :permission_template, class: Sufia::PermissionTemplate do
+    admin_set_id '88888'
+    workflow_name AdminSet::DEFAULT_WORKFLOW_NAME
+  end
+end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :workflow, class: Sipity::Workflow do
+    name 'one_step_mediated_deposit'
+  end
+end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -106,6 +106,8 @@ feature 'Creating a new work', :js do
   # let!(:uploaded_file2) { UploadedFile.create(file: file2, user: user) }
 
   before do
+    CurationConcerns::Workflow::WorkflowImporter.load_workflows
+    Sufia::AdminSetCreateService.create_default!
     allow(CharacterizeJob).to receive(:perform_later)
     page.current_window.resize_to(2000, 2000)
   end

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -92,6 +92,8 @@ describe 'end to end behavior:' do
   let!(:deleted_work) { FactoryGirl.create(:work, user: user) }
   let!(:collection) { FactoryGirl.create(:collection, user: user) }
   before do
+    CurationConcerns::Workflow::WorkflowImporter.load_workflows
+    Sufia::AdminSetCreateService.create_default!
     login_as user
   end
   context 'the user' do

--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -5,6 +5,8 @@ describe 'Adding an infected file', js: true do
   let(:user) { FactoryGirl.create(:user) }
 
   before do
+    CurationConcerns::Workflow::WorkflowImporter.load_workflows
+    Sufia::AdminSetCreateService.create_default!
     allow(CharacterizeJob).to receive(:perform_later)
     allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
     login_as user

--- a/spec/forms/curation_concerns/article_form_spec.rb
+++ b/spec/forms/curation_concerns/article_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Article`
 require 'rails_helper'
 
-describe CurationConcerns::ArticleForm do
+RSpec.describe CurationConcerns::ArticleForm do
   let(:work) { Article.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -27,12 +27,15 @@ describe CurationConcerns::ArticleForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/dataset_form_spec.rb
+++ b/spec/forms/curation_concerns/dataset_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Dataset`
 require 'rails_helper'
 
-describe CurationConcerns::DatasetForm do
+RSpec.describe CurationConcerns::DatasetForm do
   let(:work) { Dataset.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -26,12 +26,15 @@ describe CurationConcerns::DatasetForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/document_form_spec.rb
+++ b/spec/forms/curation_concerns/document_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Document`
 require 'rails_helper'
 
-describe CurationConcerns::DocumentForm do
+RSpec.describe CurationConcerns::DocumentForm do
   let(:work) { Document.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::DocumentForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/etd_form_spec.rb
+++ b/spec/forms/curation_concerns/etd_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Etd`
 require 'rails_helper'
 
-describe CurationConcerns::EtdForm do
+RSpec.describe CurationConcerns::EtdForm do
   let(:work) { Etd.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::EtdForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work GenericWork`
 require 'rails_helper'
 
-describe CurationConcerns::GenericWorkForm do
+RSpec.describe CurationConcerns::GenericWorkForm do
   let(:work) { GenericWork.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::GenericWorkForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/4.0/us/',

--- a/spec/forms/curation_concerns/image_form_spec.rb
+++ b/spec/forms/curation_concerns/image_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Image`
 require 'rails_helper'
 
-describe CurationConcerns::ImageForm do
+RSpec.describe CurationConcerns::ImageForm do
   let(:work) { Image.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::ImageForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/student_work_form_spec.rb
+++ b/spec/forms/curation_concerns/student_work_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work StudentWork`
 require 'rails_helper'
 
-describe CurationConcerns::StudentWorkForm do
+RSpec.describe CurationConcerns::StudentWorkForm do
   let(:work) { StudentWork.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::StudentWorkForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         rights: 'http://creativecommons.org/licenses/by/3.0/us/',

--- a/spec/forms/curation_concerns/video_form_spec.rb
+++ b/spec/forms/curation_concerns/video_form_spec.rb
@@ -3,7 +3,7 @@
 #  `rails generate curation_concerns:work Video`
 require 'rails_helper'
 
-describe CurationConcerns::VideoForm do
+RSpec.describe CurationConcerns::VideoForm do
   let(:work) { Video.new }
   let(:form) { described_class.new(work, nil) }
 
@@ -28,12 +28,15 @@ describe CurationConcerns::VideoForm do
   end
 
   describe '.model_attributes' do
+    before { create(:permission_template, admin_set_id: admin_set_id, workflow_name: workflow.name) }
+    let(:workflow) { create(:workflow) }
+    let(:admin_set_id) { '123' }
     let(:params) do
       ActionController::Parameters.new(
         title: 'foo',
         description: '',
         visibility: 'open',
-        admin_set_id: '123',
+        admin_set_id: admin_set_id,
         representative_id: '456',
         thumbnail_id: '789',
         keyword: ['derp'],

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -25,6 +25,8 @@ shared_examples 'doi request' do |work_class|
   let(:work_text) { work_class.name.titlecase }
 
   before do
+    CurationConcerns::Workflow::WorkflowImporter.load_workflows
+    Sufia::AdminSetCreateService.create_default!
     allow(CharacterizeJob).to receive(:perform_later)
   end
 


### PR DESCRIPTION
Pins to Sufia 7.3.0.  I also pinned Curation Concerns and Active Fedora to their current versions for stability.  We can manually update those gems when new versions come out.

This fixes a couple of overrides we have in our app, pulls in a couple of db changes, and tweaks some specs to properly handle changes in Sufia since the last release candidate.

After this is merged we should rebase existing PRs on top of develop.