### PR TITLE
Use MySQL for database in server environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem 'change_manager', git: "https://github.com/lawhorkl/change_manager.git", ref
 
 # gem 'clamav'
 
+gem 'mysql2'
+
 group :development, :test do
   gem 'brakeman', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mysql2 (0.4.6)
     nest (2.1.0)
       redic
     netrc (0.11.0)
@@ -833,6 +834,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   kaltura (= 0.1.1)
+  mysql2
   orcid!
   poltergeist
   rails (= 5.0.3)

--- a/config/database.yml.bamboo
+++ b/config/database.yml.bamboo
@@ -29,25 +29,14 @@ local_user: &local_user
   username: curate
   password: bamboo_mysql_password
 
-default: &default
-  adapter: sqlite3
-  pool: 5
+development:
+  <<: *local_user
+  database: curate
+  host: bamboo_mysql_host
   timeout: 5000
 
-development:
-  <<: *default
-  database: curate
-  host: bamboo_mysql_host
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: curate
-  host: bamboo_mysql_host
-
 production:
-  <<: *default
+  <<: *local_user
   database: curate
   host: bamboo_mysql_host
+  timeout: 5000


### PR DESCRIPTION
Part of #954 

This gets Scholar working properly with MySQL as the database in our server environments.

There isn't an easy way to test this in your local environment, but I have tested it on scholar-dev and it works.