### PR TITLE
Fix embedded video player

### DIFF
--- a/app/views/curation_concerns/file_sets/media_display/_video.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_video.html.erb
@@ -1,6 +1,6 @@
-  <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
-    <source src="<%= main_app.download_path(file_set, file: 'webm') %>" type="video/webm" />
-    <source src="<%= main_app.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+  <video controls="controls" width="320" height="240" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+    <source src="<%= main_app.download_path(file_set) %>" type="video/webm" />
+    <source src="<%= main_app.download_path(file_set) %>" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
 


### PR DESCRIPTION
Fixes #1346 

This is a bug in Sufia

1) Allows the video to be properly streamed from Fedora and displayed in the player
2) Pins the size of the video player so it doesn't automatically get larger for larger videos

Note: It can take a bit before the video finally shows up in the player.  And the experience can be different in different browsers.  It's slow because the browser must stream the video out of Fedora.  We may want to consider disabling the player for the beta if it's just going to be frustrating for users.

The speed issue could be fixed by creating web-optimized derivatives of videos using ffmpeg when the videos are ingested and then storing the derivatives on the file system instead of in Fedora.  