### PR TITLE
Fix featured work thumbnail size

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -194,7 +194,11 @@ label[for=user_password] {
 
   .featured-thumb {
     width: 210px;
-    height: 210px;
+  }
+
+  .home-content img {
+    max-width: 100%;
+    height: 100%;
   }
 
 }


### PR DESCRIPTION
Fixes #1449 

Featured work thumbnail no longer bleeds over text vertically.