### PR TITLE
Add hyperlinks to partner badges

### DIFF
--- a/app/views/layouts/scholar/_partner_branding.html.erb
+++ b/app/views/layouts/scholar/_partner_branding.html.erb
@@ -1,19 +1,27 @@
 <div class="partner-branding row">
   <div class="col-sm-8 col-sm-offset-2">
   <div class="col-sm-3 col-xs-6">
-    <%= image_tag("uclib-logo.png", class: 'img-responsive') %>
+    <%= link_to 'http://libraries.uc.edu', target: '_blank' do %>
+      <%= image_tag("uclib-logo.png", class: 'img-responsive') %>
+  <% end %>
   </div>
 
   <div class="col-sm-3 col-xs-6">
-    <%= image_tag("uc-oor-placeholder.png", class: 'img-responsive') %>
+    <%= link_to 'http://research.uc.edu', target: '_blank' do %>
+      <%= image_tag("uc-oor-placeholder.png", class: 'img-responsive') %>
+    <% end %>
   </div>
 
   <div class="col-sm-3 col-xs-6">
-    <%= image_tag("it-at-uc-placeholder.png", class: 'img-responsive') %>
+    <%= link_to 'http://ucit.uc.edu', target: '_blank' do %>
+      <%= image_tag("it-at-uc-placeholder.png", class: 'img-responsive') %>
+    <% end %>
   </div>
 
   <div class="col-sm-3 col-xs-6">
-    <%= image_tag("hydra-logo.png", class: 'img-responsive') %>
+    <%= link_to 'http://projecthydra.org', target: '_blank' do %>
+      <%= image_tag("hydra-logo.png", class: 'img-responsive') %>
+    <% end %>
   </div>
   </div>
 </div>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -64,4 +64,11 @@ RSpec.describe 'the homepage', type: :feature do
   it 'renders the partner branding' do
     expect(page).to have_css('div', class: 'partner-branding')
   end
+
+  it 'renders the partner links' do
+    expect(page).to have_link(href: 'http://libraries.uc.edu')
+    expect(page).to have_link(href: 'http://research.uc.edu')
+    expect(page).to have_link(href: 'http://ucit.uc.edu')
+    expect(page).to have_link(href: 'http://projecthydra.org')
+  end
 end


### PR DESCRIPTION
Fixes #1356 

Add links to partner badges on splash page.

Changes proposed in this pull request:
* Add link to partner branding partial
* Add feature tests to homepage specs
