### PR TITLE
fix college and department value autofill on work create/edit/batch edit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,11 +45,12 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Exclude:
     - 'lib/seed_methods.rb'
+    - 'app/helpers/sufia_helper.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
     - 'app/helpers/change_manager/change_manager_helper.rb'
-    - 'app/helpers/sufia_helper.rb'    
+    - 'app/helpers/sufia_helper.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -41,7 +41,7 @@ module SufiaHelper
   end
 
   def user_college(object)
-    if (object.is_a? Etd) || (object.is_a? StudentWork)
+    if (object.is_a? CurationConcerns::EtdForm) || (object.is_a? CurationConcerns::StudentWorkForm)
       ''
     else
       current_user.college
@@ -49,10 +49,26 @@ module SufiaHelper
   end
 
   def user_department(object)
-    if (object.is_a? Etd) || (object.is_a? StudentWork)
+    if (object.is_a? CurationConcerns::EtdForm) || (object.is_a? CurationConcerns::StudentWorkForm)
       ''
     else
       current_user.department
+    end
+  end
+
+  def old_or_new_college(object)
+    if object.college.empty?
+      user_college(object)
+    else
+      object.college
+    end
+  end
+
+  def old_or_new_department(object)
+    if object.department.empty?
+      user_department(object)
+    else
+      object.department
     end
   end
 

--- a/app/views/records/edit_fields/_college.html.erb
+++ b/app/views/records/edit_fields/_college.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :college,
       collection: sorted_college_list_for_works(f.object),
-      selected: (f.object.college || user_college(f.object)),
+      selected: (old_or_new_college(f.object)),
       input_html: { class: 'college' },
       required: true %>

--- a/app/views/records/edit_fields/_department.html.erb
+++ b/app/views/records/edit_fields/_department.html.erb
@@ -1,3 +1,3 @@
 <%= f.input :department,
       required: true,
-      input_html: { class: 'department', value: f.object.department || user_department(f.object) } %>
+      input_html: { class: 'department', value: old_or_new_department(f.object) } %>

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -66,6 +66,44 @@ describe SufiaHelper, type: :helper do
     end
   end
 
+  describe "#old_or_new_college" do
+    let(:object_with_college_value) { double('object', college: 'COB') }
+    let(:object_with_no_college_value) { double('object', college: '') }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(
+        double('user', college: 'COM')
+      )
+    end
+
+    it 'uses the preexisting college value if it already exists in the work' do
+      expect(helper.old_or_new_college(object_with_college_value)).to eq('COB')
+    end
+
+    it 'fills in the college value from user profile if it does not already exist in a work.' do
+      expect(helper.old_or_new_college(object_with_no_college_value)).to eq('COM')
+    end
+  end
+
+  describe "#old_or_new_department" do
+    let(:object_with_department_value) { double('object', department: 'Chemistry') }
+    let(:object_with_no_department_value) { double('object', department: '') }
+
+    before do
+      allow(helper).to receive(:current_user).and_return(
+        double('user', department: 'Biology')
+      )
+    end
+
+    it 'uses the preexisting department value if it already exists in the work' do
+      expect(helper.old_or_new_department(object_with_department_value)).to eq('Chemistry')
+    end
+
+    it 'fills in the department value from user profile if it does not already exist in a work.' do
+      expect(helper.old_or_new_department(object_with_no_department_value)).to eq('Biology')
+    end
+  end
+
   describe "#user_college" do
     before do
       allow(helper).to receive(:current_user).and_return(
@@ -73,9 +111,9 @@ describe SufiaHelper, type: :helper do
       )
     end
 
-    let(:etd) { Etd.new }
-    let(:student_work) { StudentWork.new }
-    let(:other_object) { GenericWork.new }
+    let(:etd) { CurationConcerns::EtdForm.new(Etd.new, nil) }
+    let(:student_work) { CurationConcerns::StudentWorkForm.new(StudentWork.new, nil) }
+    let(:other_object) { CurationConcerns::GenericWorkForm.new(GenericWork.new, nil) }
 
     it "is blank if the work is an ETD" do
       expect(helper.user_college(etd)).to eq("")
@@ -97,9 +135,9 @@ describe SufiaHelper, type: :helper do
       )
     end
 
-    let(:etd) { Etd.new }
-    let(:student_work) { StudentWork.new }
-    let(:other_object) { GenericWork.new }
+    let(:etd) { CurationConcerns::EtdForm.new(Etd.new, nil) }
+    let(:student_work) { CurationConcerns::StudentWorkForm.new(StudentWork.new, nil) }
+    let(:other_object) { CurationConcerns::GenericWorkForm.new(GenericWork.new, nil) }
 
     it "is blank if the work is an ETD" do
       expect(helper.user_department(etd)).to eq("")


### PR DESCRIPTION
Fixes #1378 

Present short summary (50 characters or less)

Previous iteration used incorrect conditional check. This gives the helper/view the proper conditional checks to function.

Changes proposed in this pull request:
* Pull out `value` logic from view into helper methods `old_or_new_college` and `old_or_new_department`, rather than keeping it in view.
* Change conditional statement to check for an empty string coming from form builder object rather than the object being `nil`.

