### PR TITLE
Fix browse everything bug for work edit

### DIFF
--- a/app/views/curation_concerns/base/_browse_everything.html.erb
+++ b/app/views/curation_concerns/base/_browse_everything.html.erb
@@ -1,0 +1,6 @@
+<div class="alert alert-success">
+  <%= t("sufia.upload.cloud_timeout_message_html", contact_href: link_to(t("sufia.upload.alert.contact_href_text"), sufia.contact_form_index_path)) %>
+</div>
+<%= button_tag(t('sufia.upload.browse_everything.browse_files_button'), type: 'button', class: 'btn btn-lg btn-success', id: "browse-btn",
+  'data-toggle' => 'browse-everything', 'data-route' => browse_everything_engine.root_path,
+  'data-target' => "##{f.object.persisted? ? 'edit' : 'new'}_#{f.object.model.model_name.param_key}#{f.object.persisted? ? '_'+f.object.model.id : ''}" ) %>


### PR DESCRIPTION
Fixes #1365

Pulls in the _browse_everything partial from Sufia to make a small change to the view.  Only the last line of the file has been changed from the original partial.

On work edit, the view was creating a data-target of `edit_generic_work` but for browse everything to work correctly the work pid needs to be appended to the data-target e.g. `edit_generic_work_h989r335q`

This is a bug from when browse_everything was first integrated into Sufia 7.  Before closing this issue we should open a new bug in Sufia and reference our fix as a suggested fix in Sufia as well.  If the bug is present in Hyrax, open an issue there as well.

You can get Dropbox and Box.com working in your local environment using the localhost keys found at https://git.uc.edu/UCLIBS/api-documentation/blob/master/browse_everything/browse_everything_on_scholar.md#localhost-branch