### PR TITLE
Remove deprecated raise_in_transactional_callbacks

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,9 +19,6 @@ module ScholarUc
 
     config.autoload_paths += %W(#{config.root}/app/presenters/concerns)
 
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
-
     config.exceptions_app = self.routes
 
     config.application_root_url = 'http://localhost:3000'


### PR DESCRIPTION
No issue

Removes the annoying `DEPRECATION WARNING: ActiveRecord::Base.raise_in_transactional_callbacks= is deprecated, has no effect and will be removed without replacement. ` message you see when you start to run specs.