### PR TITLE
Display submitter on work show page

### DIFF
--- a/app/views/curation_concerns/base/_attribute_rows.html.erb
+++ b/app/views/curation_concerns/base/_attribute_rows.html.erb
@@ -21,3 +21,4 @@
 <%= presenter.attribute_to_html(:degree) %>
 <%= presenter.attribute_to_html(:advisor) %>
 <%= presenter.attribute_to_html(:committee_member) %>
+<%= presenter.attribute_to_html(:depositor, label: 'Submitter') %>


### PR DESCRIPTION
Fixes #1304 

Display submitter on work show page.

Changes proposed in this pull request:
* Add :depositor with "submitter" label to work presenter attributes
<img width="930" alt="screen shot 2017-04-25 at 8 40 03 pm" src="https://cloud.githubusercontent.com/assets/1069588/25413296/66ac20f4-29f7-11e7-86ae-7279e939628d.png">

