### PR TITLE
Adds External Link back to the work forms.

### DIFF
--- a/app/forms/curation_concerns/article_form.rb
+++ b/app/forms/curation_concerns/article_form.rb
@@ -29,7 +29,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title journal_title
          issn subject geo_subject time_period
-         language required_software note)
+         language required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/dataset_form.rb
+++ b/app/forms/curation_concerns/dataset_form.rb
@@ -30,7 +30,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title subject
          geo_subject time_period language
-         note)
+         note related_url)
     end
 
     def self.multiple?(field)

--- a/app/forms/curation_concerns/document_form.rb
+++ b/app/forms/curation_concerns/document_form.rb
@@ -30,7 +30,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title subject
          geo_subject time_period language
-         required_software note)
+         required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -32,7 +32,7 @@ module CurationConcerns
       %i(alternate_title
          genre subject geo_subject time_period
          language required_software
-         note)
+         note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -30,7 +30,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title
          subject geo_subject time_period
-         language required_software note)
+         language required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/image_form.rb
+++ b/app/forms/curation_concerns/image_form.rb
@@ -30,7 +30,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title genre
          subject geo_subject time_period
-         language required_software note)
+         language required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/student_work_form.rb
+++ b/app/forms/curation_concerns/student_work_form.rb
@@ -31,7 +31,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title genre
          subject geo_subject time_period
-         language required_software note)
+         language required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/app/forms/curation_concerns/video_form.rb
+++ b/app/forms/curation_concerns/video_form.rb
@@ -30,7 +30,7 @@ module CurationConcerns
     def secondary_terms
       %i(date_created alternate_title subject
          geo_subject time_period language
-         required_software note)
+         required_software note related_url)
     end
 
     ## Gymnastics to allow repeatble fields to behave as non-repeatable

--- a/config/locales/article.en.yml
+++ b/config/locales/article.en.yml
@@ -13,7 +13,7 @@ en:
         creator:          "Author"
         description:      "Abstract"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/dataset.en.yml
+++ b/config/locales/dataset.en.yml
@@ -13,7 +13,7 @@ en:
         description:      "Description"
         keyword:          "Keyword"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/document.en.yml
+++ b/config/locales/document.en.yml
@@ -12,7 +12,7 @@ en:
         geo_subject:       "Geographic Subject"
         description:      "Description"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -13,7 +13,7 @@ en:
         description:      "Abstract"
         keyword:          "Keyword"
         date_created:     "Degree Date"
-        related_url:      "Related URL"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -12,7 +12,7 @@ en:
         geo_subject:       "Geographic Location"
         description:      "Description"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/image.en.yml
+++ b/config/locales/image.en.yml
@@ -13,7 +13,7 @@ en:
         description:      "Description"
         keyword:          "Keyword"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/student_work.en.yml
+++ b/config/locales/student_work.en.yml
@@ -12,7 +12,7 @@ en:
         geo_subject:       "Geographic Subject"
         description:      "Description"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/config/locales/video.en.yml
+++ b/config/locales/video.en.yml
@@ -12,7 +12,7 @@ en:
         geo_subject:       "Geographic Subject"
         description:      "Description"
         date_created:     "Date Created"
-        related_url:      "External Resource"
+        related_url:      "External Link"
         files:            "Upload a new version of this file from your computer"
         collection_ids:   "Add as member of collection"
         admin_set_id:     "Add as member of administrative set"

--- a/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_attributes.html.erb_spec.rb
@@ -4,13 +4,15 @@ require 'rails_helper'
 describe 'curation_concerns/base/_attributes.html.erb' do
   let(:college) { 'Libraries' }
   let(:department) { 'Digital Repositories' }
+  let(:related_url) { 'http://www.uc.edu' }
 
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
     {
       Solrizer.solr_name('has_model', :symbol) => ["GenericWork"],
       college_tesim: college,
-      department_tesim: department
+      department_tesim: department,
+      related_url_tesim: related_url
     }
   end
   let(:ability) { nil }
@@ -28,5 +30,6 @@ describe 'curation_concerns/base/_attributes.html.erb' do
   it 'has links to search for other objects with the same metadata' do
     expect(rendered).to have_link(college, href: search_catalog_path('f[college_sim][]': college))
     expect(rendered).to have_link(department, href: search_catalog_path('f[department_sim][]': department))
+    expect(rendered).to have_link(related_url)
   end
 end


### PR DESCRIPTION
Fixes #1275 

Present short summary (50 characters or less)

The related_url field is used for External Links.  We inadvertently removed it from the form when migrating the metadata profile.  Adding it back to the forms.  
