### PR TITLE
Auto-update creator field only for new works, not edits

### DIFF
--- a/app/views/curation_concerns/base/_guts4form.html.erb
+++ b/app/views/curation_concerns/base/_guts4form.html.erb
@@ -1,7 +1,9 @@
 <% # data attributes for creator field auto-populate %>
-<user id="current_user" data-name="<%= current_user.name_for_works %>"></user>
-<% current_user.can_make_deposits_for.each do |user| %>
-  <user id="<%= user.email %>" data-name="<%= user.name_for_works %>"></user>
+<% if params[:action] == "new" %>
+  <user id="current_user" data-name="<%= current_user.name_for_works %>"></user>
+  <% current_user.can_make_deposits_for.each do |user| %>
+    <user id="<%= user.email %>" data-name="<%= user.name_for_works %>"></user>
+  <% end %>
 <% end %>
 
 <% # we will yield to content_for for each tab, e.g. :files_tab %>

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -2,11 +2,14 @@
 require 'rails_helper'
 
 shared_examples 'edit work' do |work_class|
-  let(:user) { FactoryGirl.create(:user) }
-  let(:work) { FactoryGirl.build(:work, user: user) }
+  let(:user) { FactoryGirl.create(:user, first_name: 'John', last_name: 'Doe') }
+  let(:work) { FactoryGirl.build(:work, user: user, creator: ['User, Different'], description: ['test']) }
   let(:work_type) { work_class.name.underscore }
   let(:edit_path) { "concern/#{work_type}s/#{work.id}/edit" }
   before do
+    CurationConcerns::Workflow::WorkflowImporter.load_workflows
+    Sufia::AdminSetCreateService.create_default!
+    page.driver.browser.js_errors = false
     sign_in user
     work.ordered_members << FactoryGirl.create(:file_set, user: user, title: ['ABC123xyz'])
     work.read_groups = []
@@ -16,6 +19,7 @@ shared_examples 'edit work' do |work_class|
   context 'when the user changes permissions' do
     it 'confirms copying permissions to files using Sufia layout' do
       visit edit_path
+      expect(page).to have_field("generic_work[creator][]", id: "generic_work_creator", with: "User, Different")
       choose("#{work_type}_visibility_open")
       check('agreement')
       click_on('Save')
@@ -25,6 +29,6 @@ shared_examples 'edit work' do |work_class|
   end
 end
 
-feature 'Editing a work', type: :feature do
+feature 'Editing a work', type: :feature, js: true do
   it_behaves_like 'edit work', GenericWork
 end

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -28,6 +28,7 @@ shared_examples 'doi request' do |work_class|
     allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
     CurationConcerns::Workflow::WorkflowImporter.load_workflows
     Sufia::AdminSetCreateService.create_default!
+    page.driver.browser.js_errors = false
     allow(CharacterizeJob).to receive(:perform_later)
   end
 


### PR DESCRIPTION
Fixes #1332 

Simple change so that the JS that populates the Creator field only kicks in for new works, not when a work is edited.