### PR TITLE
Remove background image config artifact

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -24,8 +24,6 @@ Sufia.config do |config|
   # The default is true.
   config.work_requires_files = false
 
-  # Set custom banner image for UC Branding Requirements
-  config.banner_image = 'https://flic.kr/p/3kBWs4'
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"
 


### PR DESCRIPTION
Fixes #1354  

The banner image for our jumbotron is already stored locally in assets and set [here](https://github.com/uclibs/scholar_uc/blob/develop/app/assets/stylesheets/scholar.scss#L9). 

There is a place in the sufia config to set the background image, pointing to the flickr source, but this is an artifact and not in force. I'm removing [this](https://github.com/uclibs/scholar_uc/blob/develop/config/initializers/sufia.rb#L28) config setting for clarity.

Changes proposed in this pull request:
* Remove old config setting for background image.

