### PR TITLE
set fields on batch upload form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,7 @@ Metrics/MethodLength:
     - 'app/indexers/curation_concerns/file_set_indexer.rb'
     - 'spec/support/curation_concerns/factory_helpers.rb'
     - 'app/helpers/change_manager/change_manager_helper.rb'
+    - 'app/forms/sufia/forms/batch_upload_form.rb'
 
 Metrics/ModuleLength:
   Exclude:
@@ -46,6 +47,10 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Exclude:
     - 'app/helpers/change_manager/change_manager_helper.rb'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+  - 'app/forms/sufia/forms/batch_upload_form.rb'
 
 Style/BlockDelimiters:
   Exclude:

--- a/app/forms/curation_concerns/etd_form.rb
+++ b/app/forms/curation_concerns/etd_form.rb
@@ -24,7 +24,7 @@ module CurationConcerns
 
     ## Adding above the fold on the form without making this required
     def primary_terms
-      required_fields + [:committee_member, :degree, :date_created, :publisher]
+      required_fields + %i(committee_member degree date_created publisher)
     end
 
     ## Overriding secondary terms to establish custom field order

--- a/app/forms/sufia/forms/batch_upload_form.rb
+++ b/app/forms/sufia/forms/batch_upload_form.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+module Sufia
+  module Forms
+    class BatchUploadForm < Sufia::Forms::WorkForm
+      self.model_class = BatchUploadItem
+      include HydraEditor::Form::Permissions
+
+      attr_accessor :payload_concern # a Class name: what is form creating a batch of?
+
+      self.terms = %i(creator description right publisher date_created subject
+                      language identifier based_near related_url representative_id
+                      thumbnail_id files visibility_during_embargo embargo_release_date
+                      visibility_after_embargo visibility_during_lease
+                      lease_expiration_date visibility_after_lease visibility
+                      ordered_member_ids in_works_ids collection_ids admin_set_id
+                      alternate_title journal_title issn time_period required_software
+                      note geo_subject doi doi_assignment_strategy existing_identifier
+                      college department genre degree advisor)
+
+      def required_fields
+        case @payload_concern
+        when "Dataset"
+          %i(title creator college department description required_software rights)
+        when "Etd"
+          %i(title creator college department description advisor rights)
+        when "StudentWork"
+          %i(title creator college department description advisor rights)
+        else
+          %i(title creator college department description rights)
+        end
+      end
+
+      def primary_terms
+        case @payload_concern
+        when "Dataset"
+          %i(creator college department description required_software rights publisher)
+        when "StudentWork"
+          %i(creator college department description advisor rights degree publisher)
+        when "Etd"
+          %i(creator college department description advisor rights committee_member degree date_created publisher)
+        else
+          %i(creator college department description rights publisher)
+        end
+      end
+
+      def secondary_terms
+        case @payload_concern
+        when "Article"
+          %i(date_created alternate_title journal_title issn subject
+             geo_subject time_period language required_software note related_url)
+        when "Dataset"
+          %i(date_created alternate_title subject geo_subject
+             time_period language note related_url)
+        when "Document"
+          %i(date_created alternate_title subject geo_subject
+             time_period language required_software note related_url)
+        when "Image"
+          %i(date_created alternate_title genre subject geo_subject
+             time_period language required_software note related_url)
+        when "Video"
+          %i(date_created alternate_title subject geo_subject
+             time_period language required_software note related_url)
+        when "StudentWork"
+          %i(date_created alternate_title genre subject geo_subject
+             time_period language required_software note related_url)
+        when "Etd"
+          %i(alternate_title genre subject geo_subject time_period
+             language required_software note related_url)
+        else
+          %i(date_created alternate_title subject geo_subject
+             time_period language required_software note related_url)
+        end
+      end
+
+      # The WorkForm delegates `#depositor` to `:model`, but `:model` in the
+      # BatchUpload context is a blank work with a `nil` depositor
+      # value. This causes the "Sharing With" widget to display the Depositor as
+      # "()". We should be able to reliably pull back the depositor of the new
+      # batch of works by asking the form's Ability what its `current_user` is.
+      def depositor
+        current_ability.current_user
+      end
+
+      # Override of ActiveModel::Model name that allows us to use our custom name class
+      def self.model_name
+        @_model_name ||= begin
+          namespace = parents.detect do |n|
+            n.respond_to?(:use_relative_model_naming?) && n.use_relative_model_naming?
+          end
+          Name.new(model_class, namespace)
+        end
+      end
+
+      def model_name
+        self.class.model_name
+      end
+
+      # This is required for routing to the BatchUploadController
+      def to_model
+        self
+      end
+
+      # A model name that provides correct routes for the BatchUploadController
+      # without changing the param key.
+      #
+      # Example:
+      #   name = Name.new(GenericWork)
+      #   name.param_key
+      #   # => 'generic_work'
+      #   name.route_key
+      #   # => 'batch_uploads'
+      #
+      class Name < ActiveModel::Name
+        def initialize(klass, namespace = nil, name = nil)
+          super
+          @route_key          = "batch_uploads"
+          @singular_route_key = ActiveSupport::Inflector.singularize(@route_key)
+          @route_key << "_index" if @plural == @singular
+        end
+      end
+    end
+  end
+end

--- a/app/views/curation_concerns/base/_form_metadata.html.erb
+++ b/app/views/curation_concerns/base/_form_metadata.html.erb
@@ -1,0 +1,21 @@
+<div class="form-instructions">
+  <p>The more descriptive information you provide the better we can serve your needs.</p>
+</div>
+<div class="base-terms">
+  <% f.object.primary_terms.each do |term| %>
+      <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>
+<%= link_to t('sufia.works.form.additional_fields'),
+            '#extended-terms',
+            class: 'btn btn-default additional-fields',
+            data: { toggle: 'collapse'  },
+            role: "button",
+            'aria-expanded'=> "false",
+            'aria-controls'=> "extended-terms" %>
+<div id="extended-terms" class='collapse'>
+  <%= render 'form_media', f: f %>
+  <% f.object.secondary_terms.each do |term| %>
+      <%= render_edit_field_partial(term, f: f) %>
+  <% end %>
+</div>

--- a/app/views/records/edit_fields/_college.html.erb
+++ b/app/views/records/edit_fields/_college.html.erb
@@ -1,4 +1,4 @@
 <%= f.input :college,
       collection: sorted_college_list_for_works,
-      selected: (curation_concern.college || user_college),
+      selected: ((curation_concern.college if curation_concern.respond_to?(:college)) || user_college),
       input_html: { class: 'college' } %>

--- a/app/views/records/edit_fields/_department.html.erb
+++ b/app/views/records/edit_fields/_department.html.erb
@@ -1,2 +1,2 @@
 <%= f.input :department,
-      input_html: { class: 'department', value: curation_concern.department || user_department } %>
+      input_html: { class: 'department', value: (curation_concern.department if curation_concern.respond_to?(:department)) || user_department } %>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -1,4 +1,31 @@
 en:
+  simple_form:
+    hints:
+      defaults:
+        advisor: "The faculty advisor or sponsor for this work, in <i>LastName, FirstName</i> format."
+        alternate_title: "Enter an alternate title for your work. An alternate title could include acronyms, abbreviations, or a series title."
+        college: "Select the college associated with the submitter of this work."
+        committee_member: "Enter the committee member for this work."
+        creator: "Enter the names of creators of the work, in<i> LastName, FirstName</i> format. These could include important authors, co-authors, or other significant contributors."
+        date_created: "Date when the contents of the work were created. Enter date formatted as: YYYY or YYYY-MM or YYYY-MM-DD.  Examples:  January 30, 1950 would be entered 1950-01-30"
+        genre: "Select a genre matching your work."
+        degree: "The degree associated with this work, if the work was completed as part of a thesis or capstone. Please enter the abbreviation for the degree, e.g., BA or MS."
+        department: "Enter the department associated with the submitter of this work."
+        description: "Enter a summary of your work. There is no character limit for this field."
+        geo_subject: "Enter the geographic subject of your work.</br>Examples:</br><ul><li>Cincinnati, Ohio</li><li>Vancouver, British Columbia</li><li>Sahara Desert</li></ul>"
+        identifier: "A unique handle identifying the work. An example would be a DOI for a journal article, or an ISBN or OCLC number for a book."
+        issn: "ISSN of the Journal where the work was originally published, if applicable."
+        journal_title: "Title of the Journal where the work was originally published, if applicable."
+        language: "Enter the language of your work.</br>Example:</br><ul><li>English</li><li>Spanish</li><li>Arabic</li></ul>"
+        note: "Enter any additional information about your work."
+        publisher: "Enter the publisher of your work. If this has not been previously published, <i> University of Cincinnati </i> is an appropriate publisher."
+        related_url: "A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived."
+        required_software: "Special software needed to open the work."
+        resource: "Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected."
+        rights: "Licensing and distribution information governing access to the work. Select from the provided drop-down list."
+        subject: "Enter terms or keywords that describe your work.</br>Examples:</br><ul><li>Biology</li><li>Art History</li><li>Economics</li></ul>"
+        time_period: "Enter the period or date associated with the subject of your work.</br>Examples:</br><ul><li>19th century</li><li>Middle Ages</li><li>Jurassic Period</li></ul>"
+        title: "Enter the title of your work. If the work doesn't have a title, please enter a brief descriptive label."
   sufia:
     product_name:       "Scholar@UC"
     product_twitter_handle: "@Scholar@UC"

--- a/spec/controllers/sufia/batch_uploads_controller_spec.rb
+++ b/spec/controllers/sufia/batch_uploads_controller_spec.rb
@@ -91,9 +91,9 @@ describe Sufia::BatchUploadsController do
     end
     let(:expected_shared_params) do
       if Rails.version < '5.0.0'
-        { 'keyword' => [], 'visibility' => 'open' }
+        { 'visibility' => 'open' }
       else
-        ActionController::Parameters.new(keyword: [], visibility: 'open').permit!
+        ActionController::Parameters.new(visibility: 'open').permit!
       end
     end
     it "excludes uploaded_files and title" do

--- a/spec/forms/sufia/forms/batch_upload_form_spec.rb
+++ b/spec/forms/sufia/forms/batch_upload_form_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+shared_examples "batch_form_fields" do |work_class|
+  let(:work_form_class) { ("CurationConcerns::" + work_class.name + "Form").constantize }
+  let(:work_name) { work_class.name }
+  let(:subject) { Sufia::Forms::BatchUploadForm.new(BatchUploadItem.new, nil) }
+
+  context "batch form" do
+    let(:target) { work_form_class.new(work_class.new, nil) }
+    before { subject.payload_concern = work_name }
+
+    describe "#required_fields" do
+      it "equals the terms for the payload" do
+        expect(subject.required_fields).to eq(target.required_fields)
+      end
+    end
+
+    describe "#primary_terms" do
+      it "equals the terms for the payload" do
+        expect(subject.primary_terms).to eq(target.primary_terms - [:title])
+      end
+    end
+
+    describe "#secondary_terms" do
+      it "equals the terms for the payload" do
+        expect(subject.secondary_terms).to eq(target.secondary_terms)
+      end
+    end
+  end
+end
+
+RSpec.describe Sufia::Forms::BatchUploadForm do
+  Sufia.config.curation_concerns.each do |klass|
+    it_behaves_like 'batch_form_fields', klass
+  end
+
+  let(:model) { GenericWork.new }
+  let(:form) { described_class.new(model, ability) }
+  let(:ability) { Ability.new(user) }
+  let(:user) { build(:user, display_name: 'Jill Z. User') }
+
+  describe ".model_name" do
+    subject { described_class.model_name }
+    it "has a route_key" do
+      expect(subject.route_key).to eq 'batch_uploads'
+    end
+    it "has a param_key" do
+      expect(subject.param_key).to eq 'batch_upload_item'
+    end
+  end
+
+  describe "#to_model" do
+    subject { form.to_model }
+    it "returns itself" do
+      expect(subject.to_model).to be_kind_of described_class
+    end
+  end
+
+  describe "#terms" do
+    let(:terms) do
+      %i(creator description right publisher date_created subject
+         language identifier based_near related_url representative_id
+         thumbnail_id files visibility_during_embargo embargo_release_date
+         visibility_after_embargo visibility_during_lease
+         lease_expiration_date visibility_after_lease visibility
+         ordered_member_ids in_works_ids collection_ids admin_set_id
+         alternate_title journal_title issn time_period required_software
+         note geo_subject doi doi_assignment_strategy existing_identifier
+         college department genre degree advisor)
+    end
+
+    subject { form.terms }
+    it { is_expected.to eq terms }
+  end
+end


### PR DESCRIPTION
Closes #1214 

I'm setting custom fields in the Batch Upload Form class, to match the payload curation concern - ideally I would be able to reference the form class of the appropriate curation concern directly, but you can't do that without instantiating a new instance of both the model and the form (which seems like a bad idea). As an alternative, I'm duplicating the lists of terms - using the specs to guarantee that the terms on the batch form class stay in-line with the curation concern form classes.

Also set default help information to apply to any fields from this form - help info is blank without this.

Any additional form issues not addressed here should be opened as an additional issue.