### PR TITLE
fix change manager spec

### DIFF
--- a/app/helpers/change_manager/change_manager_helper.rb
+++ b/app/helpers/change_manager/change_manager_helper.rb
@@ -7,7 +7,7 @@ module ChangeManager
       editors.each do |editor_wrapper|
         editor = editor_wrapper[1]
         if new_editor? editor
-          EmailManager.queue_change(curation_concern.depositor, 'added_as_editor', curation_concern.id, editor[:name])
+          EmailManager.queue_change(curation_concern.depositor, 'added_as_editor', curation_concern.id, editor['name'])
         end
         # uncomment this once the `Ldp::Gone` error is resolved
         # elsif removed_editor? editor

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_job.queue_adapter = :inline
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,4 +84,6 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,4 +40,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_job.queue_adapter = :inline
 end


### PR DESCRIPTION
Fixes #1444 

The change manager spec was failing as we now have to explicitly define the queue adapter for each environment.