### PR TITLE
Changes from nope.png to default.png

### DIFF
--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,5 +1,5 @@
 <% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
   <%= media_display presenter.representative_presenter %>
 <% else %>
-  <%= image_tag 'nope.png', class: "canonical-image" %>
+  <%= image_tag 'default.png', class: "canonical-image" %>
 <% end %>


### PR DESCRIPTION
Fixes #1439 

Hyrax no longer uses nope.png.  It uses default.png instead.

Present short summary (50 characters or less)

See: https://github.com/samvera-labs/hyrax/commit/39f7b89b43c8add7ea71547362663c69005931ba

Failing Test:  244
