### PR TITLE
Re-enable ORCID

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem 'hyrax', '1.0.1'
 
 # repository manager
 gem 'hydra-role-management'
-# gem 'orcid', github: 'uclibs/orcid'
+gem 'orcid', github: 'uclibs/orcid', branch: 'rails-5'
+gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth', branch: 'rails-5'
 gem 'riiif', '~> 0.2.0'
 gem 'iiif_manifest', '~> 0.1.2'
 gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch: 'setting-status'
@@ -75,7 +76,6 @@ end
 gem 'rsolr', '~> 1.0'
 gem 'devise'
 gem 'devise-guests', '~> 0.5'
-# gem 'devise-multi_auth', github: 'uclibs/devise-multi_auth'
 group :development, :test do
   gem 'vcr'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: git://github.com/uclibs/devise-multi_auth.git
+  revision: 24bc234191a22f76286aeac2fb0727285c54d810
+  branch: rails-5
+  specs:
+    devise-multi_auth (0.2.0)
+      devise (= 4.3.0)
+      omniauth (~> 1.2)
+      rails (= 5.0.3)
+
+GIT
   remote: git://github.com/uclibs/hydra-remote_identifier.git
   revision: 678d88cd0388f8cad416b9310fa1f9dbdab86c4c
   branch: setting-status
@@ -6,6 +16,23 @@ GIT
     hydra-remote_identifier (0.6.8)
       activesupport (>= 3.2.13)
       rest-client (~> 2.0.2)
+
+GIT
+  remote: git://github.com/uclibs/orcid.git
+  revision: 728d7dcdf1ac02de79372c10811a0abe93465668
+  branch: rails-5
+  specs:
+    orcid (0.9.1)
+      email_validator
+      figaro
+      hashie (= 3.4.6)
+      mappy
+      nokogiri (= 1.7.2)
+      omniauth-oauth2 (< 1.4)
+      omniauth-orcid (= 0.6)
+      railties (= 5.0.3)
+      simple_form
+      virtus
 
 GIT
   remote: https://github.com/lawhorkl/change_manager.git
@@ -110,14 +137,18 @@ GEM
       execjs
     awesome_nested_set (3.1.3)
       activerecord (>= 4.0.0, < 5.2)
-    aws-sdk (2.9.29)
-      aws-sdk-resources (= 2.9.29)
-    aws-sdk-core (2.9.29)
+    aws-sdk (2.9.31)
+      aws-sdk-resources (= 2.9.31)
+    aws-sdk-core (2.9.31)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.29)
-      aws-sdk-core (= 2.9.29)
+    aws-sdk-resources (2.9.31)
+      aws-sdk-core (= 2.9.31)
     aws-sigv4 (1.0.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -165,8 +196,10 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.7.0)
       ffi (~> 1.0, >= 1.0.11)
-    clipboard-rails (1.6.1)
+    clipboard-rails (1.7.1)
     cliver (0.3.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -191,6 +224,8 @@ GEM
     declarative-option (0.1.0)
     deprecation (1.0.0)
       activesupport
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -241,6 +276,9 @@ GEM
     ebnf (1.1.0)
       rdf (~> 2.0)
       sxp (~> 1.0)
+    email_validator (1.6.0)
+      activemodel
+    equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -253,6 +291,8 @@ GEM
     fcrepo_wrapper (0.8.0)
       ruby-progressbar
     ffi (1.9.18)
+    figaro (1.1.1)
+      thor (~> 0.14)
     flipflop (2.3.1)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
@@ -286,7 +326,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.4)
-    hashie (3.5.5)
+    hashie (3.4.6)
     hiredis (0.6.1)
     htmlentities (4.3.4)
     httmultiparty (0.3.16)
@@ -393,8 +433,8 @@ GEM
       activesupport (>= 4)
       iiif-presentation (~> 0.1.0)
     inflecto (0.0.2)
-    jbuilder (2.6.4)
-      activesupport (>= 3.0.0)
+    jbuilder (2.7.0)
+      activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jmespath (1.3.1)
     jquery-datatables-rails (3.4.0)
@@ -456,6 +496,8 @@ GEM
     mailboxer (0.15.1)
       carrierwave (>= 0.5.8)
       rails (>= 5.0.0)
+    mappy (0.1.0)
+      activesupport
     memoist (0.15.0)
     method_source (0.8.2)
     mime-types (3.1)
@@ -487,6 +529,15 @@ GEM
       activesupport
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
+    omniauth (1.6.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth2 (1.3.1)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+    omniauth-orcid (0.6)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
     openseadragon (0.3.3)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
@@ -653,7 +704,7 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
-    sidekiq (5.0.0)
+    sidekiq (5.0.2)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -734,6 +785,11 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.2.1)
     vcr (3.0.3)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -767,6 +823,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-guests (~> 0.5)
+  devise-multi_auth!
   factory_girl_rails
   fcrepo_wrapper
   hydra-remote_identifier!
@@ -776,6 +833,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   kaltura (= 0.1.1)
+  orcid!
   poltergeist
   rails (= 5.0.3)
   rails-controller-testing
@@ -802,4 +860,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.0
+   1.14.6

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable # , :omniauthable, omniauth_providers: [:orcid]
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:orcid]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/views/hyrax/users/_edit_primary.html.erb
+++ b/app/views/hyrax/users/_edit_primary.html.erb
@@ -127,14 +127,11 @@
 </div>
 <div class="row orcid-section">
   <div class="col-md-5 well">
-    # ORCID partial
-    <!--   
-      <%# defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
-        <%# status_processor.call(current_user) do |on| %>
-          <%# on.authenticated_connection do |profile| %>
-          <%# end %>
-        <%# end %>
-      <%#= render partial: 'orcid/profile_connections/orcid_connector', locals: {default_search_text: current_user.name } %>
-    -->
+      <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for) %>
+        <% status_processor.call(current_user) do |on| %>
+          <% on.authenticated_connection do |profile| %>
+          <% end %>
+        <% end %>
+      <%= render partial: 'orcid/profile_connections/orcid_connector', locals: {default_search_text: current_user.name } %>
   </div>
 </div>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -1,12 +1,12 @@
 <dl id="user_info">
 
-  <%# defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for)
+  <% defined?(status_processor) || status_processor = Orcid::ProfileStatus.method(:for)
                                    status_processor.call(@user) do |on|
                                    on.authenticated_connection do |profile| %>
-                                   <dt><%#= orcid_label('profile') %></dt>
-                                   <dd><%#= link_to profile.orcid_profile_id, Orcid.url_for_orcid_id(profile.orcid_profile_id), { target: '_blank' } %></dd>
-    <%# end %>
-    <%# end %>
+                                   <dt><%= orcid_label('profile') %></dt>
+                                   <dd><%= link_to profile.orcid_profile_id, Orcid.url_for_orcid_id(profile.orcid_profile_id), { target: '_blank' } %></dd>
+    <% end %>
+    <% end %>
 <% if Hyrax.config.arkivo_api && user.zotero_userid.present? %>
   <dt><%= zotero_label(html_class: 'profile') %></dt>
   <dd><%= link_to zotero_profile_url(user.zotero_userid), zotero_profile_url(user.zotero_userid), { target: '_blank' } %></dd>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,15 +2,15 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  # config.omniauth(:orcid, Orcid.provider.id, Orcid.provider.secret,
-  #                  scope: Orcid.provider.authentication_scope,
-  #                  member: true,
-  #                  sandbox: true,
-  #                  client_options: {
-  #                    site: Orcid.provider.site_url,
-  #                    authorize_url: Orcid.provider.authorize_url,
-  #                    token_url: Orcid.provider.token_url
-  # })
+  config.omniauth(:orcid, Orcid.provider.id, Orcid.provider.secret,
+                  scope: Orcid.provider.authentication_scope,
+                  member: true,
+                  sandbox: true,
+                  client_options: {
+                    site: Orcid.provider.site_url,
+                    authorize_url: Orcid.provider.authorize_url,
+                    token_url: Orcid.provider.token_url
+                  })
 
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing

--- a/config/initializers/orcid_initializer.rb
+++ b/config/initializers/orcid_initializer.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
-# Orcid.configure do |config|
-  # Configure your Orcid Client Application. See URL below for more
-  # information
-  # http://support.orcid.org/knowledgebase/articles/116739-register-a-client-application
+Orcid.configure do |config|
+  # # Configure your Orcid Client Application. See URL below for more
+  # # information
+  # # http://support.orcid.org/knowledgebase/articles/116739-register-a-client-application
   # config.provider.id = "Your app's Orcid Client ID"
   # config.provider.secret = "Your app's Orcid Client Secret"
 
@@ -15,4 +15,4 @@
   #     [lambda{|article| article.publishers.join("; ")}, :publishers]
   #   ]
   # )
-# end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   resources :collection_avatars
   resource :featured_collection, only: [:create, :destroy]
-  # mount Orcid::Engine => "/orcid"
+  mount Orcid::Engine => "/orcid"
   mount BrowseEverything::Engine => '/browse'
   mount Qa::Engine => '/authorities'
 
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     concerns :searchable
   end
 
-  devise_for :users, controllers: { registrations: "registrations" } # { omniauth_callbacks: 'callbacks', registrations: "registrations" }
+  devise_for :users, controllers: { omniauth_callbacks: 'callbacks', registrations: "registrations" }
 
   mount Hydra::RoleManagement::Engine => '/'
 


### PR DESCRIPTION
Fixes #1398 
Fixes #1376 
Fixes #1374

Points to our custom `rails-5` branches of ORCID and devise-multi-auth on Github and turns on all the ORCID stuff.

All of our ORCID tests are passing and I verified that the `Create or Connect your ORCID iD` shows up on the profile edit page.  The reviewer should test that things still work with ORCID's sandbox.