### PR TITLE
Stops DOI/publisher notice from duplicating

### DIFF
--- a/app/assets/javascripts/toggle_publisher_requirement.js
+++ b/app/assets/javascripts/toggle_publisher_requirement.js
@@ -14,7 +14,7 @@ var togglePublisherRequirement = function() {
         var field = $('input[class*=publisher]').first();
 
         // if the notice isn't there, and the publisher is blank, we need to add it
-        if ( ($('#publisher-warning').length == 0) && (field.val() == "") ) {
+        if ( ($('#publisher-label').length == 0) && (field.val() == "") ) {
           return true;
         } else {
           return false;


### PR DESCRIPTION
Fixes #1467 Closes #1467

Switching back and forth between radio buttons on the DOI form would cause duplicated error notices. Now it doesn't