### PR TITLE
Allow owner to edit work created by proxy

### DIFF
--- a/app/jobs/attach_files_to_work_job.rb
+++ b/app/jobs/attach_files_to_work_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require Sufia::Engine.root.join('app/jobs/attach_files_to_work_job.rb')
+class AttachFilesToWorkJob < ActiveJob::Base
+  def perform(work, uploaded_files)
+    uploaded_files.each do |uploaded_file|
+      file_set = FileSet.new
+      user = User.find_by_user_key(work.depositor)
+      actor = CurationConcerns::Actors::FileSetActor.new(file_set, user)
+      actor.create_metadata(work, visibility: work.visibility) do |file|
+        file.permissions_attributes = work.permissions.map(&:to_hash)
+      end
+
+      attach_content(actor, uploaded_file.file)
+      uploaded_file.update(file_set_uri: file_set.uri)
+    end
+    work.save! # Temp fix to https://github.com/uclibs/scholar_uc/issues/1023
+  end
+end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe AttachFilesToWorkJob do
+  context "happy path" do
+    let(:file1) { File.open(fixture_path + '/world.png') }
+    let(:file2) { File.open(fixture_path + '/image.jp2') }
+    let(:uploaded_file1) { Sufia::UploadedFile.create(file: file1) }
+    let(:uploaded_file2) { Sufia::UploadedFile.create(file: file2) }
+    let(:generic_work) { create(:public_generic_work) }
+
+    context "with uploaded files on the filesystem" do
+      before do
+        generic_work.permissions.build(name: 'userz@bbb.ddd', type: 'person', access: 'edit')
+        generic_work.save
+      end
+      it "attaches files, copies visibility and permissions and updates the uploaded files" do
+        expect(CharacterizeJob).to receive(:perform_later).twice
+        described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+        generic_work.reload
+        expect(generic_work.file_sets.count).to eq 2
+        expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
+        expect(generic_work.file_sets.map(&:edit_users)).to all(match_array([generic_work.depositor, 'userz@bbb.ddd']))
+        expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+      end
+    end
+
+    context "with uploaded files in fog" do
+      let(:fog_file) { CarrierWave::Storage::Fog::File.new }
+      before do
+        module CarrierWave::Storage
+          module Fog
+            class File
+            end
+          end
+        end
+        allow(uploaded_file1.file).to receive(:file).and_return(fog_file)
+        allow(uploaded_file2.file).to receive(:file).and_return(fog_file)
+      end
+
+      after do
+        CarrierWave::Storage.send(:remove_const, :Fog)
+      end
+
+      it 'creates ImportUrlJobs' do
+        expect(ImportUrlJob).to receive(:perform_later).twice
+        described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
+        generic_work.reload
+        expect(generic_work.file_sets.count).to eq 2
+        expect(generic_work.file_sets.map(&:visibility)).to all(eq 'open')
+        expect(uploaded_file1.reload.file_set_uri).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1023 

This is a somewhat obscure bug.  The owner of a work will not see the edit button if that work was created by a proxy AND no files were attached when it was created.

This is a quick fix.  Just doing another save on the work in the attach_files_to_work_job (even when there are no files to attach) fixes the problem.  There's certainly a better way to do this, but this is the fastest with least code for the moment.
