### PR TITLE
Hide group share feature

### DIFF
--- a/app/views/curation_concerns/base/_form_share.html.erb
+++ b/app/views/curation_concerns/base/_form_share.html.erb
@@ -1,0 +1,68 @@
+<h2>Sharing With</h2>
+<% depositor = f.object.depositor %>
+
+<div class="alert alert-info hidden" id="save_perm_note">Permissions are
+  <strong>not</strong> saved until the &quot;Save&quot; button is pressed at the bottom of the page.</div>
+
+<div class="alert alert-warning hidden" role="alert" id="permissions_error">
+  <span id="permissions_error_text"></span>
+</div>
+
+<table class="table">
+  <tr id="file_permissions">
+    <td width="20%">
+      <%= Sufia.config.owner_permission_levels.keys[0] %>
+    </td>
+    <td width="60%">
+      <%= label_tag :owner_access, class: "control-label" do %>
+        Depositor (<span id="file_owner" data-depositor="<%= depositor %>"><%= link_to_profile depositor %></span>)
+      <% end %>
+    </td>
+  </tr>
+  <%= f.fields_for :permissions do |permission_fields| %>
+    <%# skip the public, registered, and depositor perms as they are displayed first at the top %>
+    <% next if ['public', 'registered', depositor].include? permission_fields.object.agent_name.downcase %>
+    <tr>
+      <td>
+	<%= permission_fields.select :access, Sufia.config.permission_levels, {}, class: 'form-control select_perm' %>
+
+      </td>
+      <td>
+	<%= permission_fields.label :agent_name, class: "control-label" do %>
+	  <%= user_display_name_and_key(permission_fields.object.agent_name) %>
+	<% end %>
+	<button class="btn close remove_perm" data-index="<%= permission_fields.index %>">&times;</button>
+      </td>
+    </tr>
+  <% end %>
+</table>
+
+<h2>Share work with other users</h2>
+<p class="sr-only">Use the add button to give access to one <%=t('sufia.account_label') %> at a time (it will be added to the list below).
+  Select the user, by name or <%= t('sufia.account_label') %>. Then select the access level you wish to grant and click on Add this
+  <%= t('sufia.account_label') %> to complete adding the permission.
+</p>
+<div class="form-group row">
+  <div class="col-sm-5">
+    <label for="new_user_name_skel" class="sr-only"><%= t('sufia.account_label') %> (without the <%= t('sufia.directory.suffix') %> part)</label>
+    <%= text_field_tag 'new_user_name_skel', nil %>
+  </div>
+  <div class="col-sm-4">
+    <label for="new_user_permission_skel" class="sr-only">Access type to grant</label>
+    <%= select_tag 'new_user_permission_skel', options_for_select(Sufia.config.permission_levels), class: 'form-control' %>
+  </div>
+  <div class="col-sm-3">
+    <button class="btn btn-default" id="add_new_user_skel">
+      <span class="sr-only">Add this <%= t('sufia.account_label') %></span>
+      <span aria-hidden="true"><i class="glyphicon glyphicon-plus"></i></span>
+    </button>
+    <br /> <span id="directory_user_result"></span>
+  </div>
+</div>
+
+<script type="text/x-tmpl" id="tmpl-work-grant">
+<tr>
+  <td>{%= o.accessLabel %}</td>
+  <td><label class="control-label">{%= o.name %}</label> <button class="btn close">&times;</button></td>
+</tr>
+</script>

--- a/config/initializers/monkey_patch_admin_set.rb
+++ b/config/initializers/monkey_patch_admin_set.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+# Override CC's AdminSet to load Sufia's updated AdminSetBehavior
+AdminSet.include(Sufia::AdminSetBehavior)

--- a/spec/features/work_share_spec.rb
+++ b/spec/features/work_share_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+shared_examples 'hide share feature' do |work_class| # snake-case work type for string interpolation
+  let(:work_type) { work_class.name.underscore }
+  let(:user) { create(:user) }
+  before do
+    sign_in user
+  end
+
+  it 'does not display group share feature' do
+    visit new_polymorphic_path(work_class)
+    click_link "Share"
+    expect(page).not_to have_content('Share work with groups of users')
+  end
+end
+
+describe "work share partial" do
+  it_behaves_like "hide share feature", GenericWork
+  it_behaves_like "hide share feature", Video
+  it_behaves_like "hide share feature", Image
+  it_behaves_like "hide share feature", Document
+  it_behaves_like "hide share feature", Article
+  it_behaves_like "hide share feature", StudentWork
+  it_behaves_like "hide share feature", Etd
+  it_behaves_like "hide share feature", Dataset
+end


### PR DESCRIPTION
Fixes #1190 

Hide group share feature for works.

Changes proposed in this pull request:
* Add view partial override for share form
* Add monkey patch initializer from sufia
* Add specs
