### PR TITLE
Route non-signed in users to classify concern landing page after login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,27 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+  before_action :store_current_location, unless: :devise_controller?
+
+  private
+
+    # override devise helper and route to CC.new when parameter is set
+    def after_sign_in_path_for(_resource)
+      return root_path unless parameter_set?
+      route_to_classify_concerns_path
+    end
+
+    # store paramater in request
+    def store_current_location
+      store_location_for(:user, request.url)
+    end
+
+    def parameter_set?
+      return false if session['user_return_to'].nil?
+      session['user_return_to'].include? '/classify_concerns/new'
+    end
+
+    def route_to_classify_concerns_path
+      session['user_return_to']
+    end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -6,6 +6,22 @@ RSpec.describe 'the homepage', type: :feature do
     visit root_path
   end
 
+  context 'when a user who is not logged in clicks the contribute button' do
+    let(:user) { FactoryGirl.create :user }
+    before do
+      visit root_path
+    end
+    it 'redirects the user to the new work landing page after sign in' do
+      click_on 'contribute'
+      within '.new_user' do
+        fill_in('Email', with: user.email)
+        fill_in('Password', with: user.password)
+        click_on('Log in')
+      end
+      expect(page).to have_current_path classify_concern_path_with_locale
+    end
+  end
+
   it 'renders the site title' do
     expect(page).to have_css('img[alt="scholar@uc"]')
   end
@@ -70,5 +86,9 @@ RSpec.describe 'the homepage', type: :feature do
     expect(page).to have_link(href: 'http://research.uc.edu')
     expect(page).to have_link(href: 'http://ucit.uc.edu')
     expect(page).to have_link(href: 'http://projecthydra.org')
+  end
+
+  def classify_concern_path_with_locale
+    new_classify_concern_path + '?locale=en'
   end
 end


### PR DESCRIPTION
Fixes #1455 

Present short summary (50 characters or less)

As in the issue description, this routes users that haven't logged in to the classify concerns page after sign in only when a user accesses it via. the contribute button on the home page

This overrides a devise method in a standard way as described in https://github.com/plataformatec/devise/wiki/how-to:-redirect-back-to-current-page-after-sign-in,-sign-out,-sign-up,-update

This PR adds a POST parameter to the request object to track which route the user had come from before.