### PR TITLE
Limit file upload and download sizes

### DIFF
--- a/app/assets/javascripts/sufia/uploader.js
+++ b/app/assets/javascripts/sufia/uploader.js
@@ -1,0 +1,71 @@
+//= require fileupload/tmpl
+//= require fileupload/jquery.iframe-transport
+//= require fileupload/jquery.fileupload.js
+//= require fileupload/jquery.fileupload-process.js
+//= require fileupload/jquery.fileupload-validate.js
+//= require fileupload/jquery.fileupload-ui.js
+//
+/*
+ * jQuery File Upload Plugin JS Example
+ * https://github.com/blueimp/jQuery-File-Upload
+ *
+ * Copyright 2010, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+(function( $ ){
+  'use strict';
+
+  $.fn.extend({
+    sufiaUploader: function( options ) {
+      // Initialize our jQuery File Upload widget.
+      // TODO: get these values from configuration.
+      this.fileupload($.extend({
+        // xhrFields: {withCredentials: true},              // to send cross-domain cookies
+        // acceptFileTypes: /(\.|\/)(png|mov|jpe?g|pdf)$/i, // not a strong check, just a regex on the filename
+        // limitMultiFileUploadSize: 500000000, // bytes
+        limitConcurrentUploads: 6,
+        maxNumberOfFiles: 100,
+        maxFileSize: 3221225472, // Limit uploads to 3 GB per file
+        autoUpload: true,
+        url: '/uploads/',
+        type: 'POST',
+        dropZone: $(this).find('.dropzone')
+      }, options))
+      .bind('fileuploadadded', function (e, data) {
+        $(e.currentTarget).find('button.cancel').removeClass('hidden');
+      });
+
+      $(document).bind('dragover', function(e) {
+        var dropZone = $('.dropzone'),
+            timeout = window.dropZoneTimeout;
+        if (!timeout) {
+            dropZone.addClass('in');
+        } else {
+            clearTimeout(timeout);
+        }
+        var found = false,
+            node = e.target;
+        do {
+            if (node === dropZone[0]) {
+                found = true;
+                break;
+            }
+            node = node.parentNode;
+        } while (node !== null);
+        if (found) {
+            dropZone.addClass('hover');
+        } else {
+            dropZone.removeClass('hover');
+        }
+        window.dropZoneTimeout = setTimeout(function () {
+            window.dropZoneTimeout = null;
+            dropZone.removeClass('in hover');
+        }, 100);
+      });
+    }
+  });
+})(jQuery);

--- a/app/helpers/file_set_helper.rb
+++ b/app/helpers/file_set_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module FileSetHelper
+  def present_terms(presenter, terms = :all, &block)
+    terms = presenter.terms if terms == :all
+    Sufia::PresenterRenderer.new(presenter, self).fields(terms, &block)
+  end
+
+  def show_request_file_button(file, text)
+    link_to "#{sufia.contact_path}?#{subject_and_message}#{main_app.root_url}#{main_app.download_path(file)}",
+            target: :_blank,
+            data: { turbolinks: false },
+            class: "btn btn-default" do
+              text
+            end
+  end
+
+  def show_request_file_action(file, text)
+    link_to text,
+            "#{sufia.contact_path}?#{subject_and_message}#{main_app.root_url}#{main_app.download_path(file)}",
+            title: "Download #{file.to_s.inspect}"
+  end
+
+  def subject_and_message
+    URI.encode("subject=Scholar@UC file request&message=Please contact me about obtaining a copy of the file at ")
+  end
+
+  def file_is_too_large_to_download(file)
+    max_file_size = 3_221_225_472 # 3 GB
+    file.respond_to?(:solr_document) && file.solr_document._source[:file_size_is].to_i > max_file_size
+  end
+end

--- a/app/views/contact_form/new.html.erb
+++ b/app/views/contact_form/new.html.erb
@@ -9,6 +9,9 @@
   <% em = '' %>
 <% end %>
 
+<% subject = params['subject'] || '' %>
+<% message = params['message'] || '' %>
+
 <%= form_for @contact_form, url: sufia.contact_form_index_path,
                             html: { class: 'form-horizontal' } do |f| %>
   <%= f.text_field :contact_method, class: 'hide' %>
@@ -24,12 +27,12 @@
 
   <div class="form-group">
     <%= f.label :subject, 'Subject', class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_field :subject, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_field :subject, value: subject, class: 'form-control', required: true %></div>
   </div>
 
   <div class="form-group">
     <%= f.label :message, 'Message', class: "col-sm-2 control-label" %>
-    <div class="col-sm-10"><%= f.text_area :message, rows: 4, class: 'form-control', required: true %></div>
+    <div class="col-sm-10"><%= f.text_area :message, value: message, rows: 4, class: 'form-control', required: true %></div>
   </div>
 
   <% if current_user.blank? %>

--- a/app/views/curation_concerns/file_sets/_actions.html.erb
+++ b/app/views/curation_concerns/file_sets/_actions.html.erb
@@ -1,0 +1,45 @@
+<div class="btn-group">
+
+  <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+
+  <% if can?(:edit, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Edit', edit_polymorphic_path([main_app, file_set]),
+        { title: "Edit #{file_set}" } %>
+    </li>
+
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Versions',  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+        { title: "Display previous versions" } %>
+    </li>
+  <% end %>
+
+  <% if can?(:destroy, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+      <%= link_to 'Delete', polymorphic_path([main_app, file_set]),
+        method: :delete, title: "Delete #{file_set}",
+        data: {confirm: "Deleting #{file_set} from #{application_name} is permanent. Click OK to delete this from #{application_name}, or Cancel to cancel this operation"} %>
+    </li>
+  <% end %>
+
+  <% if can?(:read, file_set.id) %>
+    <li role="menuitem" tabindex="-1">
+    <% if file_is_too_large_to_download(file_set) %>
+      <%= show_request_file_action(file_set, t('curation_concerns.show.requestable_content.action_link')) %>
+    <% else %>
+      <%= link_to 'Download', main_app.download_path(file_set),
+        title: "Download #{file_set.to_s.inspect}", target: "_blank" %>
+    <% end %>
+    </li>
+  <% end %>
+
+  </ul>
+</div>
+
+

--- a/app/views/curation_concerns/file_sets/media_display/_audio.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_audio.html.erb
@@ -1,0 +1,18 @@
+  <audio controls="controls" class="audiojs" preload="auto">
+    <source src="<%= main_app.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+    <source src="<%= main_app.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+    Your browser does not support the audio tag.
+  </audio>
+
+  <% if CurationConcerns.config.display_media_download_link %>
+    <% if file_is_too_large_to_download(file_set) %>            
+      <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.audio_link')) %>
+    <% else %>
+      <%= link_to main_app.download_path(file_set),
+                  target: :_blank,
+                  data: { turbolinks: false },
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.audio_link') %>
+      <% end %>
+    <% end %>
+  <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_default.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_default.html.erb
@@ -1,0 +1,15 @@
+<div class="no-preview">
+  <%= t('sufia.works.show.no_preview') %>
+  <% if CurationConcerns.config.display_media_download_link %>
+    <% if file_is_too_large_to_download(file_set) %>            
+      <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.default_link')) %>
+    <% else %>
+      <%= link_to main_app.download_path(file_set),
+                  target: :_blank,
+                  data: { turbolinks: false },
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.default_link') %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -7,11 +7,15 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
-           <%= link_to main_app.download_path(file_set),
-                  target: :_blank,
-                  data: { turbolinks: false },
-                  class: "btn btn-default" do %>
-           <%= t('curation_concerns.show.downloadable_content.image_link') %>
+           <% if file_is_too_large_to_download(file_set) %>            
+             <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
+           <% else %>
+             <%= link_to main_app.download_path(file_set),
+                    target: :_blank,
+                    data: { turbolinks: false },
+                    class: "btn btn-default" do %>
+                 <%= t('curation_concerns.show.downloadable_content.image_link') %>
+             <% end %>
            <% end %>
         
 
@@ -21,11 +25,15 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
-           <%= link_to main_app.download_path(file_set),
-                  target: :_blank,
-                  data: { turbolinks: false },
-                  class: "btn btn-default" do %>
-           <%= t('curation_concerns.show.downloadable_content.image_link') %>
+           <% if file_is_too_large_to_download(file_set) %>            
+             <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
+           <% else %>
+             <%= link_to main_app.download_path(file_set),
+                    target: :_blank,
+                    data: { turbolinks: false },
+                    class: "btn btn-default" do %>
+                 <%= t('curation_concerns.show.downloadable_content.image_link') %>
+             <% end %>
            <% end %>
 
         <% else %>

--- a/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_office_document.html.erb
@@ -1,0 +1,26 @@
+<% if CurationConcerns.config.display_media_download_link %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <% if file_is_too_large_to_download(file_set) %>            
+        <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.office_link')) %>
+      <% else %>
+        <%= link_to main_app.download_path(file_set),
+                    data: { turbolinks: false },
+                    target: :_blank,
+                    class: "btn btn-default" do %>
+            <%= t('curation_concerns.show.downloadable_content.office_link') %>
+        <% end %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,26 @@
+<% if CurationConcerns.config.display_media_download_link %>
+    <div>
+      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <% if file_is_too_large_to_download(file_set) %>            
+        <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.pdf_link')) %>
+      <% else %>
+        <%= link_to main_app.download_path(file_set),
+                    target: :_blank,
+                    data: { turbolinks: false },
+                    class: "btn btn-default" do %>
+            <%= t('curation_concerns.show.downloadable_content.pdf_link') %>
+        <% end %>
+      <% end %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_video.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_video.html.erb
@@ -1,0 +1,18 @@
+  <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+    <source src="<%= main_app.download_path(file_set, file: 'webm') %>" type="video/webm" />
+    <source src="<%= main_app.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>
+
+  <% if CurationConcerns.config.display_media_download_link %>
+    <% if file_is_too_large_to_download(file_set) %>            
+      <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.video_link')) %>
+    <% else %>
+      <%= link_to main_app.download_path(file_set),
+                  target: :_blank,
+                  data: { turbolinks: false },
+                  class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.video_link') %>
+      <% end %>
+    <% end %>
+  <% end %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -30,8 +30,27 @@ en:
     terms_of_use_html: "<a class=\"a\" href=\"/terms\">Scholar@UC Terms of Use</a>"
     non_discrimination_notice_html: "<a href=\"http://uc.edu/about/policies/non-discrimination.html\">Notice of Non-Discrimination</a>"
     share_button: "Contribute"
-
   curation_concerns:
     base:
       metadata:
         header: Attributes
+    upload:
+      cloud_timeout_message_html: "If you have files on cloud storage sites such as Box, Dropbox, Google Drive, or Kaltura, you can click the \"Browse cloud files\" button to select and upload those files directly to Scholar@UC.<br /><br />Please note that if you upload a large number of files within a short period of time, the cloud provider may not be able to accommodate your request. If you experience any errors uploading from the cloud, let us know via the %{contact_href}."
+
+  curation_concerns:
+    base:
+      form_files:
+        external_upload: "Add Files from Cloud Providers"
+    show:
+      downloadable_content:
+        audio_link: 'Download audio file'
+        video_link: 'Download video'
+      requestable_content:
+        action_link: 'Request this file'
+        default_link: 'Request a copy of this file'
+        image_link: 'Request a copy of this image'
+        office_link: 'Request a copy of this file'
+        pdf_link: 'Request a copy of this PDF'
+        audio_link: 'Request a copy of this audio file'
+        video_link: 'Request a copy of this video'
+

--- a/spec/helpers/file_set_helper_spec.rb
+++ b/spec/helpers/file_set_helper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include Devise::TestHelpers
+
+describe FileSetHelper, type: :helper do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:file_set) { FactoryGirl.create(:file_set, user: user, title: ['File Title']) }
+  let(:button_text) { 'Request this file' }
+  let(:small_solr_document) { SolrDocument.new(id: '123456', file_size_is: '3221225472') }
+  let(:large_solr_document) { SolrDocument.new(id: '123456', file_size_is: '3221225473') }
+
+  describe 'show_request_file_button' do
+    it 'renders the request file button' do
+      expect(helper.show_request_file_button(file_set, button_text)).to have_link(button_text, href: "#{sufia.contact_path}?#{helper.subject_and_message}#{main_app.root_url}#{main_app.download_path(file_set)}")
+    end
+  end
+
+  describe 'show_request_file_action' do
+    it 'renders the request file action link' do
+      expect(helper.show_request_file_action(file_set, button_text)).to have_link("Download #{file_set.to_s.inspect}", href: "#{sufia.contact_path}?#{helper.subject_and_message}#{main_app.root_url}#{main_app.download_path(file_set)}")
+    end
+  end
+
+  describe 'subject_and_message' do
+    it 'returns the subject and message query params' do
+      expect(helper.subject_and_message).to have_content('subject=')
+      expect(helper.subject_and_message).to have_content('message=')
+    end
+  end
+
+  describe 'file_is_too_large_to_download' do
+    context 'when the file is larger than the max download size' do
+      before do
+        allow(file_set).to receive(:solr_document).and_return(large_solr_document)
+      end
+      it 'returns true' do
+        expect(helper.file_is_too_large_to_download(file_set)).to be true
+      end
+    end
+
+    context 'when the file is smaller than the max download size' do
+      before do
+        allow(file_set).to receive(:solr_document).and_return(small_solr_document)
+      end
+      it 'returns false' do
+        expect(helper.file_is_too_large_to_download(file_set)).to be false
+      end
+    end
+  end
+end

--- a/spec/views/contact_form/new.html.erb_spec.rb
+++ b/spec/views/contact_form/new.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe '/contact_form/new.html.erb', type: :view do
+  before do
+    view.stub(:user_signed_in?) { false }
+    allow(view).to receive(:current_user).and_return('')
+    @contact_form = Sufia::ContactForm.new
+    params['subject'] = 'This is the subject'
+    params['message'] = 'This is the message'
+    render
+  end
+
+  it 'includes the passed subject text to the form' do
+    expect(rendered).to have_selector('input[name="sufia_contact_form[subject]"][value="This is the subject"]')
+  end
+
+  it 'includes the passed message text to the form' do
+    expect(rendered).to have_content('This is the message')
+  end
+end

--- a/spec/views/curation_concerns/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_actions.html.erb_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'curation_concerns/file_sets/_actions', type: :view do
+  before do
+    allow(view).to receive_messages(blacklight_config: CatalogController.blacklight_config,
+                                    blacklight_configuration_context: Blacklight::Configuration::Context.new(controller))
+    allow(CurationConcerns.config).to receive(:display_media_download_link) { true }
+    allow(view).to receive(:can?).and_return(true)
+  end
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:small_solr_document) { SolrDocument.new(id: '123456', file_size_is: '3221225472') }
+
+  let(:small_file) do
+    stub_model(FileSet, id: '123',
+                        depositor: depositor.user_key,
+                        audit_stat: 1,
+                        title: ['Small File'],
+                        description: ['Lorem ipsum lorem ipsum. http://my.link.com'],
+                        mime_type: 'application/binary',
+                        has?: false,
+                        solr_document: small_solr_document)
+  end
+
+  let(:large_solr_document) { SolrDocument.new(id: '234567', file_size_is: '3221225473') }
+
+  let(:large_file) do
+    stub_model(FileSet, id: '456',
+                        depositor: depositor.user_key,
+                        audit_stat: 1,
+                        title: ['Large File'],
+                        description: ['Lorem ipsum lorem ipsum. http://my.link.com'],
+                        mime_type: 'application/binary',
+                        has?: false,
+                        solr_document: large_solr_document)
+  end
+
+  context 'when the file is smaller than the max download size' do
+    before do
+      render 'curation_concerns/file_sets/actions', file_set: small_file
+    end
+
+    it 'renders the download file link' do
+      expect(rendered).to have_link 'Download "Small File"'
+    end
+  end
+
+  context 'when the image is larger than the max download size' do
+    before do
+      render 'curation_concerns/file_sets/actions', file_set: large_file
+    end
+
+    it 'renders the request image link' do
+      expect(rendered).to have_link 'Request this file'
+    end
+  end
+end

--- a/spec/views/curation_concerns/file_sets/media_display_spec.rb
+++ b/spec/views/curation_concerns/file_sets/media_display_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'curation_concerns/file_sets/media_display', type: :view do
+  before do
+    allow(view).to receive_messages(blacklight_config: CatalogController.blacklight_config,
+                                    blacklight_configuration_context: Blacklight::Configuration::Context.new(controller))
+    allow(CurationConcerns.config).to receive(:display_media_download_link) { true }
+  end
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:small_solr_document) { SolrDocument.new(id: '123456', file_size_is: '3221225472') }
+
+  let(:small_file) do
+    stub_model(FileSet, id: '123',
+                        depositor: depositor.user_key,
+                        audit_stat: 1,
+                        title: ['Small File'],
+                        description: ['Lorem ipsum lorem ipsum. http://my.link.com'],
+                        mime_type: 'application/binary',
+                        has?: false,
+                        solr_document: small_solr_document)
+  end
+
+  let(:large_solr_document) { SolrDocument.new(id: '234567', file_size_is: '3221225473') }
+
+  let(:large_file) do
+    stub_model(FileSet, id: '456',
+                        depositor: depositor.user_key,
+                        audit_stat: 1,
+                        title: ['Large File'],
+                        description: ['Lorem ipsum lorem ipsum. http://my.link.com'],
+                        mime_type: 'application/binary',
+                        has?: false,
+                        solr_document: large_solr_document)
+  end
+
+  describe 'image' do
+    context 'when the image is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/image', file_set: small_file
+      end
+
+      it 'renders the download image link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.image_link')
+      end
+    end
+
+    context 'when the image is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/image', file_set: large_file
+      end
+
+      it 'renders the request image link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.image_link')
+      end
+    end
+  end
+
+  describe 'pdf' do
+    context 'when the PDF is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/pdf', file_set: small_file
+      end
+
+      it 'renders the download PDF link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.pdf_link')
+      end
+    end
+
+    context 'when the PDF is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/pdf', file_set: large_file
+      end
+
+      it 'renders the request PDF link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.pdf_link')
+      end
+    end
+  end
+
+  describe 'office_document' do
+    context 'when the office document is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/office_document', file_set: small_file
+      end
+
+      it 'renders the download office document link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.office_link')
+      end
+    end
+
+    context 'when the office document is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/office_document', file_set: large_file
+      end
+
+      it 'renders the request office document link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.office_link')
+      end
+    end
+  end
+
+  describe 'video' do
+    context 'when the video is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/video', file_set: small_file
+      end
+
+      it 'renders the download video link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.video_link')
+      end
+    end
+
+    context 'when the video is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/video', file_set: large_file
+      end
+
+      it 'renders the request video link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.video_link')
+      end
+    end
+  end
+
+  describe 'audio' do
+    context 'when the audio is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/audio', file_set: small_file
+      end
+
+      it 'renders the download audio link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.audio_link')
+      end
+    end
+
+    context 'when the audio is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/audio', file_set: large_file
+      end
+
+      it 'renders the request audio link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.audio_link')
+      end
+    end
+  end
+
+  describe 'default' do
+    context 'when the file is smaller than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/default', file_set: small_file
+      end
+
+      it 'renders the download file document link' do
+        expect(rendered).to have_link t('curation_concerns.show.downloadable_content.default_link')
+      end
+    end
+
+    context 'when the file is larger than the max download size' do
+      before do
+        render 'curation_concerns/file_sets/media_display/default', file_set: large_file
+      end
+
+      it 'renders the request file link' do
+        expect(rendered).to have_link t('curation_concerns.show.requestable_content.default_link')
+      end
+    end
+  end
+end

--- a/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
+++ b/vendor/assets/javascripts/fileupload/jquery.fileupload-validate.js
@@ -1,0 +1,122 @@
+/*
+ * jQuery File Upload Validation Plugin
+ * https://github.com/blueimp/jQuery-File-Upload
+ *
+ * Copyright 2013, Sebastian Tschan
+ * https://blueimp.net
+ *
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/MIT
+ */
+
+/* global define, require, window */
+
+(function (factory) {
+    'use strict';
+    if (typeof define === 'function' && define.amd) {
+        // Register as an anonymous AMD module:
+        define([
+            'jquery',
+            './jquery.fileupload-process'
+        ], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS:
+        factory(require('jquery'));
+    } else {
+        // Browser globals:
+        factory(
+            window.jQuery
+        );
+    }
+}(function ($) {
+    'use strict';
+
+    // Append to the default processQueue:
+    $.blueimp.fileupload.prototype.options.processQueue.push(
+        {
+            action: 'validate',
+            // Always trigger this action,
+            // even if the previous action was rejected:
+            always: true,
+            // Options taken from the global options map:
+            acceptFileTypes: '@',
+            maxFileSize: '@',
+            minFileSize: '@',
+            maxNumberOfFiles: '@',
+            disabled: '@disableValidation'
+        }
+    );
+
+    // The File Upload Validation plugin extends the fileupload widget
+    // with file validation functionality:
+    $.widget('blueimp.fileupload', $.blueimp.fileupload, {
+
+        options: {
+            /*
+            // The regular expression for allowed file types, matches
+            // against either file type or file name:
+            acceptFileTypes: /(\.|\/)(gif|jpe?g|png)$/i,
+            // The maximum allowed file size in bytes:
+            maxFileSize: 10000000, // 10 MB
+            // The minimum allowed file size in bytes:
+            minFileSize: undefined, // No minimal file size
+            // The limit of files to be uploaded:
+            maxNumberOfFiles: 10,
+            */
+
+            // Function returning the current number of files,
+            // has to be overriden for maxNumberOfFiles validation:
+            getNumberOfFiles: $.noop,
+
+            // Error and info messages:
+            messages: {
+                maxNumberOfFiles: 'Maximum number of files exceeded',
+                acceptFileTypes: 'File type not allowed',
+                maxFileSize: 'This file is too large to upload to Scholar@UC via the website.  For files larger than 3 gigabytes, upload them using the cloud providers option below or use the Contact Us form to request other ways to add your content to Scholar@UC.',
+                minFileSize: 'File is too small'
+            }
+        },
+
+        processActions: {
+
+            validate: function (data, options) {
+                if (options.disabled) {
+                    return data;
+                }
+                var dfd = $.Deferred(),
+                    settings = this.options,
+                    file = data.files[data.index],
+                    fileSize;
+                if (options.minFileSize || options.maxFileSize) {
+                    fileSize = file.size;
+                }
+                if ($.type(options.maxNumberOfFiles) === 'number' &&
+                        (settings.getNumberOfFiles() || 0) + data.files.length >
+                            options.maxNumberOfFiles) {
+                    file.error = settings.i18n('maxNumberOfFiles');
+                } else if (options.acceptFileTypes &&
+                        !(options.acceptFileTypes.test(file.type) ||
+                        options.acceptFileTypes.test(file.name))) {
+                    file.error = settings.i18n('acceptFileTypes');
+                } else if (fileSize > options.maxFileSize) {
+                    file.error = settings.i18n('maxFileSize');
+                } else if ($.type(fileSize) === 'number' &&
+                        fileSize < options.minFileSize) {
+                    file.error = settings.i18n('minFileSize');
+                } else {
+                    delete file.error;
+                }
+                if (file.error || data.files.error) {
+                    data.files.error = true;
+                    dfd.rejectWith(this, [data]);
+                } else {
+                    dfd.resolveWith(this, [data]);
+                }
+                return dfd.promise();
+            }
+
+        }
+
+    });
+
+}));


### PR DESCRIPTION
1) Limits uploads to 3 GB per file
2) Limits downloads to file < 3 GB.  Larger files will instead show a request link that composes a contact form message.
3) Adjusts the description for cloud provider uploads so users better understand it.
4) Video and audio files did not previously have a download button.  This adds it.

To test the upload limit locally, you can lower the `maxFileSize` variable in app/assets/javascripts/sufia/uploader.js to something much lower than 3 GB.

To test the download limit locally, you can lower the `max_file_file` variable at the bottom of app/helpers/file_set_helper.rb to something much lower than 3 GB.