### PR TITLE
Allow Solr to handle files larger than 2 gigs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,11 +28,14 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
   #everything here was sufia-specific
+    - 'app/indexers/curation_concerns/file_set_indexer.rb'
 
 Metrics/MethodLength:
   Max: 15
   Exclude:
     - 'lib/seed_methods.rb'
+    - 'app/indexers/curation_concerns/file_set_indexer.rb'
+    - 'spec/support/curation_concerns/factory_helpers.rb'
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/indexers/curation_concerns/file_set_indexer.rb
+++ b/app/indexers/curation_concerns/file_set_indexer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require CurationConcerns::Engine.root.join('app/indexers/curation_concerns/file_set_indexer.rb')
+module CurationConcerns
+  class FileSetIndexer < ActiveFedora::IndexingService
+    STORED_LONG = Solrizer::Descriptor.new(:long, :stored)
+
+    def generate_solr_document
+      super.tap do |solr_doc|
+        solr_doc[Solrizer.solr_name('hasRelatedMediaFragment', :symbol)] = object.representative_id
+        solr_doc[Solrizer.solr_name('hasRelatedImage', :symbol)] = object.thumbnail_id
+        # Label is the actual file name. It's not editable by the user.
+        solr_doc[Solrizer.solr_name('label')] = object.label
+        solr_doc[Solrizer.solr_name('label', :stored_sortable)] = object.label
+        solr_doc[Solrizer.solr_name('file_format')] = file_format
+        solr_doc[Solrizer.solr_name('file_format', :facetable)] = file_format
+        solr_doc[Solrizer.solr_name(:file_size, STORED_LONG)] = object.file_size[0]
+        solr_doc['all_text_timv'] = object.extracted_text.content if object.extracted_text.present?
+        solr_doc['height_is'] = Integer(object.height.first) if object.height.present?
+        solr_doc['width_is'] = Integer(object.width.first) if object.width.present?
+        solr_doc[Solrizer.solr_name('mime_type', :stored_sortable)] = object.mime_type
+        solr_doc['thumbnail_path_ss'] = thumbnail_path
+        # Index the Fedora-generated SHA1 digest to create a linkage
+        # between files on disk (in fcrepo.binary-store-path) and objects
+        # in the repository.
+        solr_doc[Solrizer.solr_name('digest', :symbol)] = digest_from_content
+        solr_doc[Solrizer.solr_name('page_count')] = object.page_count
+        solr_doc[Solrizer.solr_name('file_title')] = object.file_title
+        solr_doc[Solrizer.solr_name('duration')] = object.duration
+        solr_doc[Solrizer.solr_name('sample_rate')] = object.sample_rate
+        solr_doc[Solrizer.solr_name('original_checksum')] = object.original_checksum
+      end
+    end
+  end
+end

--- a/app/models/concerns/curation_concerns/collection_behavior.rb
+++ b/app/models/concerns/curation_concerns/collection_behavior.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require CurationConcerns::Engine.root.join('app/models/concerns/curation_concerns/collection_behavior.rb')
+module CurationConcerns
+  module CollectionBehavior
+    private
+
+      # Field name to look up when locating the size of each file in Solr.
+      # Override for your own installation if using something different
+      def file_size_field
+        Solrizer.solr_name(:file_size, CurationConcerns::FileSetIndexer::STORED_LONG)
+      end
+  end
+end

--- a/spec/indexers/curation_concerns/file_set_indexer_spec.rb
+++ b/spec/indexers/curation_concerns/file_set_indexer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe CurationConcerns::FileSetIndexer do
+  include CurationConcerns::FactoryHelpers
+
+  let(:file_set) do
+    FileSet.new(id: 'foo123')
+  end
+
+  let(:mock_file) do
+    mock_file_factory(
+      file_size: ['5000000000000000000']
+    )
+  end
+
+  let(:indexer) { described_class.new(file_set) }
+
+  describe '#generate_solr_document' do
+    before do
+      allow(file_set).to receive(:label).and_return('CastoriaAd.tiff')
+      allow(CurationConcerns::ThumbnailPathService).to receive(:call).and_return('/downloads/foo123?file=thumbnail')
+      allow(file_set).to receive(:original_file).and_return(mock_file)
+    end
+    subject { indexer.generate_solr_document }
+
+    it 'has a file_size field stored as a :long' do
+      expect(subject[Solrizer.solr_name('file_size', Solrizer::Descriptor.new(:long, :stored))]).to eq '5000000000000000000'
+    end
+  end
+end

--- a/spec/support/curation_concerns/factory_helpers.rb
+++ b/spec/support/curation_concerns/factory_helpers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+module CurationConcerns
+  module FactoryHelpers
+    module_function
+
+    def mock_file_factory(opts = {})
+      mock_model('MockFileTwo',
+                 mime_type:         opts.fetch(:mime_type, 'text/plain'),
+                 content:           opts.fetch(:content, 'content'),
+                 file_size:         opts.fetch(:file_size, []),
+                 format_label:      opts.fetch(:format_label, []),
+                 height:            opts.fetch(:height, []),
+                 width:             opts.fetch(:width, []),
+                 filename:          opts.fetch(:filename, []),
+                 well_formed:       opts.fetch(:well_formed, []),
+                 page_count:        opts.fetch(:page_count, []),
+                 file_title:        opts.fetch(:file_title, []),
+                 last_modified:     opts.fetch(:last_modified, []),
+                 original_checksum: opts.fetch(:original_checksum, []),
+                 digest:            opts.fetch(:digest, []),
+                 duration:          opts.fetch(:duration, []),
+                 sample_rate:       opts.fetch(:sample_rate, []))
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1283 

To test this, make sure you can ingest a file larger than 2 GB without Solr throwing a file_size_is error.

I had to add a few ignores to the .rubocop.yml because a couple methods I pulled over from CC were too long, but I didn't want to change them more than I had to.