### PR TITLE
[Not really a serious PR] Bug/#1411 citations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,7 +137,10 @@ Rails:
 
 Rails/OutputSafety:
   Exclude:
-    - app/values/universal_viewer.rb
+    - 'app/values/universal_viewer.rb'
+    - 'app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb'
+    - 'app/helpers/sufia/citations_behaviors/formatters/chicago_formatter.rb'
+    - 'app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb'
 
 RSpec/AnyInstance:
   Exclude:

--- a/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
@@ -1,0 +1,57 @@
+module Sufia
+  module CitationsBehaviors
+    module Formatters
+      class ApaFormatter < BaseFormatter
+        include Sufia::CitationsBehaviors::PublicationBehavior
+        include Sufia::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+
+          # setup formatted author list
+          authors_list = author_list(work).select { |author| !author.blank? }
+          text << format_authors(authors_list)
+          unless text.blank?
+            text = "<span class=\"citation-author\">#{text}</span> "
+          end
+          # Get Pub Date
+          pub_date = setup_pub_date(work)
+          text << format_date(pub_date)
+
+          # setup title info
+          title_info = setup_title_info(work)
+          text << format_title(title_info)
+
+          # Publisher info
+          pub_info = clean_end_punctuation(setup_pub_info(work))
+          text << pub_info unless pub_info.nil?
+          text << "." unless text.blank? || text =~ /\.$/
+          text.html_safe
+        end
+
+        def format_authors(authors_list = [])
+          authors_list = Array.wrap(authors_list).collect { |name| abbreviate_name(surname_first(name)).strip }
+          text = ''
+          text << authors_list.first if authors_list.first
+          authors_list[1..-1].each do |author|
+            if author == authors_list.last # last
+              text << ", &amp; " << author
+            else # all others
+              text << ", " << author
+            end
+          end
+          text << "." unless text =~ /\.$/
+          text
+        end
+
+        def format_date(pub_date)
+          pub_date.blank? ? "" : "(" + pub_date + "). "
+        end
+
+        def format_title(title_info)
+          title_info.nil? ? "" : "<i class=\"citation-title\">#{title_info}</i> "
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/apa_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Sufia
   module CitationsBehaviors
     module Formatters
@@ -26,6 +27,7 @@ module Sufia
           pub_info = clean_end_punctuation(setup_pub_info(work))
           text << pub_info unless pub_info.nil?
           text << "." unless text.blank? || text =~ /\.$/
+          text.gsub!(/(\.\s*<\/?\w+>\s*)\./, "\\1")
           text.html_safe
         end
 

--- a/app/helpers/sufia/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/chicago_formatter.rb
@@ -1,0 +1,59 @@
+module Sufia
+  module CitationsBehaviors
+    module Formatters
+      class ChicagoFormatter < BaseFormatter
+        include Sufia::CitationsBehaviors::PublicationBehavior
+        include Sufia::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ""
+
+          # setup formatted author list
+          authors_list = all_authors(work)
+          text << format_authors(authors_list)
+          unless text.blank?
+            text = "<span class=\"citation-author\">#{text}</span>"
+          end
+          # Get Pub Date
+          pub_date = setup_pub_date(work)
+          text << " #{pub_date}." unless pub_date.nil?
+          text << "." unless text.blank? || text =~ /\.$/
+
+          text << format_title(work.to_s)
+          pub_info = setup_pub_info(work, false)
+          text << " #{pub_info}." unless pub_info.blank?
+          text.html_safe
+        end
+
+        def format_authors(authors_list = [])
+          unless authors_list.blank?
+            text = ''
+            text << surname_first(authors_list.first) if authors_list.first
+            authors_list[1..6].each_with_index do |author, index|
+              text << if index + 2 == authors_list.length # we've skipped the first author
+                        ", and #{given_name_first(author)}."
+                      else
+                        ", #{given_name_first(author)}"
+                      end
+            end
+            text << " et al." if authors_list.length > 7
+          end
+          # if for some reason the first author ended with a comma
+          text.gsub!(',,', ',')
+          text << "." unless text =~ /\.$/
+          text
+        end
+
+        def format_date(pub_date)
+        end
+
+        def format_title(title_info)
+          return "" if title_info.blank?
+          title_text = chicago_citation_title(title_info)
+          title_text << '.' unless title_text =~ /\.$/
+          " <i class=\"citation-title\">#{title_text}</i>"
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/sufia/citations_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/chicago_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Sufia
   module CitationsBehaviors
     module Formatters
@@ -22,6 +23,7 @@ module Sufia
           text << format_title(work.to_s)
           pub_info = setup_pub_info(work, false)
           text << " #{pub_info}." unless pub_info.blank?
+          text.gsub!(/(\.\s*<\/?\w+>\s*)\./, "\\1")
           text.html_safe
         end
 

--- a/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
@@ -1,0 +1,64 @@
+module Sufia
+  module CitationsBehaviors
+    module Formatters
+      class MlaFormatter < BaseFormatter
+        include Sufia::CitationsBehaviors::PublicationBehavior
+        include Sufia::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+
+          # setup formatted author list
+          authors = author_list(work).select { |author| !author.blank? }
+          text << "<span class=\"citation-author\">#{format_authors(authors)}</span>"
+          # setup title
+          title_info = setup_title_info(work)
+          text << format_title(title_info)
+
+          # Publication
+          pub_info = clean_end_punctuation(setup_pub_info(work, true))
+
+          text << pub_info unless pub_info.blank?
+          text << "." unless text.blank? || text =~ /\.$/
+          text.html_safe
+        end
+
+        def format_authors(authors_list = [])
+          return "" if authors_list.blank?
+          authors_list = Array.wrap(authors_list)
+          text = concatenate_authors_from(authors_list)
+          unless text.blank?
+            text << "." unless text =~ /\.$/
+            text << " "
+          end
+          text
+        end
+
+        def concatenate_authors_from(authors_list)
+          text = ''
+          text << surname_first(authors_list.first)
+          if authors_list.length > 1
+            if authors_list.length < 4
+              authors_list[1...-1].each do |author|
+                text << ", " << given_name_first(author)
+              end
+              text << ", and #{given_name_first(authors_list.last)}"
+            else
+              text << ", et al"
+            end
+          end
+          text
+        end
+        private :concatenate_authors_from
+
+        def format_date(pub_date)
+          pub_date
+        end
+
+        def format_title(title_info)
+          title_info.blank? ? "" : "<i class=\"citation-title\">#{mla_citation_title(title_info)}</i> "
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/sufia/citations_behaviors/formatters/mla_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Sufia
   module CitationsBehaviors
     module Formatters
@@ -20,6 +21,7 @@ module Sufia
 
           text << pub_info unless pub_info.blank?
           text << "." unless text.blank? || text =~ /\.$/
+          text.gsub!(/(\.\s*<\/?\w+>\s*)\./, "\\1")
           text.html_safe
         end
 


### PR DESCRIPTION
Fixes #1411 

Searching for double periods separated by only whitespace or html markup in citation formatters and removes the second period.

I put this in two commits so it would be easier to view my changes.