### PR TITLE
Omit locales in permalinks

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -17,7 +17,7 @@ module Hyrax
       presenter
       query_collection_members
       @collection_avatar = fetch_collection_avatar
-      @permalinks_presenter = PermalinksPresenter.new(collection_path)
+      @permalinks_presenter = PermalinksPresenter.new(collection_path(locale: nil))
     end
 
     def edit

--- a/app/controllers/concerns/scholar/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholar/works_controller_behavior.rb
@@ -36,7 +36,7 @@ module Scholar
     def show
       super
       permalink_message = "Permanent link to this page"
-      @permalinks_presenter = PermalinksPresenter.new(main_app.common_object_path, permalink_message)
+      @permalinks_presenter = PermalinksPresenter.new(main_app.common_object_path(locale: nil), permalink_message)
     end
 
     private

--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -5,7 +5,7 @@ module Hyrax
 
     def show
       @presenter = Hyrax::UserProfilePresenter.new(@user, current_ability)
-      @permalinks_presenter = PermalinksPresenter.new(hyrax.profile_path)
+      @permalinks_presenter = PermalinksPresenter.new(hyrax.profile_path(locale: nil))
     end
 
     def search(query)

--- a/spec/features/permalinks_spec.rb
+++ b/spec/features/permalinks_spec.rb
@@ -49,6 +49,10 @@ describe 'permalinks' do
     it "displays a link to the collection" do
       expect(page).to have_content "Link to this page: http://my.url/collections/#{collection.id}"
     end
+
+    it "excludes locales from the permalink" do
+      expect(page).to have_no_content "?locale=en"
+    end
   end
 
   describe 'user profiles' do


### PR DESCRIPTION
Fixes #1536  

Omit locale in permalinks: set to `locale: nil` in permalinks presenter call. All other URLs unaffected.

