### PR TITLE
fix batch edit with multiple work types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -157,6 +157,7 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/features/*'
     - 'spec/support/shared/*'
+    - 'spec/forms/sufia/forms/batch_edit_form_spec.rb'
 
 RSpec/SubjectStub:
   Enabled: false

--- a/app/forms/sufia/forms/batch_edit_form.rb
+++ b/app/forms/sufia/forms/batch_edit_form.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+module Sufia
+  module Forms
+    class BatchEditForm < Sufia::Forms::WorkForm
+      # Used for drawing the fields that appear on the page
+      self.terms = [:creator, :contributor, :description,
+                    :keyword, :resource_type, :rights, :publisher, :date_created,
+                    :subject, :language, :identifier, :based_near,
+                    :related_url]
+      self.required_fields = []
+      self.model_class = Sufia.primary_work_type
+
+      attr_accessor :names
+
+      # @param [ActiveFedora::Base] model the model backing the form
+      # @param [Ability] current_ability the user authorization model
+      # @param [Array<String>] batch_document_ids a list of document ids in the batch
+      def initialize(model, current_ability, batch_document_ids)
+        super(model, current_ability)
+        @names = []
+        @batch_document_ids = batch_document_ids
+        initialize_combined_fields
+      end
+
+      attr_reader :batch_document_ids
+
+      # Which parameters can we accept from the form
+      def self.build_permitted_params
+        super + [:visibility_during_embargo, :embargo_release_date,
+                 :visibility_after_embargo, :visibility_during_lease,
+                 :lease_expiration_date, :visibility_after_lease, :visibility] -
+          [{ work_members_attributes: [:id, :_destroy] }]
+      end
+
+      private
+
+        # override this method if you need to initialize more complex RDF assertions (b-nodes)
+        def initialize_combined_fields
+          combined_attributes = {}
+          permissions = []
+          # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
+          batch_document_ids.each do |doc_id|
+            work = ActiveFedora::Base.find(doc_id)
+            terms.each do |key|
+              combined_attributes[key] ||= []
+              combined_attributes[key] = (combined_attributes[key] + work[key].to_a).uniq
+            end
+            names << work.to_s
+            permissions = (permissions + work.permissions).uniq
+          end
+
+          terms.each do |key|
+            # if value is empty, we create an one element array to loop over for output
+            model[key] = combined_attributes[key].empty? ? [''] : combined_attributes[key]
+          end
+          model.permissions_attributes = [{ type: 'group', name: 'public', access: 'read' }]
+        end
+    end
+  end
+end

--- a/spec/forms/sufia/forms/batch_edit_form_spec.rb
+++ b/spec/forms/sufia/forms/batch_edit_form_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sufia::Forms::BatchEditForm do
+  let(:model) { GenericWork.new }
+  let(:work1) { create :generic_work, title: ["title 1"], keyword: ["abc"], creator: ["Wilma"], language: ['en'], contributor: ['contributor1'], description: ['description1'], rights: ['rights1'], subject: ['subject1'], identifier: ['id1'], based_near: ['based_near1'], related_url: ['related_url1'] }
+  let(:work2) { create :generic_work, title: ["title 2"], keyword: ["123"], creator: ["Fred"], publisher: ['Rand McNally'], language: ['en'], resource_type: ['bar'], contributor: ['contributor2'], description: ['description2'], rights: ['rights2'], subject: ['subject2'], identifier: ['id2'], based_near: ['based_near2'], related_url: ['related_url2'] }
+  let(:batch) { [work1.id, work2.id] }
+  let(:form) { described_class.new(model, ability, batch) }
+  let(:ability) { Ability.new(user) }
+  let(:user) { build(:user, display_name: 'Jill Z. User') }
+
+  describe "#terms" do
+    subject { form.terms }
+    it do
+      is_expected.to eq [:creator,
+                         :contributor,
+                         :description,
+                         :keyword,
+                         :resource_type,
+                         :rights,
+                         :publisher,
+                         :date_created,
+                         :subject,
+                         :language,
+                         :identifier,
+                         :based_near,
+                         :related_url]
+    end
+  end
+
+  describe "#model" do
+    it "combines the models in the batch" do
+      expect(form.model.creator).to match_array ["Wilma", "Fred"]
+      expect(form.model.contributor).to match_array ["contributor1", "contributor2"]
+      expect(form.model.description).to match_array ["description1", "description2"]
+      expect(form.model.keyword).to match_array ["abc", "123"]
+      expect(form.model.resource_type).to match_array ["bar"]
+      expect(form.model.rights).to match_array ["rights1", "rights2"]
+      expect(form.model.publisher).to match_array ["Rand McNally"]
+      expect(form.model.subject).to match_array ["subject1", "subject2"]
+      expect(form.model.language).to match_array ["en"]
+      expect(form.model.identifier).to match_array ["id1", "id2"]
+      expect(form.model.based_near).to match_array ["based_near1", "based_near2"]
+      expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
+    end
+  end
+
+  describe ".build_permitted_params" do
+    subject { described_class.build_permitted_params }
+    it do
+      is_expected.to eq [{ creator: [] },
+                         { contributor: [] },
+                         { description: [] },
+                         { keyword: [] },
+                         { resource_type: [] },
+                         { rights: [] },
+                         { publisher: [] },
+                         { date_created: [] },
+                         { subject: [] },
+                         { language: [] },
+                         { identifier: [] },
+                         { based_near: [] },
+                         { related_url: [] },
+                         :version,
+                         { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
+                         :on_behalf_of,
+                         { collection_ids: [] },
+                         :visibility_during_embargo,
+                         :embargo_release_date,
+                         :visibility_after_embargo,
+                         :visibility_during_lease,
+                         :lease_expiration_date,
+                         :visibility_after_lease,
+                         :visibility]
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1280 

Present short summary (50 characters or less)

This PR changes minor sufia functionality. `batch_edit_form.rb` assumed that all works in a batch edit would be the same work type, resulting in a broken `find` operation.

This change enables the batch edit form to process any work type which is a child of `ActiveFedora::Base`.

The only changed line in the batch edit form is:

https://github.com/projecthydra/sufia/blob/master/app/forms/sufia/forms/batch_edit_form.rb#L42


Changes proposed in this pull request:
* Change line 42 of `batch_edit_form.rb` to `ActiveBase.find` rather than `model_class.find`
