### PR TITLE
Update form_visibility partial for Hyrax

### DIFF
--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -9,37 +9,28 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, data: { 'target': '#collapsePublic' }  %>
-            <%= t('hyrax.visibility.open.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
             <div class="collapse" id="collapsePublic">
-              <p>
-                <strong>Please note</strong>, making something visible to the world (i.e.
-                marking this as <%= t('hyrax.visibility.open.label_html') %>) may be
-                viewed as publishing which could impact your ability to:
-              </p>
-              <ul>
-                <li>Patent your work</li>
-                <li>Publish your work in a journal</li>
-              </ul>
-              <p>
-                Check out <a href="http://www.sherpa.ac.uk/romeo/">SHERPA/RoMEO</a> for more
-                information about publisher copyright policies.
-              </p>
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
             </div>
           </label>
         </li>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
-            <%= t('hyrax.visibility.authenticated.label_html', institution: t('hyrax.institution.name')) %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+            <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
           </label>
         </li>
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, data: { 'target': '#collapseEmbargo' } %>
-            <%= t('hyrax.visibility.embargo.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
             <div class="collapse" id="collapseEmbargo">
               <div class="form-inline">
                 <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
                 <%= f.date_field :embargo_release_date, wrapper: :inline, value: f.object.embargo_release_date || Date.tomorrow, class: 'datepicker form-control' %>
                 <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
               </div>
@@ -49,7 +40,8 @@
         <li class="radio">
           <label>
             <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
-            <%= t('hyrax.visibility.private.label_html') %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+            <%= t('hyrax.visibility.private.note_html') %>
           </label>
         </li>
       </ul>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -61,7 +61,7 @@ en:
       open:
         text: "Public"
       authenticated:
-        label_html: 'University of Cincinnati'
+        text: 'University of Cincinnati'
     welcome:
       waive_page: "Click here to hide this welcome page from displaying when you log in"
     works:

--- a/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
@@ -25,4 +25,20 @@ describe '/hyrax/base/_form_visibility_component.html.erb', type: :view do
   it 'does not have a Lease option for visibility' do
     expect(rendered).not_to have_selector('div#collapseLease')
   end
+
+  it 'has text for open visibility' do
+    expect(rendered).to have_text(t('hyrax.visibility.open.text'))
+  end
+
+  it 'has text for authenticated visibility' do
+    expect(rendered).to have_text(t('hyrax.visibility.authenticated.text'))
+  end
+
+  it 'has text for embargo visibility' do
+    expect(rendered).to have_text(t('hyrax.visibility.embargo.text'))
+  end
+
+  it 'has text for private visibility' do
+    expect(rendered).to have_text(t('hyrax.visibility.private.text'))
+  end
 end


### PR DESCRIPTION
Fixes #1544 

This bug was a result of an outdated override in app/views/hyrax/base/_form_visibility_component.html.erb.  Hyrax updated that partial to use the green/blue/yellow/red visibility badges, but our override didn't get updated during the Hyrax migration.

So this fixes the visibility text and the colored badges now show up too.