### PR TITLE
Fix abilities spec

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -35,8 +35,8 @@ class Ability
   private
 
     # remove create ability for Etd's from all users
-    def hyrax_models
-      default_hyrax = Hyrax.config.hyrax
+    def curation_concerns_models
+      default_hyrax = Hyrax.config.curation_concerns
       default_hyrax.delete(Etd)
       [::FileSet, ::Collection] + default_hyrax
     end


### PR DESCRIPTION
Fixes #1506

Resolves `spec/models/hyrax/ability_spec.rb:32`

This was failing because the private method `curation_concerns_models` in app/models/ability.rb was broken by the global curation_concerns -> hyrax find and replace.