### PR TITLE
Fix undefined work_type in specs

### DIFF
--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -21,7 +21,7 @@ describe 'Adding an infected file', js: true do
       expect(page).to have_content "Add files"
       attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
       click_link "Metadata" # switch tab
-      title_element = find_by_id("#{work_type}_title")
+      title_element = find_by_id("generic_work_title")
       title_element.set("My Test Work")
       fill_in('Creator', with: 'Test User')
       college_element = find_by_id("generic_work_college")

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -60,7 +60,7 @@ shared_examples 'doi request' do |work_class|
       click_link "Files" # switch tab
       attach_file("files[]", Rails.root + "spec/fixtures/world.png", visible: false)
       click_link "Metadata" # switch tab
-      title_element = find_by_id("#{work_type}_title")
+      title_element = find_by_id("#{work_label}_title")
       title_element.set("My Test Work")
       creator_element = find(:css, "input.#{work_label}_creator")
       creator_element.set("Test User")


### PR DESCRIPTION
This doesn't fully resolve any failures, but it gets rid of the `undefined local variable or method `work_type'` error in virus_scan_spec and doi_request_spec.  

This changes the error to the same as #1488 like in our other feature specs.