### PR TITLE
Replace sufia.rb with hydrax.rb in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ config/authentication.yml
 config/blacklight.yml
 config/initializers/devise.rb
 config/initializers/scholar_uc.rb
-config/initializers/sufia.rb
+config/initializers/hyrax.rb


### PR DESCRIPTION
No issue

Git should be ignoring `config/initializers/hyrax.rb` instead of `config/initializers/hyrax.rb` now that we are on Hyrax.  

(We only track `config/initializers/hyrax.rb.sample` in Git.  The `config/initializers/hyrax.rb` file is created by the copy_config_local script.)