### PR TITLE
fix rights persistence on batch create

### DIFF
--- a/app/forms/sufia/forms/batch_upload_form.rb
+++ b/app/forms/sufia/forms/batch_upload_form.rb
@@ -81,6 +81,10 @@ module Sufia
         current_ability.current_user
       end
 
+      def self.build_permitted_params
+        super + [:rights]
+      end
+
       # Override of ActiveModel::Model name that allows us to use our custom name class
       def self.model_name
         @_model_name ||= begin


### PR DESCRIPTION
Fixes #1383 

Present short summary (50 characters or less)
The rights field was not persisting on batch create due to the rights parameter not being permitted, thereby excluded from `attributes_for_actor`

Changes proposed in this pull request:
* Override default `build_permitted_params` method to include the rights field.

