### PR TITLE
Adds dashboard layouts to dashboard controllers.

### DIFF
--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Hyrax
+  class DashboardController < ApplicationController
+    include Hyrax::DashboardControllerBehavior
+
+    layout 'dashboard'
+  end
+end

--- a/app/controllers/hyrax/my_controller.rb
+++ b/app/controllers/hyrax/my_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Hyrax::MyController < ApplicationController
+  include Hyrax::MyControllerBehavior
+
+  layout 'dashboard'
+end

--- a/spec/features/browse_dashboard_files_spec.rb
+++ b/spec/features/browse_dashboard_files_spec.rb
@@ -39,7 +39,7 @@ describe "Browse Dashboard", type: :feature do
 
     within("#document_#{mp3_work.id}") do
       expect(page).to have_link("Display all details of Test Document MP3",
-                                href: hyrax_generic_work_path(mp3_work))
+                                href: "#{hyrax_generic_work_path(mp3_work)}?locale=en")
     end
     click_link("Remove constraint Subject: consectetur")
 


### PR DESCRIPTION
Fixes #1497

Present short summary (50 characters or less)

Adds Dashboard layout to my_controller and dashboard_controller to allow sidebar to display properly.  

Adjusted Dashboard test to account for locales=en in href.
