### PR TITLE
Rename Contributors to People and link from menus

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -137,6 +137,10 @@
   font-size: 12px;
 }
 
+.people {
+  margin-top: 2em;
+}
+
 /* Medium devices */
 @media (min-width: 768px) and (max-width: 991px) {
 

--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,0 +1,19 @@
+<nav class="navbar navbar-default navbar-static-top" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <ul class="nav navbar-nav col-sm-5 col-md-6">
+        <li <%= 'class=active' if current_page?(sufia.profiles_path) %>>
+          <%= link_to t(:'sufia.controls.users'), sufia.profiles_path %></li>
+        <li <%= 'class=active' if current_page?(sufia.about_path) %>>
+          <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
+          <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
+      </ul><!-- /.nav -->
+      <div class="searchbar-right navbar-right col-sm-7 col-md-6">
+        <%= render partial: 'catalog/search_form' %>
+      </div>
+    </div>
+  </div>
+</nav><!-- /.navbar -->

--- a/app/views/layouts/scholar/_splash_controls.html.erb
+++ b/app/views/layouts/scholar/_splash_controls.html.erb
@@ -2,14 +2,14 @@
   <div class="container-fluid">
     <div class="row">
       <ul class="col-xs-12 col-sm-7 jumbo-nav spec-flag">
-        <li <%= 'class=active' if current_page?(sufia.root_path) %>>
-          <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if current_page?(sufia.profiles_path) %>>
+          <%= link_to t(:'sufia.controls.users'), sufia.profiles_path %></li>
         <li <%= 'class=active' if current_page?(sufia.about_path) %>>
           <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
-        <li <%= 'class=active' if action_name == "help" %>>
-          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
         <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
           <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
       </ul><!-- /.nav -->
       <div class="col-xs-12 col-sm-5 text-right cc-text">
         <%= link_to 'Photo', 'https://flic.kr/p/3kBWs4', target: '_blank' %> by fusion-of-horizons | <%= link_to 'CC-BY', 'https://creativecommons.org/licenses/by/2.0/', target: '_blank' %>
@@ -25,14 +25,14 @@
     <div class="container-fluid">
       <div class="row">
         <ul class="col-xs-12 jumbo-nav">
-          <li <%= 'class=active' if current_page?(sufia.root_path) %>>
-            <%= link_to t(:'sufia.controls.home'), sufia.root_path, :'data-no-turbolink'=>"true" %></li>
-          <li <%= 'class=active' if current_page?(sufia.about_path) %>>
-            <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
-          <li <%= 'class=active' if action_name == "help" %>>
-            <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
-          <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
-            <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+        <li <%= 'class=active' if current_page?(sufia.profiles_path) %>>
+          <%= link_to t(:'sufia.controls.users'), sufia.profiles_path %></li>
+        <li <%= 'class=active' if current_page?(sufia.about_path) %>>
+          <%= link_to t(:'sufia.controls.about'), sufia.about_path, :'data-no-turbolink'=>"true" %></li>
+        <li <%= 'class=active' if current_page?(sufia.contact_path) %>>
+          <%= link_to t(:'sufia.controls.contact'), sufia.contact_path %></li>
+        <li <%= 'class=active' if action_name == "help" %>>
+          <%= link_to t(:'sufia.controls.help'), sufia.help_path %></li>
         </ul><!-- /.nav -->
         <div class="jumbo-controls">
           <div class="col-xs-12 text-center cc-text">

--- a/app/views/users/_left_sidebar.html.erb
+++ b/app/views/users/_left_sidebar.html.erb
@@ -1,4 +1,4 @@
 <%= render @user %>
 
 <br />
-<a class="btn btn-primary" href="<%= sufia.profiles_path %>"><i class="glyphicon glyphicon-globe"></i> View Contributors</a>
+<a class="btn btn-primary" href="<%= sufia.profiles_path %>"><i class="glyphicon glyphicon-globe"></i> View People</a>

--- a/app/views/users/_search_form.html.erb
+++ b/app/views/users/_search_form.html.erb
@@ -1,7 +1,7 @@
 <div>
   <%= form_tag sufia.profiles_path, method: :get, class: "form-search" do %>
-    <label class="sr-only" for="user_search">Search Contributors</label>
-    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search Contributors", size: '30', type: "search", id: "user_search" %>
+    <label class="sr-only" for="user_search">Search People</label>
+    <%= text_field_tag :uq, params[:uq], class: "q", placeholder: "Search People", size: '30', type: "search", id: "user_search" %>
     <%= hidden_field_tag :sort, params[:sort], id: 'user_sort' %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:uq, :sort, :qt, :page, :utf8)) %>
     <button type="submit" class="btn btn-primary" id="user_submit"> 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,8 +1,9 @@
 <div id="search">
   <%= render partial: 'search_form' %>
-  <h1><%= application_name %> Contributors</h1>
+  <h1><%= application_name %> People</h1>
 </div>
-<table class="table table-striped">
+<p>Users that have contributed content to <%= application_name %> are listed below.</p>
+<table class="table table-striped people">
     <thead>
         <tr>
             <th>Avatar</th>

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -7,6 +7,8 @@ en:
     account_name:       "My Institution Account Id"
     directory:
       suffix:           "@uc.edu"
+    controls:
+      users: "People"
     footer:
       copyright_info_html: "<a href=\"http://commercialization.uc.edu/copyright-infringement\">Copyright Information</a>"
       copyright_html: "&copy; 2017 <a href=\"http://www.uc.edu/\"><u>University of Cincinnati</u></a>"

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'the homepage', type: :feature do
   end
 
   it 'renders the splash controls' do
-    expect(page).to have_content 'Home'
+    expect(page).to have_content 'People'
     expect(page).to have_content 'About'
     expect(page).to have_content 'Contact'
     expect(page).to have_content 'Help'

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -13,7 +13,7 @@ describe "User Profile", type: :feature do
       visit profile_path
       expect(page).to have_content(user.email)
       expect(page).to have_content('Edit Your Profile')
-      expect(page).to have_content('View Contributors')
+      expect(page).to have_content('View People')
     end
   end
 
@@ -48,26 +48,26 @@ describe "User Profile", type: :feature do
     end
   end
 
-  context 'when clicking view contributors' do
+  context 'when clicking view people' do
     # TODO: Move this to a view test
 
     before do
       visit profile_path
-      click_link 'View Contributors'
+      click_link 'View People'
     end
 
-    it "has a Search Contributors field label" do
-      expect(page).to have_css("label", text: "Search Contributors")
+    it "has a Search People field label" do
+      expect(page).to have_css("label", text: "Search People")
     end
 
-    it "has Contributors in the heading" do
-      expect(page).to have_css("h1", text: "Contributors")
+    it "has People in the heading" do
+      expect(page).to have_css("h1", text: "People")
     end
 
     context "when the user doesn't own works" do
       it 'does not include the user in the display' do
         visit profile_path
-        click_link 'View Contributors'
+        click_link 'View People'
         expect(page).not_to have_xpath("//td/a[@href='#{profile_path}']")
       end
     end
@@ -76,7 +76,7 @@ describe "User Profile", type: :feature do
       let!(:work) { FactoryGirl.create(:work, user: user) }
       it 'includes the user in the display' do
         visit profile_path
-        click_link 'View Contributors'
+        click_link 'View People'
         expect(page).to have_xpath("//td/a[@href='#{profile_path}']")
       end
     end
@@ -89,7 +89,7 @@ describe "User Profile", type: :feature do
       end
       it 'includes the user without works in the display' do
         visit profile_path
-        click_link 'View Contributors'
+        click_link 'View People'
         expect(page).to have_xpath("//td/a[@href='#{profile_path}']")
       end
     end
@@ -114,7 +114,7 @@ describe "User Profile", type: :feature do
 
     it 'is searchable' do
       visit profile_path
-      click_link 'View Contributors'
+      click_link 'View People'
       expect(page).to have_xpath("//td/a[@href='#{profile_path}']")
       expect(page).to have_xpath("//td/a[@href='#{dewey_path}']")
       fill_in 'user_search', with: 'Dewey'

--- a/spec/views/_controls.html.erb_spec.rb
+++ b/spec/views/_controls.html.erb_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe '/_controls.html.erb', type: :view do
+  before do
+    stub_template 'catalog/_search_form.html.erb' => 'search form'
+    render
+  end
+
+  it 'has navigation links' do
+    expect(rendered).to have_link 'People'
+    expect(rendered).to have_link 'About'
+    expect(rendered).to have_link 'Contact'
+    expect(rendered).to have_link 'Help'
+  end
+end


### PR DESCRIPTION
Fixes #1281 

Changes "Contributors" to "People" on the /users page

Add a sentence to the /users page explaining that only content contributors are listed

Replaces the links to Home with links to the People page

