### PR TITLE
Set bounds for featured work display image

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -71,16 +71,10 @@ div[class*="_admin_set_id"] {
   margin-bottom: 20px;
 }
 
-.featured-thumb {
-  width: 270px;
-  height: 270px;
-}
-
 .featured-thumb img {
-  min-width: 100%;
-  min-height: 100%;
-  width: auto;
-  height: auto;
+    width: 270px;
+    height: 270px;
+    object-fit: cover;
 }
 
 .partners-text {


### PR DESCRIPTION
Fixes #1271 

Set bounds for featured work display image. Image will fill bounds from top left

Changes proposed in this pull request:
* Add style to set bounding for feature work thumb

![screen shot 2017-04-25 at 12 43 22 pm](https://cloud.githubusercontent.com/assets/1069588/25397018/cf467be8-29b4-11e7-8cc4-5359d55f8350.png)

