### PR TITLE
[ready to merge] implement etd manager role

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -124,13 +124,18 @@ RSpec/AnyInstance:
   Exclude:
     - 'spec/controllers/contact_form_controller_spec.rb'
     - 'spec/features/admin_admin_set_spec.rb'
+    - 'spec/controllers/curation_concerns/etds_controller_spec.rb'
+    - 'spec/features/create_work_spec.rb'
+    - 'spec/features/end_to_end_spec.rb'
+    - 'spec/support/shared/doi_request.rb'
+    - 'spec/models/sufia/ability_spec.rb'
 
 RSpec/DescribeClass:
   Exclude:
     - 'spec/views/**/*'
     - 'spec/features/*'
     - 'spec/controllers/curation_concerns/generic_works_controller_spec.rb'
-    - 'spec/routing/curation_concerns_spec.rb'   
+    - 'spec/routing/curation_concerns_spec.rb'
 
 RSpec/DescribedClass:
   Exclude:

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -22,7 +22,7 @@ class Ability
     # end
 
     cannot [:edit, :update, :delete], Etd
-    can [:manage], Etd if user_is_etd_manager
+    can [:manage], Etd if user_is_etd_manager || user_is_proxy_of_etd_manager
 
     if current_user.admin?
       can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
@@ -41,5 +41,16 @@ class Ability
 
     def user_is_etd_manager
       user_groups.include? 'etd_manager'
+    end
+
+    def user_is_proxy_of_etd_manager
+      return false if current_user.can_make_deposits_for.empty?
+      current_user.can_make_deposits_for.each do |grantor|
+        if grantor.groups.include? 'etd_manager'
+          return true
+        else
+          return false
+        end
+      end
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,8 +21,25 @@ class Ability
     #   can [:create], ActiveFedora::Base
     # end
 
+    cannot [:edit, :update, :delete], Etd
+    can [:manage], Etd if user_is_etd_manager
+
     if current_user.admin?
       can [:create, :show, :add_user, :remove_user, :index, :edit, :update, :destroy], Role
+      can [:manage], Etd
     end
   end
+
+  private
+
+    # remove create ability for Etd's from all users
+    def curation_concerns_models
+      default_curation_concerns = Sufia.config.curation_concerns
+      default_curation_concerns.delete(Etd)
+      [::FileSet, ::Collection] + default_curation_concerns
+    end
+
+    def user_is_etd_manager
+      user_groups.include? 'etd_manager'
+    end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ require 'seed_methods'
 class AddInitialObjects < ActiveRecord::Migration
 
   rando_pass = Devise.friendly_token.first(8)
-  accounts = {'manydeposits@example.com' => 'Many Deposits', 'nodeposits@example.com' => 'No Deposits', 'delegate@example.com' => 'Student Delegate'} 
+  accounts = {'manydeposits@example.com' => 'Many Deposits', 'nodeposits@example.com' => 'No Deposits', 'delegate@example.com' => 'Student Delegate'}
 
   accounts.each do | email, name |
     unless User.where(email: email).exists?
@@ -24,7 +24,7 @@ class AddInitialObjects < ActiveRecord::Migration
   end
 
   def self.create_admin_role(id)
-    admin = Role.create(name: "admin")
+    admin = Role.create(name: 'admin')
     admin.users << User.find(id)
     admin.save
   end
@@ -37,6 +37,20 @@ class AddInitialObjects < ActiveRecord::Migration
     user.id
   end
 
-  create_admin_role(create_admin_account)
+  def self.create_etd_manager_role(id)
+    etd_manager = Role.create(name: 'etd_manager')
+    etd_manager.users << User.find(id)
+    etd_manager.save
+  end
 
+  def self.create_etd_manager_account
+    rando_pass = Devise.friendly_token.first(8)
+    user = User.create email: 'etd_manager@example.com', password: rando_pass
+    puts "\n\n\t\t*** ETD MANAGER (etd_manager@example.com) PASS: #{rando_pass} ***\n\n"
+    user.save
+    user.id
+  end
+
+  create_admin_role(create_admin_account)
+  create_etd_manager_role(create_etd_manager_account)
 end

--- a/spec/controllers/curation_concerns/etds_controller_spec.rb
+++ b/spec/controllers/curation_concerns/etds_controller_spec.rb
@@ -5,8 +5,10 @@ require 'rails_helper'
 
 describe CurationConcerns::EtdsController do
   let(:user) { create(:user) }
-
-  before { sign_in user }
+  before do
+    allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
+    sign_in user
+  end
 
   describe "#new" do
     before { get :new }

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -124,6 +124,7 @@ feature 'Creating a new work', :js do
 
   context "when the user is not a proxy", :js do
     before do
+      allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
       sign_in user
     end
 
@@ -141,6 +142,7 @@ feature 'Creating a new work', :js do
     let(:second_user) { create(:user) }
     before do
       ProxyDepositRights.create!(grantor: second_user, grantee: user)
+      allow_any_instance_of(Ability).to receive(:user_is_proxy_of_etd_manager).and_return(true)
       sign_in user
       click_link "Dashboard"
       click_link "My Dashboard"

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 shared_examples 'work crud' do |work|
   let(:work_type) { work.name.underscore }
 
+  before { allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true) }
+
   it 'can view the new work form' do
     visit sufia.root_path
     click_on 'New Work'

--- a/spec/models/sufia/ability_spec.rb
+++ b/spec/models/sufia/ability_spec.rb
@@ -28,6 +28,9 @@ describe Sufia::Ability, type: :model do
     it { is_expected.not_to be_able_to(:read, Sufia::Statistics) }
     it { is_expected.not_to be_able_to(:read, :admin_dashboard) }
     it { is_expected.not_to be_able_to(:create, AdminSet) }
+    it { is_expected.not_to be_able_to(:create, Etd) }
+    it { is_expected.not_to be_able_to(:update, Etd) }
+    it { is_expected.not_to be_able_to(:delete, Etd) }
   end
 
   describe "a user in the admin group" do
@@ -48,6 +51,16 @@ describe Sufia::Ability, type: :model do
     skip 'Need to test :add_user and :remove_user from admin role' do
       it { is_expected.to be_able_to(:add_user, Role, User) }
     end
+  end
+
+  describe "a user in the ETD manager group" do
+    let(:user) { create(:user) }
+    before { allow(user).to receive_messages(groups: ['etd_manager', 'registered']) }
+    it { is_expected.to be_able_to(:create, Etd) }
+    it { is_expected.to be_able_to(:edit, Etd) }
+    it { is_expected.to be_able_to(:delete, Etd) }
+    it { is_expected.to be_able_to(:read, Etd) }
+    it { is_expected.to be_able_to(:manage, Etd) }
   end
 
   describe "proxies and transfers" do

--- a/spec/models/sufia/ability_spec.rb
+++ b/spec/models/sufia/ability_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 require 'rails_helper'
 require 'cancan/matchers'
@@ -73,6 +74,17 @@ describe Sufia::Ability, type: :model do
     describe "user_is_depositor?" do
       subject { ability.send(:user_is_depositor?, work.id) }
       it { is_expected.to be false }
+    end
+
+    describe 'user_is_proxy_of_etd_manager' do
+      let(:user) { create(:user) }
+      let(:etd_manager) { create(:user) }
+      before { allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true) }
+      it { is_expected.to be_able_to(:create, Etd) }
+      it { is_expected.to be_able_to(:edit, Etd) }
+      it { is_expected.to be_able_to(:delete, Etd) }
+      it { is_expected.to be_able_to(:read, Etd) }
+      it { is_expected.to be_able_to(:manage, Etd) }
     end
 
     context "with a ProxyDepositRequest for a work they have deposited" do

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -25,6 +25,7 @@ shared_examples 'doi request' do |work_class|
   let(:work_text) { work_class.name.titlecase }
 
   before do
+    allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
     CurationConcerns::Workflow::WorkflowImporter.load_workflows
     Sufia::AdminSetCreateService.create_default!
     allow(CharacterizeJob).to receive(:perform_later)


### PR DESCRIPTION
Fixes #1051

Present short summary (50 characters or less)

Implements an ETD manager role similar in functionality to scholar 2.

Uses Sufia Roles and Abilities rather than `role_map.yml`.

This removes the `create` ability for ETD's from all users and grants only to users who are ETD managers

Changes proposed in this pull request:
* Modify `curation_concern_models` to exclude ETD's
* Inclusion of new method within `Ability.rb` to determine whether user is an ETD manager
* Grant `create` ability only to ETD managers for ETD work types
