### PR TITLE
Fix bug preventing visibiliy section from expanding on batch create

### DIFF
--- a/app/views/sufia/batch_uploads/_form.html.erb
+++ b/app/views/sufia/batch_uploads/_form.html.erb
@@ -1,4 +1,8 @@
-<%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
+<%= simple_form_for [sufia, @form], 
+                    html: { 
+                      data: { behavior: 'work-form' },
+                      multipart: true 
+                    } do |f| %>
   <% content_for :files_tab do %>
     <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
     <p class="switch-upload-type">Note: To create a single work for all the files, go to the <%= link_to "Add New " + @form.payload_concern.constantize.model_name.human.titleize, main_app.new_polymorphic_path(@form.payload_concern.constantize) %> page.</p>


### PR DESCRIPTION
Fixes #1336 

Fixes the bug by adding `data-behavior="work-form"` to the batch create form.  This had been added to sing work create, but was missed on the batch create form.  So the JS didn't know what HTML to target.