### PR TITLE
Restore video player and enable ffmpeg derivatives

### DIFF
--- a/app/views/curation_concerns/file_sets/media_display/_video.html.erb
+++ b/app/views/curation_concerns/file_sets/media_display/_video.html.erb
@@ -1,6 +1,6 @@
-  <video controls="controls" width="320" height="240" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
-    <source src="<%= main_app.download_path(file_set) %>" type="video/webm" />
-    <source src="<%= main_app.download_path(file_set) %>" type="video/mp4" />
+  <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+    <source src="<%= main_app.download_path(file_set, file: 'webm') %>" type="video/webm" />
+    <source src="<%= main_app.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
     Your browser does not support the video tag.
   </video>
 

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -55,7 +55,7 @@ Sufia.config do |config|
   # config.persistent_hostpath = 'http://localhost/files/'
 
   # If you have ffmpeg installed and want to transcode audio and video uncomment this line
-  # config.enable_ffmpeg = true
+  config.enable_ffmpeg = true
 
   # Sufia uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens


### PR DESCRIPTION
Fixes #1346 

Restores the video player settings to their original status.  

Enables the application to generate video derivatives upon ingestion.  The derivatives will automatically be used by the player.