### PR TITLE
Fix active_workflow error in specs

### DIFF
--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -13,6 +13,7 @@ shared_examples 'work creation' do |work_class| # apply underscore for snake cas
     expect(page).to have_content "Browse cloud files" # with browse-everything enabled
     # expect(page).to have_content "Add folder"  -- only works in Chrome
     attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/image.jp2", visible: false)
+    sleep(5)
     attach_file("files[]", File.dirname(__FILE__) + "/../../spec/fixtures/jp2_fits.xml", visible: false)
     click_link "Metadata" # switch tab
     # checking for work creator auto-fill and also filling it in
@@ -130,6 +131,7 @@ end
 
 feature 'Creating a new work', :js, :workflow do
   let(:user) { create(:user) }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   # Don't bother making these, until we unskip tests
@@ -137,17 +139,13 @@ feature 'Creating a new work', :js, :workflow do
   # let!(:uploaded_file2) { UploadedFile.create(file: file2, user: user) }
 
   before do
-    create(:permission_template_access,
-           :deposit,
-           permission_template: create(:permission_template, with_admin_set: true),
-           agent_type: 'user',
-           agent_id: user.user_key)
     allow(CharacterizeJob).to receive(:perform_later)
     page.current_window.resize_to(2000, 2000)
   end
 
   context "when the user is not a proxy", :js do
     before do
+      page.driver.browser.js_errors = false
       allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
       sign_in user
     end

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-shared_examples 'edit work' do |work_class|
+shared_examples 'edit work', :workflow do |work_class|
   let(:user) { FactoryGirl.create(:user, first_name: 'John', last_name: 'Doe') }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
   let(:work) { FactoryGirl.build(
     :work, user: user, creator: ['User, Different'],
            alt_description: 'test', college: "Business", department: "Marketing"
@@ -10,11 +11,6 @@ shared_examples 'edit work' do |work_class|
   let(:work_type) { work_class.name.underscore }
   let(:edit_path) { "concern/#{work_type}s/#{work.id}/edit" }
   before do
-    create(:permission_template_access,
-           :deposit,
-           permission_template: create(:permission_template, with_admin_set: true),
-           agent_type: 'user',
-           agent_id: user.user_key)
     page.driver.browser.js_errors = false
     sign_in user
     work.ordered_members << FactoryGirl.create(:file_set, user: user, title: ['ABC123xyz'])

--- a/spec/features/end_to_end_spec.rb
+++ b/spec/features/end_to_end_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 
 shared_examples 'work crud' do |work|
   let(:work_type) { work.name.underscore }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
 
   before { allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true) }
 
@@ -88,17 +89,13 @@ shared_examples 'work crud' do |work|
   end
 end
 
-describe 'end to end behavior:', :workflow do
+describe 'end to end behavior:', :workflow, :js do
   let!(:user) { FactoryGirl.create(:user) }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
   let!(:persisted_work) { FactoryGirl.create(:work, user: user) }
   let!(:deleted_work) { FactoryGirl.create(:work, user: user) }
   let!(:collection) { FactoryGirl.create(:collection, user: user) }
   before do
-    create(:permission_template_access,
-           :deposit,
-           permission_template: create(:permission_template, with_admin_set: true),
-           agent_type: 'user',
-           agent_id: user.user_key)
     login_as user
   end
   context 'the user' do

--- a/spec/features/virus_scan_spec.rb
+++ b/spec/features/virus_scan_spec.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'Adding an infected file', js: true do
+describe 'Adding an infected file', :workflow, js: true do
   let(:user) { FactoryGirl.create(:user) }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
 
   before do
-    create(:permission_template_access,
-           :deposit,
-           permission_template: create(:permission_template, with_admin_set: true),
-           agent_type: 'user',
-           agent_id: user.user_key)
+    page.driver.browser.js_errors = false
     allow(CharacterizeJob).to receive(:perform_later)
     allow(Hydra::Works::VirusCheckerService).to receive(:file_has_virus?).and_return(true)
     login_as user

--- a/spec/support/shared/doi_request.rb
+++ b/spec/support/shared/doi_request.rb
@@ -2,6 +2,7 @@
 
 shared_examples 'doi request' do |work_class|
   let(:user) { create(:user) }
+  let!(:role1) { Sipity::Role.create(name: 'depositing') }
   let(:work_without_doi) do
     create("#{work_class.to_s.underscore}_with_one_file".to_sym,
            title: ["Magnificent splendor"],
@@ -28,11 +29,6 @@ shared_examples 'doi request' do |work_class|
 
   before do
     allow_any_instance_of(Ability).to receive(:user_is_etd_manager).and_return(true)
-    create(:permission_template_access,
-           :deposit,
-           permission_template: create(:permission_template, with_admin_set: true),
-           agent_type: 'user',
-           agent_id: user.user_key)
     page.driver.browser.js_errors = false
     allow(CharacterizeJob).to receive(:perform_later)
   end


### PR DESCRIPTION
Fixes #1488 
Fixes #1501 
Fixes #1500 

Resolves the `does not have an active_workflow` error we were seeing across many of the feature specs.  All tests in doi_request_spec and create_work_spec should now be passing.  There are new errors in virus_scan_spec and end_to_end_spec that need to be resolved.