### PR TITLE
Fix single work link on batch create form

### DIFF
--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,0 +1,15 @@
+<%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
+  <% content_for :files_tab do %>
+    <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
+    <p class="switch-upload-type">Note: To create a single work for all the files, go to the <%= link_to "Add New " + @form.payload_concern.constantize.model_name.human.titleize, main_app.new_polymorphic_path(@form.payload_concern.constantize) %> page.</p>
+  <% end %>
+  <%= render 'curation_concerns/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
+  <% end %>
+  <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'batch-template-download')
+  });
+</script>

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -10,7 +10,7 @@ describe 'Batch creation of works', type: :feature do
   end
 
   it "renders the batch create form" do
-    visit sufia.new_batch_upload_path
+    visit "#{sufia.new_batch_upload_path}/?payload_concern=GenericWork"
     within("li.active") do
       expect(page).to have_content("Files")
     end

--- a/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/sufia/batch_uploads/_form.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'sufia/batch_uploads/_form.html.erb', type: :view do
+  let(:work) { GenericWork.new }
+  let(:ability) { double('ability', current_user: user) }
+  let(:form) { Sufia::Forms::BatchUploadForm.new(work, ability) }
+  let(:user) { stub_model(User) }
+
+  before do
+    allow(form).to receive(:payload_concern).and_return('GenericWork')
+    stub_template "curation_concerns/base/_guts4form.html.erb" => "Form guts"
+    assign(:form, form)
+  end
+
+  let(:page) do
+    render
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  it "draws the page" do
+    expect(page).to have_selector("form[action='/batch_uploads']")
+    # No title, because it's captured per file (e.g. Display label)
+    expect(page).not_to have_selector("input#generic_work_title")
+    expect(view.content_for(:files_tab)).to have_link("Add New Generic Work", href: "/concern/generic_works/new")
+  end
+end


### PR DESCRIPTION
Fixes #1251 

Pulls in a view and spec from Sufia so we can change the "create a single work" link to point to the appropriate type of work.  The changed line in the view is line #4.