### PR TITLE
Excludes GIF files from UV.

### DIFF
--- a/app/helpers/file_set_helper.rb
+++ b/app/helpers/file_set_helper.rb
@@ -28,4 +28,8 @@ module FileSetHelper
     max_file_size = 3_221_225_472 # 3 GB
     file.respond_to?(:solr_document) && file.solr_document._source[:file_size_is].to_i > max_file_size
   end
+
+  def this_is_a_file?(presenter)
+    presenter.human_readable_type == 'File'
+  end
 end

--- a/app/views/curation_concerns/file_sets/media_display/_image.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_image.html.erb
@@ -1,63 +1,18 @@
 <% if CurationConcerns.config.display_media_download_link %>
-    <div>
-      <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
-       <% if @presenter.nil? %>
-        
-           <%= image_tag thumbnail_url(file_set),
-                    class: "representative-media",
-                    alt: "",
-                    role: "presentation" %>
-           <% if file_is_too_large_to_download(file_set) %>            
-             <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
-           <% else %>
-             <%= link_to main_app.download_path(file_set),
-                    target: :_blank,
-                    data: { turbolinks: false },
-                    class: "btn btn-default" do %>
-                 <%= t('curation_concerns.show.downloadable_content.image_link') %>
-             <% end %>
-           <% end %>
-        
-
-      <% elsif @presenter.human_readable_type == 'File' %>
-
-          <%= image_tag thumbnail_url(file_set),
-                    class: "representative-media",
-                    alt: "",
-                    role: "presentation" %>
-           <% if file_is_too_large_to_download(file_set) %>            
-             <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
-           <% else %>
-             <%= link_to main_app.download_path(file_set),
-                    target: :_blank,
-                    data: { turbolinks: false },
-                    class: "btn btn-default" do %>
-                 <%= t('curation_concerns.show.downloadable_content.image_link') %>
-             <% end %>
-           <% end %>
-
-        <% else %>
-
-        <%= UniversalViewer.script_tag %>
-        <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, @presenter] %>"></div>
-        </br>
+  <div>
+    <h2 class="sr-only"><%= t('curation_concerns.show.downloadable_content.heading') %></h2>
+      <% if @presenter.nil? %>
+        <%= render 'curation_concerns/file_sets/media_display/thumbnail', file_set: file_set  %>
+      <% elsif this_is_a_file?(@presenter) %>
+        <%= render 'curation_concerns/file_sets/media_display/thumbnail', file_set: file_set  %>
+      <% else %>
+        <%= render 'curation_concerns/file_sets/media_display/universal_viewer', file_set: file_set %>
       <% end %>
   </div>
 <% else %>
-    <div>
-  
-     <% if @presenter.human_readable_type == 'File' %>
-
-           <%= image_tag thumbnail_url(file_set),
-                    class: "representative-media",
-                    alt: "",
-                    role: "presentation" %>
-
-     <% else %>
-
-
-    <%= UniversalViewer.script_tag %>
-    <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, @presenter] %>"></div>
+  <div>
+     <% if this_is_a_file?(@presenter) %>
+       <%= render 'curation_concerns/file_sets/media_display/universal_viewer', file_set: file_set %>
      <% end %>
-    </div>
+  </div>
 <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_thumbnail.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_thumbnail.html.erb
@@ -1,0 +1,14 @@
+<%= image_tag thumbnail_url(file_set),
+         class: "representative-media",
+         alt: "",
+         role: "presentation" %>
+<% if file_is_too_large_to_download(file_set) %>
+  <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
+<% else %>
+  <%= link_to main_app.download_path(file_set),
+       target: :_blank,
+       data: { turbolinks: false },
+       class: "btn btn-default" do %>
+          <%= t('curation_concerns.show.downloadable_content.image_link') %>
+          <% end %>
+  <% end %>

--- a/app/views/curation_concerns/file_sets/media_display/_universal_viewer.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_universal_viewer.html.erb
@@ -1,0 +1,20 @@
+  <% if file_set.mime_type == "image/gif" %>
+    <%= image_tag thumbnail_url(file_set),
+          class: "representative-media",
+          alt: "",
+          role: "presentation" %>
+    <% if file_is_too_large_to_download(file_set) %>
+      <%= show_request_file_button(file_set, t('curation_concerns.show.requestable_content.image_link')) %>
+    <% else %>
+      <%= link_to main_app.download_path(file_set),
+          target: :_blank,
+          data: { turbolinks: false },
+          class: "btn btn-default" do %>
+            <%= t('curation_concerns.show.downloadable_content.image_link') %>
+          <% end %>  
+   <% end %>
+<% else %>
+    <%= UniversalViewer.script_tag %>
+    <div class="uv viewer" data-uri="<%= main_app.polymorphic_path [main_app, :manifest, @presenter] %>"></div>
+    </br>
+  <% end %>


### PR DESCRIPTION
Fixes #1259 

Present short summary (50 characters or less)

Provides thumbnail and download link for GIF files instead of including them in manifest for Universal Viewer.  