### PR TITLE
Fix rubocop violations under Hyrax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,16 +28,17 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
   #everything here was hyrax-specific
-    - 'app/indexers/curation_concerns/file_set_indexer.rb'
+    - 'app/indexers/hyrax/file_set_indexer.rb'
     - 'app/helpers/change_manager/change_manager_helper.rb'
     - 'app/forms/hyrax/forms/batch_edit_form.rb'
+    - 'app/indexers/hyrax/work_indexer.rb'
 
 Metrics/MethodLength:
   Max: 15
   Exclude:
     - 'lib/seed_methods.rb'
-    - 'app/indexers/curation_concerns/file_set_indexer.rb'
-    - 'spec/support/curation_concerns/factory_helpers.rb'
+    - 'app/indexers/hyrax/file_set_indexer.rb'
+    - 'spec/support/hyrax/factory_helpers.rb'
     - 'app/helpers/change_manager/change_manager_helper.rb'
     - 'app/forms/hyrax/forms/batch_upload_form.rb'
     - 'app/forms/hyrax/forms/batch_edit_form.rb'
@@ -64,14 +65,22 @@ Style/BlockEndNewline:
   Exclude:
     - 'spec/**/*'
 
+Style/FileName:
+  Exclude:
+    - 'Gemfile'
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'app/controllers/contact_form_controller.rb'
     - 'app/controllers/concerns/hyrax/contact_form_controller_behavior.rb'
+    - 'bin/*'
 
 Style/GuardClause:
   Exclude:
     - 'app/models/ability.rb'
+    - 'app/indexers/hyrax/collection_indexer.rb'
+    - 'app/indexers/hyrax/work_indexer.rb'
+    - 'app/services/change_manager/email_manager.rb'
 
 Style/SymbolProc: # https://github.com/bbatsov/rubocop/issues/3071
   Exclude:
@@ -118,6 +127,10 @@ Style/BracesAroundHashParameters:
     - 'spec/views/workgroups/new.html.erb_spec.rb'
     - 'spec/views/workgroups/show.html.erb_spec.rb'
 
+Style/CommentIndentation:
+  Exclude:
+    - 'config/initializers/orcid_initializer.rb'
+
 Style/BlockComments:
   Exclude:
     - 'spec/spec_helper.rb'
@@ -131,8 +144,16 @@ Style/DoubleNegation:
   Exclude:
     - 'config/environments/development.rb'
 
+Style/EmptyLineAfterMagicComment:
+  Enabled: false
+
 Rails:
   Enabled: true
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'app/models/user.rb'
+    - 'app/jobs/user_edit_profile_event_job.rb'
 
 Rails/OutputSafety:
   Exclude:
@@ -142,7 +163,7 @@ RSpec/AnyInstance:
   Exclude:
     - 'spec/controllers/contact_form_controller_spec.rb'
     - 'spec/features/admin_admin_set_spec.rb'
-    - 'spec/controllers/curation_concerns/etds_controller_spec.rb'
+    - 'spec/controllers/hyrax/etds_controller_spec.rb'
     - 'spec/features/create_work_spec.rb'
     - 'spec/features/end_to_end_spec.rb'
     - 'spec/support/shared/doi_request.rb'
@@ -153,12 +174,15 @@ RSpec/DescribeClass:
   Exclude:
     - 'spec/views/**/*'
     - 'spec/features/*'
-    - 'spec/controllers/curation_concerns/generic_works_controller_spec.rb'
-    - 'spec/routing/curation_concerns_spec.rb'
+    - 'spec/controllers/hyrax/generic_works_controller_spec.rb'
+    - 'spec/routing/hyrax_spec.rb'
 
 RSpec/DescribedClass:
   Exclude:
     - 'spec/presenters/hyrax/work_show_presenter_spec.rb'
+
+Rails/DynamicFindBy:
+  Enabled: false
 
 RSpec/ExpectActual:
   Enabled: false
@@ -168,6 +192,10 @@ RSpec/LetSetup:
 
 RSpec/MessageExpectation:
   Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: true
+  EnforcedStyle: receive
 
 RSpec/MultipleExpectations:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,5 +1,17 @@
 require: rubocop-rspec
 
+Bundler/OrderedGems:
+  Exclude:
+    - 'Gemfile'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'app/controllers/catalog_controller.rb'
+    - 'app/models/concerns/remotely_identified_by_doi.rb'
+    - 'config/initializers/simple_form_bootstrap.rb'
+    - 'config/routes.rb'
+
 Metrics/CyclomaticComplexity:
   Exclude:
   #everything here was hyrax-specific
@@ -29,6 +41,23 @@ Style/PredicateName:
   Exclude:
   #everything here was hyrax-specific
 
+Style/SafeNavigation:
+  Exclude:
+    - 'app/controllers/concerns/hyrax/collections_controller_behavior.rb'
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Rails/Present:
+  Exclude:
+    - 'app/controllers/hyrax/users_controller.rb'
+    - 'app/indexers/hyrax/collection_indexer.rb'
+    - 'app/indexers/hyrax/work_indexer.rb'
+    - 'app/models/concerns/remotely_identified_by_doi.rb'
+
 Rails/Output:
   Exclude:
   #keeping this as we may use generators in the future
@@ -38,6 +67,10 @@ Rails/HasAndBelongsToMany:
   Exclude:
   #everything here was hyrax-specific
 
+Rails/HttpPositionalArguments:
+  Exclude:
+    - 'spec/**/*'
+
 RSpec/NamedSubject:
   Enabled: false
 
@@ -46,9 +79,20 @@ RSpec/ExampleLength:
   Exclude:
   #everything here was hyrax-specific
 
+Rails/FilePath:
+  Exclude:
+    - 'config/**/*'
+    - 'app/jobs/change_manager/process_change_job.rb'
+    - 'app/mailers/change_manager/scholar_notification_mailer.rb'
+    - 'spec/rails_helper.rb'
+
 RSpec/VerifiedDoubles:
   Enabled: false
 
 RSpec/AnyInstance:
   Exclude:
   #everything here was hyrax-specific
+
+RSpec/ImplicitExpect:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'hyrax', github: 'projecthydra-labs/hyrax', ref: '0b663c43b97ecd30b2c42115b9c0d933559f0ba3'
 
-#repository manager
+# repository manager
 gem 'hydra-role-management'
-#gem 'orcid', github: 'uclibs/orcid'
+# gem 'orcid', github: 'uclibs/orcid'
 gem 'riiif', '~> 0.2.0'
 gem 'iiif_manifest', '~> 0.1.2'
 gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch: 'setting-status'
@@ -16,7 +17,7 @@ gem 'rails', '5.0.3'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use Puma as the app server
-#gem 'puma', '~> 3.0'
+# gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -47,10 +48,10 @@ gem 'change_manager', git: "https://github.com/lawhorkl/change_manager.git", ref
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
-#gem 'clamav'
+# gem 'clamav'
 
 group :development, :test do
-  gem 'brakeman', :require => false
+  gem 'brakeman', require: false
 end
 
 group :development, :test do
@@ -67,7 +68,6 @@ group :development do
   gem 'spring'
 end
 
-
 group :development, :test do
   gem 'solr_wrapper', '>= 0.13'
 end
@@ -75,7 +75,7 @@ end
 gem 'rsolr', '~> 1.0'
 gem 'devise'
 gem 'devise-guests', '~> 0.5'
-#gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
+# gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
 group :development, :test do
   gem 'vcr'
   gem 'webmock'

--- a/app/controllers/collection_avatars_controller.rb
+++ b/app/controllers/collection_avatars_controller.rb
@@ -4,8 +4,7 @@ class CollectionAvatarsController < ApplicationController
 
   # GET /collection_avatars/1
   # GET /collection_avatars/1.json
-  def show
-  end
+  def show; end
 
   # GET /collection_avatars/new
   def new
@@ -13,8 +12,7 @@ class CollectionAvatarsController < ApplicationController
   end
 
   # GET /collection_avatars/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /collection_avatars
   # POST /collection_avatars.json

--- a/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/batch_uploads_controller_behavior.rb
@@ -64,7 +64,7 @@ module Hyrax
                                      params[:title].permit!.to_h,
                                      params[:uploaded_files],
                                      attributes_for_actor.to_h.merge!(model: klass),
-                                     log)
+                                     operation)
       end
 
       def uploading_on_behalf_of?

--- a/app/controllers/concerns/hyrax/contact_form_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/contact_form_controller_behavior.rb
@@ -8,8 +8,7 @@ module Hyrax
       layout 'homepage'
     end
 
-    def new
-    end
+    def new; end
 
     def create
       # not spam and a valid form

--- a/app/controllers/welcome_page_controller.rb
+++ b/app/controllers/welcome_page_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class WelcomePageController < ApplicationController
-  def index
-  end
+  def index; end
 
   def create
     if user_just_waived_welcome_page?

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -2,7 +2,6 @@
 require Hyrax::Engine.root.join('app/indexers/hyrax/file_set_indexer.rb')
 module Hyrax
   class FileSetIndexer < ActiveFedora::IndexingService
-
     def generate_solr_document
       super.tap do |solr_doc|
         solr_doc[Solrizer.solr_name('hasRelatedMediaFragment', :symbol)] = object.representative_id

--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -31,8 +31,8 @@ class BatchCreateJob < ActiveJob::Base
         attributes = attributes.merge(uploaded_files: [upload_id],
                                       title: title)
         child_log = Hyrax::Operation.create!(user: user,
-                                                        operation_type: "Create Work",
-                                                        parent: log)
+                                             operation_type: "Create Work",
+                                             parent: log)
         CreateWorkJob.perform_later(user, model, attributes, child_log)
       end
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/concerns/remotely_identified_by_doi.rb
+++ b/app/models/concerns/remotely_identified_by_doi.rb
@@ -36,13 +36,13 @@ module RemotelyIdentifiedByDoi
 
       protected
 
-      def doi_remote_service
-        @doi_remote_service ||= Hydra::RemoteIdentifier.remote_service(:doi)
-      end
+        def doi_remote_service
+          @doi_remote_service ||= Hydra::RemoteIdentifier.remote_service(:doi)
+        end
 
-      def remote_doi_assignment_strategy?
-        doi_assignment_strategy.to_s == doi_remote_service.accessor_name.to_s
-      end
+        def remote_doi_assignment_strategy?
+          doi_assignment_strategy.to_s == doi_remote_service.accessor_name.to_s
+        end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable #, :omniauthable, omniauth_providers: [:orcid]
+         :recoverable, :rememberable, :trackable, :validatable # , :omniauthable, omniauth_providers: [:orcid]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/bin/spring
+++ b/bin/spring
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 # This file loads spring without using Bundler, in order to be fast.

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'boot'
 
 require 'rails/all'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -47,7 +48,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/config/initializers/arkivo_constraint.rb
+++ b/config/initializers/arkivo_constraint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Hyrax
   class ArkivoConstraint
     def self.matches?(_request)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/college_and_department_initializer.rb
+++ b/config/initializers/college_and_department_initializer.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-COLLEGE_AND_DEPARTMENT = YAML.load(File.open(Rails.root.join('config/college_and_department.yml'))).freeze if File.exist?(Rails.root.join('config/college_and_department.yml'))
+COLLEGE_AND_DEPARTMENT = YAML.safe_load(File.open(Rails.root.join('config/college_and_department.yml'))).freeze if File.exist?(Rails.root.join('config/college_and_department.yml'))

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,15 +2,15 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-#  config.omniauth(:orcid, Orcid.provider.id, Orcid.provider.secret,
-#                  scope: Orcid.provider.authentication_scope,
-#                  member: true,
-#                  sandbox: true,
-#                  client_options: {
-#                    site: Orcid.provider.site_url,
-#                    authorize_url: Orcid.provider.authorize_url,
-#                    token_url: Orcid.provider.token_url
-#                  })
+  # config.omniauth(:orcid, Orcid.provider.id, Orcid.provider.secret,
+  #                  scope: Orcid.provider.authentication_scope,
+  #                  member: true,
+  #                  sandbox: true,
+  #                  client_options: {
+  #                    site: Orcid.provider.site_url,
+  #                    authorize_url: Orcid.provider.authorize_url,
+  #                    token_url: Orcid.provider.token_url
+  # })
 
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing

--- a/config/initializers/file_set_displays_image.rb
+++ b/config/initializers/file_set_displays_image.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-#Hyrax::FileSetPresenter.include DisplaysImage
+# Hyrax::FileSetPresenter.include DisplaysImage

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/genre_type_initializer.rb
+++ b/config/initializers/genre_type_initializer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-GENRE_TYPES_DOCUMENT = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_document.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_document.yml'))
+GENRE_TYPES_DOCUMENT = YAML.safe_load(File.open(Rails.root.join('config/authorities/genre_types_document.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_document.yml'))
 
-GENRE_TYPES_IMAGE = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_image.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_image.yml'))
+GENRE_TYPES_IMAGE = YAML.safe_load(File.open(Rails.root.join('config/authorities/genre_types_image.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_image.yml'))
 
-GENRE_TYPES_STUDENTWORK = YAML.load(File.open(Rails.root.join('config/authorities/genre_types_student_work.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_student_work.yml'))
+GENRE_TYPES_STUDENTWORK = YAML.safe_load(File.open(Rails.root.join('config/authorities/genre_types_student_work.yml'))).freeze if File.exist?(Rails.root.join('config/authorities/genre_types_student_work.yml'))

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -48,7 +48,7 @@ Hyrax.config do |config|
 
   # Enables a link to the citations page for a work
   # Default is false
-  config.citations =  true
+  config.citations = true
 
   # Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)
   # config.temp_file_base = '/home/developer1'

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.

--- a/config/initializers/orcid_initializer.rb
+++ b/config/initializers/orcid_initializer.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
-=begin
-Orcid.configure do |config|
-  # # Configure your Orcid Client Application. See URL below for more
-  # # information
-  # # http://support.orcid.org/knowledgebase/articles/116739-register-a-client-application
+# Orcid.configure do |config|
+  # Configure your Orcid Client Application. See URL below for more
+  # information
+  # http://support.orcid.org/knowledgebase/articles/116739-register-a-client-application
   # config.provider.id = "Your app's Orcid Client ID"
   # config.provider.secret = "Your app's Orcid Client Secret"
 
-  # # Configure how your applications models will be mapped to an Orcid Work so
-  # # that your application can append the work to an Orcid Profile.
+  # Configure how your applications models will be mapped to an Orcid Work so
+  # that your application can append the work to an Orcid Profile.
   # config.register_mapping_to_orcid_work(
   #   :article,
   #   [
@@ -16,5 +15,4 @@ Orcid.configure do |config|
   #     [lambda{|article| article.publishers.join("; ")}, :publishers]
   #   ]
   # )
-end
-=end
+# end

--- a/config/initializers/redis_config.rb
+++ b/config/initializers/redis_config.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 require 'redis'
-config = YAML.load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
+config = YAML.safe_load(ERB.new(IO.read(File.join(Rails.root, 'config', 'redis.yml'))).result)[Rails.env].with_indifferent_access
 Redis.current = Redis.new(config.merge(thread_safe: true))

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_scholar_uc_session'

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   mount Blacklight::Engine => '/'
 
-  authenticate :user, ->(u) { u.admin? } do
+  authenticate :user, (->(u) { u.admin? }) do
     mount Sidekiq::Web => '/sidekiq'
   end
 

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 %w(
   .ruby-version
   .rbenv-vars

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rspec/core'
 require 'rspec/core/rake_task'
 require 'solr_wrapper'
@@ -5,7 +6,7 @@ require 'fcrepo_wrapper'
 require 'active_fedora/rake_support'
 
 desc 'Spin up test servers and run specs'
-task :spec_with_app_load  do
+task :spec_with_app_load do
   reset_statefile! if ENV['TRAVIS'] == 'true'
   with_test_server do
     Rake::Task['spec'].invoke
@@ -19,5 +20,5 @@ task :ci do
 end
 
 def reset_statefile!
- FileUtils.rm_f('/tmp/minter-state')
+  FileUtils.rm_f('/tmp/minter-state')
 end

--- a/lib/tasks/embargo_manager.rake
+++ b/lib/tasks/embargo_manager.rake
@@ -1,17 +1,16 @@
+# frozen_string_literal: true
 namespace :embargo_manager do
   desc 'Starts EmbargoWorker to manage expired embargoes'
-  task :release => :environment do
-
-    #Controls when reminder emails are sent out for expiring embargoed works.
+  task release: :environment do
+    # Controls when reminder emails are sent out for expiring embargoed works.
     FOURTEEN_DAYS = 14
     THIRTY_DAYS = 30
     ZERO_DAYS = 0
-    results_cap = 1000000
+    results_cap = 1_000_000
 
-    solr_results = ActiveFedora::SolrService.query( 'embargo_release_date_dtsi:[* TO *]', rows: results_cap )
+    solr_results = ActiveFedora::SolrService.query('embargo_release_date_dtsi:[* TO *]', rows: results_cap)
     solr_results.each do |work|
-
-      days_until_release = (Date.parse(work['embargo_release_date_dtsi']) - Date.today).to_i
+      days_until_release = (Date.parse(work['embargo_release_date_dtsi']) - Time.zone.today).to_i
 
       receiver = work['depositor_tesim']
       mail_contents = work['title_tesim'].first

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
-#require "byebug"
-#byebug
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'simplecov'


### PR DESCRIPTION
Fixes #1394 

This resolves all of the Rubocop violations.  In most cases I tried to follow the rules the Hyrax gem is using.  

Unless it was a dead-simple change, I tried to avoid changing code since our test suite isn't passing right now.  I didn't want to unknowingly break anything.  So some violations went into .rubocop_todo.yml until we can work on them later.

After this is merged, Travis should be able to run our test suite.