### PR TITLE
Add college and department fields to works

### DIFF
--- a/app/assets/stylesheets/sufia.scss
+++ b/app/assets/stylesheets/sufia.scss
@@ -131,7 +131,9 @@ div.input-group-btn button.btn-primary:active {
   background-color: #e00122;
 }
 
-.form-control.select.rights {
+.form-control.select.rights,
+.form-control.select.college,
+.form-control.string.department {
   max-width: 40em;
 }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -53,6 +53,8 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("creator", :facetable), label: "Creator", limit: 5
     config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
     config.add_facet_field solr_name("subject", :facetable), label: "Subject", limit: 5
+    config.add_facet_field solr_name("college", :facetable), label: "College", limit: 5
+    config.add_facet_field solr_name("department", :facetable), label: "Program or Dept.", limit: 5
     config.add_facet_field solr_name("language", :facetable), label: "Language", limit: 5
     config.add_facet_field solr_name("geo_subject", :facetable), label: "Geographic Subject", limit: 5
     config.add_facet_field solr_name("publisher", :facetable), label: "Publisher", limit: 5
@@ -98,6 +100,8 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("description", :stored_searchable), label: "Description"
     config.add_show_field solr_name("subject", :stored_searchable), label: "Subject"
     config.add_show_field solr_name("creator", :stored_searchable), label: "Creator"
+    config.add_show_field solr_name("college", :stored_searchable), label: "College"
+    config.add_show_field solr_name("department", :stored_searchable), label: "Program or Department"
     config.add_show_field solr_name("contributor", :stored_searchable), label: "Contributor"
     config.add_show_field solr_name("publisher", :stored_searchable), label: "Publisher"
     config.add_show_field solr_name("geo_subject", :stored_searchable), label: "Geographic Subject"

--- a/app/controllers/concerns/sufia/users_controller_behavior.rb
+++ b/app/controllers/concerns/sufia/users_controller_behavior.rb
@@ -41,7 +41,7 @@ module Sufia::UsersControllerBehavior
 
     def user_params
       params.require(:user).permit(:first_name, :last_name, :avatar, :facebook_handle, :twitter_handle, :title,
-                                   :googleplus_handle, :linkedin_handle, :remove_avatar, :orcid, :department,
+                                   :googleplus_handle, :linkedin_handle, :remove_avatar, :orcid, :ucdepartment,
                                    :blog, :alternate_phone_number, :alternate_email, :uc_affiliation, :website, :telephone)
     end
 end

--- a/app/forms/curation_concerns/article_form.rb
+++ b/app/forms/curation_concerns/article_form.rb
@@ -11,11 +11,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description rights)
+    self.required_fields = %i(title creator college department description rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/dataset_form.rb
+++ b/app/forms/curation_concerns/dataset_form.rb
@@ -12,11 +12,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description required_software rights)
+    self.required_fields = %i(title creator college department description required_software rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -12,11 +12,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description rights)
+    self.required_fields = %i(title creator college department description rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -13,11 +13,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description advisor rights)
+    self.required_fields = %i(title creator college department description advisor rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -12,11 +12,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description rights)
+    self.required_fields = %i(title creator college department description rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/image_form.rb
+++ b/app/forms/curation_concerns/image_form.rb
@@ -12,11 +12,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description rights)
+    self.required_fields = %i(title creator college department description rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/student_work_form.rb
+++ b/app/forms/curation_concerns/student_work_form.rb
@@ -13,11 +13,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description advisor rights)
+    self.required_fields = %i(title creator college department description advisor rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/forms/curation_concerns/video_form.rb
+++ b/app/forms/curation_concerns/video_form.rb
@@ -12,11 +12,14 @@ module CurationConcerns
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
 
+    ## Adding terms college and department
+    self.terms += %i(college department)
+
     ## Removing terms that we don't use
     self.terms -= %i(keyword source contributor)
 
     ## Setting custom required fields
-    self.required_fields = %i(title creator description rights)
+    self.required_fields = %i(title creator college department description rights)
 
     ## Adding above the fold on the form without making this required
     def primary_terms

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -3,4 +3,56 @@ module SufiaHelper
   include ::BlacklightHelper
   include Sufia::BlacklightOverride
   include Sufia::SufiaHelperBehavior
+
+  def sorted_college_list_for_works
+    if curation_concern.is_a? Etd
+      sorted_college_list_for_etds
+    elsif curation_concern.is_a? StudentWork
+      sorted_college_list_for_student_works
+    else
+      sorted_college_list_for_other_works
+    end
+  end
+
+  def sorted_college_list_for_etds
+    [''] + sorted_college_list_for_degrees + COLLEGE_AND_DEPARTMENT["legacy_colleges"]
+  end
+
+  def sorted_college_list_for_degrees
+    COLLEGE_AND_DEPARTMENT["current_colleges_for_degrees"].keys.collect do |k|
+      COLLEGE_AND_DEPARTMENT["current_colleges_for_degrees"][k]["label"]
+    end.sort << "Other"
+  end
+
+  def sorted_college_list_for_student_works
+    list = COLLEGE_AND_DEPARTMENT["current_colleges_for_degrees"].merge(COLLEGE_AND_DEPARTMENT["additional_current_colleges"])
+    [''] + list.keys.collect do |k|
+      list[k]["label"]
+    end.sort << "Other"
+  end
+
+  def sorted_college_list_for_other_works
+    list = COLLEGE_AND_DEPARTMENT["current_colleges_for_degrees"].merge(
+      COLLEGE_AND_DEPARTMENT["additional_current_colleges_library"]
+    )
+    list.keys.collect do |k|
+      list[k]["label"]
+    end.sort << "Other"
+  end
+
+  def user_college
+    if (curation_concern.is_a? Etd) || (curation_concern.is_a? StudentWork)
+      ''
+    else
+      current_user.college
+    end
+  end
+
+  def user_department
+    if (curation_concern.is_a? Etd) || (curation_concern.is_a? StudentWork)
+      ''
+    else
+      current_user.department
+    end
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -41,4 +41,12 @@ class Article < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -36,4 +36,12 @@ class Dataset < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -36,4 +36,12 @@ class Document < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -44,4 +44,12 @@ class Etd < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -40,4 +40,12 @@ class GenericWork < ActiveFedora::Base
   property :date_digitized, predicate: ::RDF::URI.new('http://purl.org/dc/terms/date#digitized'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -36,4 +36,12 @@ class Image < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -77,4 +77,12 @@ class SolrDocument
   def doi
     self[Solrizer.solr_name('doi')]
   end
+
+  def college
+    self[Solrizer.solr_name('college')]
+  end
+
+  def department
+    self[Solrizer.solr_name('department')]
+  end
 end

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -44,4 +44,12 @@ class StudentWork < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,4 +48,30 @@ class User < ActiveRecord::Base
   def student?
     uc_affiliation == 'student'
   end
+
+  def college
+    return "Other" if ucdepartment.blank?
+    user_colleges.keys.each do |key|
+      if ucdepartment.downcase.start_with?(key + " ")
+        return user_colleges[key]["label"]
+      end
+    end
+    "Other"
+  end
+
+  def department
+    return "Unknown" if ucdepartment.blank?
+    user_colleges.keys.each do |key|
+      if ucdepartment.downcase.start_with?(key + " ")
+        return ucdepartment[/(?<=\s).*/]
+      end
+    end
+    ucdepartment
+  end
+
+  private
+
+    def user_colleges
+      COLLEGE_AND_DEPARTMENT["current_colleges_for_degrees"].merge(COLLEGE_AND_DEPARTMENT["additional_current_colleges_library"])
+    end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -36,4 +36,12 @@ class Video < ActiveFedora::Base
   property :note, predicate: ::RDF::URI.new('http://purl.org/dc/terms/description#note'), multiple: false do |index|
     index.as :stored_searchable
   end
+
+  property :college, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#college'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :department, predicate: ::RDF::URI.new('http://purl.org/dc/terms/subject#department'), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
 end

--- a/app/presenters/article_presenter.rb
+++ b/app/presenters/article_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ArticlePresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :journal_title, :issn, :time_period, :required_software, :note, :geo_subject, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :journal_title, :issn, :time_period, :required_software, :note, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/dataset_presenter.rb
+++ b/app/presenters/dataset_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class DatasetPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/document_presenter.rb
+++ b/app/presenters/document_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class DocumentPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class EtdPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class GenericWorkPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ImagePresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :cultural_context, :doi, to: :solr_document
 end

--- a/app/presenters/student_work_presenter.rb
+++ b/app/presenters/student_work_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class StudentWorkPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/video_presenter.rb
+++ b/app/presenters/video_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class VideoPresenter < Sufia::WorkShowPresenter
-  delegate :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,5 +1,7 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:college, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:department, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_college.html.erb
+++ b/app/views/records/edit_fields/_college.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :college,
+      collection: sorted_college_list_for_works,
+      selected: (curation_concern.college || user_college),
+      input_html: { class: 'college' } %>

--- a/app/views/records/edit_fields/_department.html.erb
+++ b/app/views/records/edit_fields/_department.html.erb
@@ -1,0 +1,2 @@
+<%= f.input :department,
+      input_html: { class: 'department', value: curation_concern.department || user_department } %>

--- a/app/views/users/_edit_primary.html.erb
+++ b/app/views/users/_edit_primary.html.erb
@@ -53,9 +53,9 @@
     </div><!-- .form-group -->
 
     <div class="form-group">
-      <%= f.label :department, 'Department', class: 'col-xs-4 control-label' %>
+      <%= f.label :ucdepartment, 'Department', class: 'col-xs-4 control-label' %>
       <div class="col-xs-8">
-         <%= f.text_field :department, class: "form-control" %>
+         <%= f.text_field :ucdepartment, class: "form-control" %>
       </div>
     </div><!-- .form-group -->
 

--- a/config/college_and_department.yml
+++ b/config/college_and_department.yml
@@ -1,0 +1,42 @@
+current_colleges_for_degrees:
+  cahs:
+    label: 'Allied Health Sciences'
+  com:
+    label: 'Medicine'
+  a&s:
+    label: 'Arts and Sciences'
+  cob:
+    label: 'Business'
+  ccm:
+    label: 'College-Conservatory of Music'
+  daap:
+    label: 'Design, Architecture, Art and Planning'
+  cech:
+    label: 'Education, Criminal Justice, and Human Services'
+  ceas:
+    label: 'Engineering and Applied Science'
+  nursing:
+    label: 'Nursing'
+  pharm:
+    label: 'Pharmacy'
+additional_current_colleges:
+  clermont:
+    label: 'Clermont College'
+  law:
+    label: 'Law'
+  ucba:
+    label: 'Blue Ash College' 
+additional_current_colleges_library:
+  clermont:
+    label: 'Clermont College'
+  law:
+    label: 'Law'
+  ucba:
+    label: 'Blue Ash College' 
+  ucl:
+    label: 'Libraries'
+legacy_colleges:
+  - "Business Administration"
+  - "Education"
+  - "Engineering"
+  - "Interdisciplinary"

--- a/config/initializers/college_and_department_initializer.rb
+++ b/config/initializers/college_and_department_initializer.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+COLLEGE_AND_DEPARTMENT = YAML.load(File.open(Rails.root.join('config/college_and_department.yml'))).freeze if File.exist?(Rails.root.join('config/college_and_department.yml'))

--- a/config/locales/article.en.yml
+++ b/config/locales/article.en.yml
@@ -24,7 +24,8 @@ en:
         required_software: "Required Software"
         note:             "Note"
         publisher:        "Publisher (Required for DOI registration)"
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       article:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -47,4 +48,5 @@ en:
         note: "Enter any additional information about your Article."
         publisher: "Enter the publisher of your Article. If this has not been previously published,<i> University of Cincinnati</i> is an appropriate publisher."
         rights: "Who should be able to view or download this content?"
-
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/dataset.en.yml
+++ b/config/locales/dataset.en.yml
@@ -20,7 +20,8 @@ en:
         required_software: "Required Software"
         note:             "Note"
         publisher:        "Publisher (Required for DOI registration)"   
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       dataset:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -41,4 +42,5 @@ en:
         alternate_title: "Enter an alternate title for your Dataset. An alternate title could include acronyms, abbreviations, or a series title."
         time_period: "Enter the period or date associated with the subject of your Dataset.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
         note: "Enter any additional information about your Dataset."
-
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/document.en.yml
+++ b/config/locales/document.en.yml
@@ -22,7 +22,8 @@ en:
         required_software: "Required Software"
         note:             "Note"
         publisher:        "Publisher (Required for DOI registration)"
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       document:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -43,4 +44,5 @@ en:
         time_period: "Enter the period or date associated with the subject of your Document.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
         required_software: "Special software needed to open the Document."
         note: "Enter any additional information about your Document."
-
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -26,7 +26,8 @@ en:
         degree:           "Degree" 
         genre:            "Type" 
         publisher:        "Publisher (Required for DOI registration)" 
-
+        college:          "College"
+        department:       "Degree Program"
     hints:
       etd:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -52,4 +53,5 @@ en:
         genre: "Select the type of your work. If you are unsure about the type, please select 'Other'."
         publisher: "Enter the publisher of your work. If this has not been previously published, University of Cincinnati is an appropriate publisher."
         required_software: "Special software needed to open the work"
-
+        college: "Select the college associated with the ETD."
+        department: "Enter the department associated with the ETD."

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -21,7 +21,8 @@ en:
         required_software: "Required Software"
         note:             "Enter any additional information about your Generic Work."
         publisher:        "Publisher (Required for DOI registration)"
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       generic_work:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -40,5 +41,5 @@ en:
         time_period: "Enter the period or date associated with the subject of your Generic Work.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
         required_software: "Special software needed to open the Generic Work."
         note: "Enter any additional information about your Generic Work."
-
-
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/image.en.yml
+++ b/config/locales/image.en.yml
@@ -24,8 +24,8 @@ en:
         time_period:      "Time Period"
         note:             "Note"
         required_software: "Required Software" 
-
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       image:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -48,3 +48,5 @@ en:
         time_period: "Enter the period or date associated with the subject of your Image.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
         note: "Enter any additional information about your Image."
         required_software: "Special software needed to open the Image."
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/student_work.en.yml
+++ b/config/locales/student_work.en.yml
@@ -24,7 +24,8 @@ en:
         publisher:        "Publisher (Required for DOI registration)"
         degree:           "Degree"
         advisor:          "Advisor"
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       student_work:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -48,4 +49,5 @@ en:
         degree: "The degree associated with this work, if the work was completed as part of a thesis or capstone. Please enter the abbreviation for the degree, e.g., BA or MS."
         advisor: "The faculty advisor or sponsor for this work, in<i> LastName, FirstName</i> format."
         alternate_title: "Enter an alternate title for your work. An alternate title could include acronyms, abbreviations, or a series title."
-
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/config/locales/video.en.yml
+++ b/config/locales/video.en.yml
@@ -21,7 +21,8 @@ en:
         required_software: "Required Software"
         note:              "Note"
         publisher:         "Publisher (Required for DOI registration)"
-
+        college:          "College"
+        department:       "Program or Department"
     hints:
       video:
         resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
@@ -42,3 +43,5 @@ en:
         time_period: "Enter the period or date associated with the subject of your Video.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul"
         required_software: "Special software needed to open the Video"
         note: "Enter any additional information about your Video."
+        college: "Select the college associated with the submitter of this work."
+        department: "Enter the department associated with the submitter of this work."

--- a/db/migrate/20170321160926_add_ucdepartment_to_user.rb
+++ b/db/migrate/20170321160926_add_ucdepartment_to_user.rb
@@ -1,0 +1,5 @@
+class AddUcdepartmentToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :ucdepartment, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -590,6 +590,7 @@ ActiveRecord::Schema.define(version: 20170321160926) do
     t.string   "alternate_email"
     t.boolean  "waived_welcome_page"
     t.boolean  "profile_update_not_required"
+    t.string   "ucdepartment"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -21,21 +21,26 @@ shared_examples 'work creation' do |work_class| # snake-case work type for strin
     if work_class == Document || work_class == GenericWork || work_class == Image || work_class == Video
       fill_in('Description', with: 'This is a description.')
       fill_in('Creator', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     elsif work_class == Etd
       fill_in('Abstract', with: 'This is an abstract.')
       fill_in('Creator', with: 'Test User')
       fill_in('Advisor', with: 'Ima Advisor.')
+      fill_in('Degree Program', with: 'Test Department')
     elsif work_class == StudentWork
       fill_in('Description', with: 'This is an abstract.')
       fill_in('Creator', with: 'Test User')
       fill_in('Advisor', with: 'Ima Advisor.')
+      fill_in('Program or Department', with: 'Test Department')
     elsif work_class == Article
       fill_in('Abstract', with: 'This is an abstract.')
       fill_in('Author', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     else
       fill_in('Description', with: 'This is a description.')
       fill_in('Required Software', with: 'This is Required Software.')
       fill_in('Creator', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     end
 
     select 'Attribution-ShareAlike 4.0 International', from: "#{work_type}_rights"
@@ -65,21 +70,26 @@ shared_examples 'proxy work creation' do |work_class|
     if work_class == Document || work_class == GenericWork || work_class == Image || work_class == Video
       fill_in('Description', with: 'This is a description.')
       fill_in('Creator', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     elsif work_class == Etd
       fill_in('Abstract', with: 'This is an abstract.')
       fill_in('Creator', with: 'Test User')
       fill_in('Advisor', with: 'Ima Advisor')
+      fill_in('Degree Program', with: 'Test Department')
     elsif work_class == StudentWork
       fill_in('Description', with: 'This is an abstract.')
       fill_in('Creator', with: 'Test User')
       fill_in('Advisor', with: 'Ima Advisor')
+      fill_in('Program or Department', with: 'Test Department')
     elsif work_class == Article
       fill_in('Abstract', with: 'This is an abstract.')
       fill_in('Author', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     else
       fill_in('Description', with: 'This is a description.')
       fill_in('Required Software', with: 'This is Required Software.')
       fill_in('Creator', with: 'Test User')
+      fill_in('Program or Department', with: 'Test Department')
     end
 
     select 'Attribution-ShareAlike 4.0 International', from: "#{work_type}_rights"

--- a/spec/forms/curation_concerns/article_form_spec.rb
+++ b/spec/forms/curation_concerns/article_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::ArticleForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/dataset_form_spec.rb
+++ b/spec/forms/curation_concerns/dataset_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::DatasetForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :required_software, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :required_software, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :required_software, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :required_software, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/document_form_spec.rb
+++ b/spec/forms/curation_concerns/document_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::DocumentForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/etd_form_spec.rb
+++ b/spec/forms/curation_concerns/etd_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::EtdForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::GenericWorkForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/image_form_spec.rb
+++ b/spec/forms/curation_concerns/image_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::ImageForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/student_work_form_spec.rb
+++ b/spec/forms/curation_concerns/student_work_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::StudentWorkForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :advisor, :rights, :degree, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :advisor, :rights, :degree, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/forms/curation_concerns/video_form_spec.rb
+++ b/spec/forms/curation_concerns/video_form_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurationConcerns::VideoForm do
 
   describe "#required_fields" do
     subject { form.required_fields }
-    it { is_expected.to eq [:title, :creator, :description, :rights] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights] }
   end
 
   describe "#primary_terms" do
     subject { form.primary_terms }
-    it { is_expected.to eq [:title, :creator, :description, :rights, :publisher] }
+    it { is_expected.to eq [:title, :creator, :college, :department, :description, :rights, :publisher] }
   end
 
   describe "#secondary_terms" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -110,6 +110,8 @@ describe Article do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -108,6 +108,8 @@ describe Dataset do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -108,6 +108,8 @@ describe Document do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -110,6 +110,8 @@ describe Etd do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -108,6 +108,8 @@ describe GenericWork do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -108,6 +108,8 @@ describe Image do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/student_work_spec.rb
+++ b/spec/models/student_work_spec.rb
@@ -110,6 +110,8 @@ describe StudentWork do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,4 +116,54 @@ describe User do
     subject.waive_welcome_page!
     expect(subject.waived_welcome_page).to be true
   end
+
+  describe "college" do
+    subject { described_class.new }
+
+    context "when the user doesn't have a department" do
+      it "returns Other" do
+        subject.ucdepartment = nil
+        expect(subject.college).to eq "Other"
+      end
+    end
+
+    context "when the user has a department that starts with a college abbreviation" do
+      it "returns the college abbreviation" do
+        subject.ucdepartment = "UCL Test Department"
+        expect(subject.college).to eq "Libraries"
+      end
+    end
+
+    context "when the user has a department that doesn't start with a college abbreviation" do
+      it "returns Other" do
+        subject.ucdepartment = "Test Department"
+        expect(subject.college).to eq "Other"
+      end
+    end
+  end
+
+  describe "department" do
+    subject { described_class.new }
+
+    context "when the user doesn't have a department" do
+      it "returns Unknown" do
+        subject.ucdepartment = nil
+        expect(subject.department).to eq "Unknown"
+      end
+    end
+
+    context "when the user has a department that starts with a college abbreviation" do
+      it "returns the department without the abreviation" do
+        subject.ucdepartment = "UCL Test Department"
+        expect(subject.department).to eq "Test Department"
+      end
+    end
+
+    context "when the user has a department that doesn't start with a college abbreviation" do
+      it "returns the department without the abreviation" do
+        subject.ucdepartment = "Test Department"
+        expect(subject.department).to eq "Test Department"
+      end
+    end
+  end
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -108,6 +108,8 @@ describe Video do
     it { should respond_to(:language) }
     it { should respond_to(:rights) }
     it { should respond_to(:identifier) }
+    it { should respond_to(:college) }
+    it { should respond_to(:department) }
   end
 
   it_behaves_like 'is remotely identifiable by doi'

--- a/spec/presenters/article_presenter_spec.rb
+++ b/spec/presenters/article_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ArticlePresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/dataset_presenter_spec.rb
+++ b/spec/presenters/dataset_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe DatasetPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe DocumentPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe EtdPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe GenericWorkPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ImagePresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/student_work_presenter_spec.rb
+++ b/spec/presenters/student_work_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe StudentWorkPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/presenters/video_presenter_spec.rb
+++ b/spec/presenters/video_presenter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe VideoPresenter do
+  let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:presenter) { described_class.new(solr_document, ability) }
+
+  subject { described_class.new(double, double) }
+  it { is_expected.to delegate_method(:college).to(:solr_document) }
+  it { is_expected.to delegate_method(:department).to(:solr_document) }
+end

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -54,6 +54,11 @@ shared_examples 'doi request' do |work_class|
       description_element = find_by_id("#{work_label}_description")
       description_element.set("Test description")
       fill_in('Required Software', with: "database thingy") if work_class == Dataset
+      if work_class == Etd
+        fill_in('Degree Program', with: 'Test Department')
+      else
+        fill_in('Program or Department', with: 'Test Department')
+      end
       fill_in('Adviso', with: "Advisor Name") if [Etd, StudentWork].include?(work_class)
       select 'Attribution-ShareAlike 4.0 International', from: "#{work_label}_rights"
       fill_in('Publisher', with: 'tests')

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'curation_concerns/base/_attributes.html.erb' do
+  let(:college) { 'Libraries' }
+  let(:department) { 'Digital Repositories' }
+
+  let(:solr_document) { SolrDocument.new(attributes) }
+  let(:attributes) do
+    {
+      Solrizer.solr_name('has_model', :symbol) => ["GenericWork"],
+      college_tesim: college,
+      department_tesim: department
+    }
+  end
+  let(:ability) { nil }
+  let(:presenter) do
+    GenericWorkPresenter.new(solr_document, ability)
+  end
+  let(:doc) { Nokogiri::HTML(rendered) }
+
+  before do
+    allow(view).to receive(:dom_class) { '' }
+
+    render 'curation_concerns/base/attributes', presenter: presenter
+  end
+
+  it 'has links to search for other objects with the same metadata' do
+    expect(rendered).to have_link(college, href: search_catalog_path('f[college_sim][]': college))
+    expect(rendered).to have_link(department, href: search_catalog_path('f[department_sim][]': department))
+  end
+end


### PR DESCRIPTION
Fixes #895 

Adds college and department fields to works.  Everything works just as it does in Scholar 2.x including special cases for ETDs and Student Works.
