### PR TITLE
Adjust specs for workflow and admin set changes

### DIFF
--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :admin_set do
+    sequence(:title) { |n| ["Title #{n}"] }
+
+    # Given the relationship between permission template and admin set, when
+    # an admin set is created via a factory, I believe it is appropriate to go ahead and
+    # create the corresponding permission template
+    #
+    # This way, we can go ahead
+    after(:create) do |admin_set, evaluator|
+      if evaluator.with_permission_template
+        attributes = { admin_set_id: admin_set.id }
+        attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
+        # There is a unique constraint on permission_templates.admin_set_id; I don't want to
+        # create a permission template if one already exists for this admin_set
+        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(admin_set_id: admin_set.id)
+      end
+    end
+
+    transient do
+      # false, true, or Hash with keys for permission_template
+      with_permission_template false
+    end
+  end
+
+  trait :public do
+    read_groups ['public']
+  end
+end

--- a/spec/factories/permission_template_accesses.rb
+++ b/spec/factories/permission_template_accesses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+FactoryGirl.define do
+  factory :permission_template_access, class: Hyrax::PermissionTemplateAccess do
+    permission_template
+    trait :manage do
+      access 'manage'
+    end
+
+    trait :deposit do
+      access 'deposit'
+    end
+
+    trait :view do
+      access 'view'
+    end
+  end
+end

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -125,7 +125,7 @@ shared_examples 'proxy work creation' do |work_class|
   end
 end
 
-feature 'Creating a new work', :js do
+feature 'Creating a new work', :js, :workflow do
   let(:user) { create(:user) }
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
@@ -134,8 +134,11 @@ feature 'Creating a new work', :js do
   # let!(:uploaded_file2) { UploadedFile.create(file: file2, user: user) }
 
   before do
-    Hyrax::Workflow::WorkflowImporter.load_workflows
-    AdminSet.find_or_create_default_admin_set_id
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
     allow(CharacterizeJob).to receive(:perform_later)
     page.current_window.resize_to(2000, 2000)
   end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -10,8 +10,11 @@ shared_examples 'edit work' do |work_class|
   let(:work_type) { work_class.name.underscore }
   let(:edit_path) { "concern/#{work_type}s/#{work.id}/edit" }
   before do
-    Hyrax::Workflow::WorkflowImporter.load_workflows
-    AdminSet.find_or_create_default_admin_set_id
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
     page.driver.browser.js_errors = false
     sign_in user
     work.ordered_members << FactoryGirl.create(:file_set, user: user, title: ['ABC123xyz'])

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -88,14 +88,17 @@ shared_examples 'work crud' do |work|
   end
 end
 
-describe 'end to end behavior:' do
+describe 'end to end behavior:', :workflow do
   let!(:user) { FactoryGirl.create(:user) }
   let!(:persisted_work) { FactoryGirl.create(:work, user: user) }
   let!(:deleted_work) { FactoryGirl.create(:work, user: user) }
   let!(:collection) { FactoryGirl.create(:collection, user: user) }
   before do
-    Hyrax::Workflow::WorkflowImporter.load_workflows
-    AdminSet.find_or_create_default_admin_set_id
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
     login_as user
   end
   context 'the user' do

--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -5,8 +5,11 @@ describe 'Adding an infected file', js: true do
   let(:user) { FactoryGirl.create(:user) }
 
   before do
-    Hyrax::Workflow::WorkflowImporter.load_workflows
-    AdminSet.find_or_create_default_admin_set_id
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
     allow(CharacterizeJob).to receive(:perform_later)
     allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
     login_as user

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -28,8 +28,11 @@ shared_examples 'doi request' do |work_class|
 
   before do
     allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
-    Hyrax::Workflow::WorkflowImporter.load_workflows
-    AdminSet.find_or_create_default_admin_set_id
+    create(:permission_template_access,
+           :deposit,
+           permission_template: create(:permission_template, with_admin_set: true),
+           agent_type: 'user',
+           agent_id: user.user_key)
     page.driver.browser.js_errors = false
     allow(CharacterizeJob).to receive(:perform_later)
   end


### PR DESCRIPTION
Fixes #1438 

Adjust some feature specs to run properly with Hyrax's workflows and admin sets.  Gets rid of the `Couldn't find Sipity::Role` errors

Looks like this resolves close to 70 failures.