### PR TITLE
Fix admin set creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,7 @@ Rails/OutputSafety:
 RSpec/AnyInstance:
   Exclude:
     - 'spec/controllers/contact_form_controller_spec.rb'
+    - 'spec/features/admin_admin_set_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:

--- a/app/controllers/sufia/admin/admin_sets_controller.rb
+++ b/app/controllers/sufia/admin/admin_sets_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require Sufia::Engine.root.join('app/controllers/sufia/admin/admin_sets_controller.rb')
+module Sufia
+  class Admin::AdminSetsController
+    private
+
+      def create_admin_set
+        AdminSetCreateService.new(@admin_set, current_user, selected_workflow).create
+      end
+
+      def selected_workflow
+        params[:admin_set][:workflow_name]
+      end
+  end
+end

--- a/spec/features/admin_admin_set_spec.rb
+++ b/spec/features/admin_admin_set_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "New admin set" do
+  let(:user) { create :user }
+
+  before do
+    allow_any_instance_of(Ability).to receive(:user_groups).and_return(['admin'])
+  end
+
+  scenario do
+    login_as(user)
+    visit '/admin/admin_sets/new'
+    within('#description') do
+      fill_in "Title", with: 'The title'
+      click_button 'Save'
+    end
+    expect(page).to have_content "The title"
+  end
+end


### PR DESCRIPTION
Fixes #1269 

Re-opens Sufia::Admin::AdminSetsController to fix create_admin_set