### PR TITLE
[WIP] Add thumbnail to collections

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -110,11 +110,12 @@
   width: 100%;
 }
 
-.clear-button {
+.clear-button, .clear-button:active, .clear-button:visited, .clear-button:focus {
   border: 4px solid #fff;
   border-radius: 5px;
   outline-offset: 10px;
   color: #fff;
+  text-decoration: none;
   font-size: 22px;
 }
 
@@ -129,6 +130,11 @@
 .beta-tag {
   color: #e00122;
   font-size: 12px;
+}
+
+.catalog-collection-thumb, .catalog-collection-thumb:focus, catalog-collection-thumb:active, .catalog-collection-thumb:hover, .catalog-collection-thumb:visited {
+  color: inherit;
+  text-decoration: none;
 }
 
 /* Medium devices */

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -67,6 +67,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
+    config.add_index_field solr_name("has_model", :symbol), label: "Type"
     config.add_index_field solr_name("title", :stored_searchable), label: "Title", itemprop: 'name', if: false
     config.add_index_field solr_name("description", :stored_searchable), label: "Description", itemprop: 'description', helper_method: :iconify_auto_link
     config.add_index_field solr_name("creator", :stored_searchable), label: "Creator", itemprop: 'creator', link_to_search: solr_name("creator", :facetable)

--- a/app/presenters/sufia/collection_presenter.rb
+++ b/app/presenters/sufia/collection_presenter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Sufia
+  class CollectionPresenter < CurationConcerns::CollectionPresenter
+    delegate :thumbnail_id, :resource_type, :based_near, :related_url, :identifier, to: :solr_document
+
+    # Terms is the list of fields displayed by
+    # app/views/collections/_show_descriptions.html.erb
+    def self.terms
+      [:total_items, :size, :resource_type, :creator, :contributor, :keyword,
+       :rights, :publisher, :date_created, :subject, :language, :identifier,
+       :based_near, :related_url, :thumbnail_id]
+    end
+
+    def terms_with_values
+      self.class.terms.select { |t| self[t].present? }
+    end
+
+    def [](key)
+      case key
+      when :size
+        size
+      when :total_items
+        total_items
+      else
+        solr_document.send key
+      end
+    end
+  end
+end

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,0 +1,9 @@
+    <div class="col-sm-3">
+      <%= link_to document, class: 'catalog-collection-thumb' do %>
+        <% if document.thumbnail_id != nil %>
+          <%= render_thumbnail_tag document, {}, suppress_link: true %>
+        <% else %>
+          <span class="<%= Sufia::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
+        <% end %>
+      <% end %>
+    </div>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,0 +1,43 @@
+<%= simple_form_for @form, html: { class: 'editor' } do |f| %>
+  <div id="descriptions_display">
+    <h2 class="non lower"><%= t('sufia.collection.edit.description') %></h2>
+    <div id="base-terms">
+      <% f.object.primary_terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f) %>
+      <% end %>
+    </div>
+    <%= link_to t('sufia.collection.edit.additional_fields'),
+            '#extended-terms',
+            class: 'btn btn-default additional-fields',
+            data: { toggle: 'collapse' },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "extended-terms" %>
+    <div id="extended-terms" class='collapse'>
+<%= f.input :thumbnail_id, collection: @form.select_files %>
+      <% f.object.secondary_terms.each do |term| %>
+        <%= render_edit_field_partial(term, f: f) %>
+      <% end %>
+    </div>
+  </div>
+  <%= hidden_field_tag :type, params[:type] %>
+  <% if params[:batch_document_ids].present? %>
+    <% params[:batch_document_ids].each do |batch_item| %>
+      <input type="hidden" name="batch_document_ids[]" value="<%= batch_item %>"/>
+    <% end %>
+  <% end %>
+
+  <div class="collection_form_visibility">
+    <%= render 'form_permission', f: f %>
+  </div>
+
+  <div class="primary-actions">
+    <% if params[:action] == "new" %>
+      <%= f.submit 'Create Collection', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "create_submit", name: "create_collection" %>
+    <% else %>
+      <%= f.submit 'Update Collection', class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "update_submit", name: "update_collection" %>
+    <% end %>
+    <%= link_to t(:'helpers.action.cancel'), main_app.root_path, class: 'btn btn-link' %>
+  </div>
+<% end %>
+

--- a/app/views/collections/_media_display.html.erb
+++ b/app/views/collections/_media_display.html.erb
@@ -1,0 +1,7 @@
+<% if @presenter.nil? or @presenter.thumbnail_id.blank? %>
+  <span class="fa fa-cubes collection-icon-search"></span>
+<% else %>
+  <div class="document-thumbnail">
+    <%= render_thumbnail_tag @presenter.solr_document, {}, suppress_link: true %>
+  </div>
+<% end %>

--- a/app/views/collections/_show_descriptions.html.erb
+++ b/app/views/collections/_show_descriptions.html.erb
@@ -1,0 +1,9 @@
+<h2 class="sr-only">Descriptions</h2>
+<dl class="dl-horizontal metadata-collections">
+  <% present_terms(@presenter, @presenter.terms_with_values) do |r, term| %>
+     <% unless r.label(term) == 'Thumbnail' %>
+       <dt><%= r.label(term) %></dt>
+       <dd><%= r.value(term) %></dd>
+     <% end %>
+  <% end %>
+</dl>

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,0 +1,28 @@
+<% provide :page_title, construct_page_title("Edit Collection #{@form.title.first}") %>
+
+<%= provide :page_header do %>
+  <h1>Edit Collection: <%= @form.title.first %></h1>
+<% end %>
+
+<% unless has_collection_search_parameters? %>
+  <div class="row">
+    <div class="col-xs-12 col-sm-10 pull-right">
+      <%= render 'collections/form' %>
+    </div>
+    <div class="col-xs-12 col-sm-2">
+      <%= render 'collections/edit_actions' %>
+    </div>
+  </div>
+<% end %>
+
+<div class="row m-t-3">
+  <h2 class="col-xs-12 col-sm-6"><%= t('sufia.collection.edit.manage_items') %></h2>
+  <div class="col-xs-12 col-sm-6">
+    <%= render 'search_form', presenter: @collection %>
+  </div>
+</div>
+<%= render 'my/did_you_mean' %>
+<%= render 'my/facet_selected' %>
+<%= render 'collections/sort_and_per_page', collection: @collection if @response.response['numFound'] > 0 %>
+<%= render 'document_list', documents: @member_docs, document_list_format: "dashboard" %>
+<%= render 'paginate' %>

--- a/spec/features/catalog_search_spec.rb
+++ b/spec/features/catalog_search_spec.rb
@@ -24,12 +24,16 @@ describe 'catalog searching', type: :feature do
         fill_in('search-field-header', with: 'shared_keyword')
         click_button('Go')
       end
+      expect(page).to have_content(jills_work.class)
       expect(page).to have_content(jills_work.title.first)
       expect(page).to have_content(jills_work.description.first)
       expect(page).to have_content(jills_work.creator.first)
+      expect(page).to have_content(jacks_work.class)
       expect(page).to have_content(jacks_work.title.first)
       expect(page).to have_content(jacks_work.description.first)
       expect(page).to have_content(jacks_work.creator.first)
+      expect(page).to have_content(collection.class)
+      byebug
       expect(page).to have_content(collection.title.first)
       expect(page).to have_content(collection.description.first)
       expect(page).to have_content(collection.creator.first)

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -6,6 +6,8 @@ describe 'collection', type: :feature do
 
   let(:work1) { FactoryGirl.create(:work, title: ["King Louie"], user: user) }
   let(:work2) { FactoryGirl.create(:work, title: ["King Kong"], user: user) }
+  let(:work3) { FactoryGirl.create(:generic_work_with_one_file, title: ["King work with files"], user: user) }
+
   let(:collection1) { FactoryGirl.create(:public_collection, user: user) }
   let(:collection2) { FactoryGirl.create(:public_collection, user: user) }
 
@@ -21,7 +23,7 @@ describe 'collection', type: :feature do
       visit '/dashboard'
       first('#hydra-collection-add').click
       expect(page).to have_content 'Create New Collection'
-      click_link('Additional fields')
+      click_link('Additional Fields')
 
       expect(page).to have_selector "input.collection_creator.multi_value"
       expect(page).to have_selector "input.collection_title.multi_value"
@@ -194,7 +196,7 @@ describe 'collection', type: :feature do
   end
 
   describe 'edit collection' do
-    let!(:collection) { FactoryGirl.create(:named_collection, members: [work1, work2], user: user) }
+    let!(:collection) { FactoryGirl.create(:named_collection, members: [work1, work2, work3], user: user) }
 
     before do
       sign_in user
@@ -213,6 +215,7 @@ describe 'collection', type: :feature do
       expect(page).to have_field('collection_description', with: collection.description.first)
       expect(page).to have_content(work1.title.first)
       expect(page).to have_content(work2.title.first)
+      expect(page).to have_content(work3.title.first)
 
       new_title = "Altered Title"
       new_description = "Completely new Description text."
@@ -220,6 +223,7 @@ describe 'collection', type: :feature do
       fill_in('Title', with: new_title)
       fill_in('Abstract or Summary', with: new_description)
       fill_in('Creator', with: creators.first)
+      select('A Contained FileSet', from: 'collection_thumbnail_id')
       within('.primary-actions') do
         click_button('Update Collection')
       end


### PR DESCRIPTION
Fixes #1284  

Add thumbnails to collections.

Changes proposed in this pull request:
* Add form select for selecting thumb from collected works
* Add spec to test select
* Catalog and collection view overrides to display thumb when present
* Add type to catalog index view
