### PR TITLE
Remove savewidget id from the sidebar div tag

### DIFF
--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -53,7 +53,7 @@
     </div>
   </div>
 
-  <div id="savewidget" class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
+  <div class="col-xs-12 col-sm-4 fixedsticky" role="complementary">
     <%= render 'form_progress', f: f %>
   </div>
 </div>


### PR DESCRIPTION
Fixes #1108 

The sidebar can no longer get hidden under the footer, and scrolls properly with any screen size
