### PR TITLE
Adds genre to Image, Document, and StudentWork.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -115,7 +115,6 @@ class CatalogController < ApplicationController
     config.add_show_field solr_name("time_period", :stored_searchable), label: "Time Period"
     config.add_show_field solr_name("required_software", :stored_searchable), label: "Required Software"
     config.add_show_field solr_name("note", :stored_searchable), label: "Note"
-    config.add_show_field solr_name("genre", :stored_searchable), label: "Genre"
     config.add_show_field solr_name("degree", :stored_searchable), label: "Degree"
     config.add_show_field solr_name("advisor", :stored_searchable), label: "Advisor"
     config.add_show_field solr_name("committee_member", :stored_searchable), label: "Committee Member"

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -6,8 +6,8 @@ module CurationConcerns
     self.model_class = ::Document
 
     ## Adding custom descriptive metadata terms
-    self.terms += %i(resource_type alternate_title genre
-                     time_period required_software note geo_subject)
+    self.terms += %i(alternate_title genre time_period
+                     required_software note geo_subject)
 
     ## Adding terms needed for the special DOI form tab
     self.terms += %i(doi doi_assignment_strategy existing_identifier)
@@ -28,7 +28,7 @@ module CurationConcerns
 
     ## Overriding secondary terms to establish custom field order
     def secondary_terms
-      %i(date_created alternate_title subject
+      %i(date_created alternate_title genre subject
          geo_subject time_period language
          required_software note related_url)
     end

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -6,7 +6,7 @@ module CurationConcerns
     self.model_class = ::Etd
 
     ## Adding custom descriptive metadata terms
-    self.terms += %i(resource_type alternate_title genre
+    self.terms += %i(alternate_title genre
                      time_period required_software note
                      degree degree_date advisor committee_member geo_subject)
 

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -69,4 +69,40 @@ module SufiaHelper
     end
     cache
   end
+
+  def sorted_genre_list_for_works
+    if curation_concern.is_a? Document
+      sorted_genre_list_for_documents
+    elsif curation_concern.is_a? StudentWork
+      sorted_genre_list_for_student_works
+    elsif curation_concern.is_a? Image
+      sorted_genre_list_for_images
+    else
+      sorted_genre_list_for_other_works
+    end
+  end
+
+  def sorted_genre_list_for_documents
+    GENRE_TYPES_DOCUMENT["terms"].keys.collect do |k|
+      GENRE_TYPES_DOCUMENT["terms"][k]["label"]
+    end.sort
+  end
+
+  def sorted_genre_list_for_student_works
+    GENRE_TYPES_STUDENTWORK["terms"].keys.collect do |k|
+      GENRE_TYPES_STUDENTWORK["terms"][k]["label"]
+    end.sort
+  end
+
+  def sorted_genre_list_for_images
+    GENRE_TYPES_IMAGE["terms"].keys.collect do |k|
+      GENRE_TYPES_IMAGE["terms"][k]["label"]
+    end.sort
+  end
+
+  def sorted_genre_list_for_other_works
+    GENRE_TYPES_STUDENTWORK["terms"].keys.collect do |k|
+      GENRE_TYPES_STUDENTWORK["terms"][k]["label"]
+    end.sort
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,7 +21,7 @@ class Document < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre') do |index|
+  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre'), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -21,7 +21,7 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
-  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre') do |index|
+  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre'), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -69,7 +69,7 @@ class SolrDocument
     self[Solrizer.solr_name('issn')]
   end
 
-  # Added for Document and Image work types
+  # Added for StudentWork, Document, and Image work types
   def genre
     self[Solrizer.solr_name('genre')]
   end

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -29,7 +29,7 @@ class StudentWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
-  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre') do |index|
+  property :genre, predicate: ::RDF::URI.new('http://purl.org/dc/terms/type#genre'), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
 

--- a/app/presenters/etd_presenter.rb
+++ b/app/presenters/etd_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class EtdPresenter < Sufia::WorkShowPresenter
-  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :degree, :advisor, :committee_member, :geo_subject, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :time_period, :required_software, :note, :degree, :advisor, :committee_member, :geo_subject, :doi, to: :solr_document
 end

--- a/app/presenters/generic_work_presenter.rb
+++ b/app/presenters/generic_work_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class GenericWorkPresenter < Sufia::WorkShowPresenter
-  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/presenters/video_presenter.rb
+++ b/app/presenters/video_presenter.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class VideoPresenter < Sufia::WorkShowPresenter
-  delegate :college, :department, :alternate_title, :genre, :time_period, :required_software, :note, :doi, to: :solr_document
+  delegate :college, :department, :alternate_title, :time_period, :required_software, :note, :doi, to: :solr_document
 end

--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -1,8 +1,8 @@
 <%= presenter.attribute_to_html(:creator, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:contributor, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:contributor) %>
 <%= presenter.attribute_to_html(:college, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:department, render_as: :faceted) %>
-<%= presenter.attribute_to_html(:admin_set, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:admin_set) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted) %>

--- a/app/views/records/edit_fields/_genre.html.erb
+++ b/app/views/records/edit_fields/_genre.html.erb
@@ -1,0 +1,3 @@
+<%= f.input :genre,
+      collection: sorted_genre_list_for_works,
+      input_html: { class: 'genre' } %>

--- a/config/authorities/genre_types_document.yml
+++ b/config/authorities/genre_types_document.yml
@@ -1,0 +1,23 @@
+terms:
+  Book:
+    label: Book
+  Book Chapter:   
+    label: Book Chapter
+  Brochure:   
+    label: Brochure
+  Document:   
+    label: Document
+  Letter:   
+    label: Letter
+  Manuscript:   
+    label: Manuscript  
+  Newsletter:   
+    label: Newsletter
+  Pamphlet:   
+    label: Pamphlet
+  Press Release:   
+    label: Press Release
+  Report:   
+    label: Report
+  White Paper:   
+    label: White Paper

--- a/config/authorities/genre_types_image.yml
+++ b/config/authorities/genre_types_image.yml
@@ -1,0 +1,14 @@
+terms:
+  Cartoon/Comic:
+    label: Cartoon/Comic
+  Map/Chart:
+    label: Map/Chart
+  Painting:
+    label: Painting
+  Photograph:
+    label: Photograph
+  Poster:
+    label: Poster
+  Visual Art:
+    label: Visual Art
+

--- a/config/authorities/genre_types_student_work.yml
+++ b/config/authorities/genre_types_student_work.yml
@@ -1,0 +1,35 @@
+terms:
+  Book:
+    label: Book
+  Book Chapter:
+    label: Book Chapter
+  Brochure:
+    label: Brochure
+  Cartoon/Comic:
+    label: Cartoon/Comic
+  Document:
+    label: Document
+  Letter:
+    label: Letter
+  Manuscript:
+    label: Manuscript
+  Map/Chart:
+    label: Map/Chart
+  Newsletter:
+    label: Newsletter
+  Painting:
+    label: Painting
+  Pamphlet:
+    label: Pamphlet
+  Photograph:
+    label: Photograph
+  Poster:
+    label: Poster 
+  Press Release:
+    label: Press Release
+  Report:
+    label: Report
+  Visual Art:
+    label: Visual Art
+  White Paper:
+    label: White Paper

--- a/config/initializers/genre_type_initializer.rb
+++ b/config/initializers/genre_type_initializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+GENRE_TYPES_DOCUMENT = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_document.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_document.yml'))
+
+GENRE_TYPES_IMAGE = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_image.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_image.yml'))
+
+GENRE_TYPES_STUDENTWORK = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_student_work.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_student_work.yml'))

--- a/config/locales/student_work.en.yml
+++ b/config/locales/student_work.en.yml
@@ -42,7 +42,7 @@ en:
         publisher: "The person or group making the work available. Generally this is the institution."
         rights: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
         alterante_title: "Enter an alternate title for your work. An alternate title could include acronyms, abbreviations, or a series title."
-        genre: "Select the type of your work. If you are unsure about the type, please select 'Other'."
+        genre: "Select the type of your work."
         time_period: "Enter the period or date associated with the subject of your work.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
         required_software: "Special software needed to open the work"
         note: "Enter any additional information about your work."

--- a/spec/forms/curation_concerns/document_form_spec.rb
+++ b/spec/forms/curation_concerns/document_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CurationConcerns::DocumentForm do
   describe "#secondary_terms" do
     subject { form.secondary_terms }
     it do
-      is_expected.to include(:date_created, :alternate_title,
+      is_expected.to include(:date_created, :alternate_title, :genre,
                              :subject, :geo_subject,
                              :time_period, :language,
                              :required_software, :note)

--- a/spec/forms/curation_concerns/image_form_spec.rb
+++ b/spec/forms/curation_concerns/image_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CurationConcerns::ImageForm do
   describe "#secondary_terms" do
     subject { form.secondary_terms }
     it do
-      is_expected.to include(:date_created, :alternate_title,
+      is_expected.to include(:date_created, :alternate_title, :genre,
                              :subject, :geo_subject,
                              :time_period, :language,
                              :required_software, :note)

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+def new_state
+  Blacklight::SearchState.new({}, CatalogController.blacklight_config)
+end
+
+describe SufiaHelper, type: :helper do
+  describe '#sorted_genre_list_for_documents' do
+    it "returns an array" do
+      expect(helper.sorted_genre_list_for_documents).to be_an(Array)
+    end
+
+    it "contains all the genre types for documents" do
+      expect(helper.sorted_genre_list_for_documents).to eq(
+        ['Book', 'Book Chapter', 'Brochure', 'Document', 'Letter', 'Manuscript', 'Newsletter', 'Pamphlet', 'Press Release', 'Report', 'White Paper']
+      )
+    end
+  end
+
+  describe '#sorted_genre_list_for_student_works' do
+    it "returns an array" do
+      expect(helper.sorted_genre_list_for_student_works).to be_an(Array)
+    end
+
+    it "contains all the genre types for student works" do
+      expect(helper.sorted_genre_list_for_student_works).to eq(
+        ['Book', 'Book Chapter', 'Brochure', 'Cartoon/Comic', 'Document', 'Letter', 'Manuscript', 'Map/Chart', 'Newsletter', 'Painting', 'Pamphlet', 'Photograph', 'Poster', 'Press Release', 'Report', 'Visual Art', 'White Paper']
+      )
+    end
+  end
+
+  describe '#sorted_genre_list_for_images' do
+    it "returns an array" do
+      expect(helper.sorted_genre_list_for_images).to be_an(Array)
+    end
+
+    it "contains all the genre types for student works" do
+      expect(helper.sorted_genre_list_for_images).to eq(
+        ['Cartoon/Comic', 'Map/Chart', 'Painting', 'Photograph', 'Poster', 'Visual Art']
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1102 
Fixes #1273 

Summary:

Adds the genre as a controlled vocabulary to Images, Documents, and Student Works as it is in Scholar 2.x.  Removes the resource_type from all work types.  