### PR TITLE
Update solr_wrapper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -697,7 +697,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (4.4.1)
-    solr_wrapper (0.23.0)
+    solr_wrapper (1.0.0)
       faraday
       ruby-progressbar
       rubyzip


### PR DESCRIPTION
Travis builds are failing because Apache removed Solr 6.5.0 and released 6.5.1.  So we need to update solr_wrapper.

After this PR is merged, failing builds on Travis can be fixed by rebasing your branch and pushing up again.