### PR TITLE
Add scripts for managing Sidekiq, Embargos, and logs

### DIFF
--- a/script/check_sidekiq_running.sh
+++ b/script/check_sidekiq_running.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Kill the Sidekiq process (if it exists) and restart it
+# script/check_sidekiq_running.sh [production|development]
+
+RECIPIENTS="scholar@uc.edu"
+HOSTNAME=$(hostname -s)
+ENVIRONMENT=$1
+APP_DIRECTORY="/srv/apps/curate_uc"
+
+function banner {
+  echo -e "$0 ↠ $1"
+}
+
+if [ $# -eq 0 ]; then
+  echo -e "ERROR: no environment argument [production|development] provided"
+  exit 1
+fi
+
+if [ $ENVIRONMENT != "production" ] && [ $ENVIRONMENT != "development" ]; then
+  echo -e "ERROR: environment argument must be either [production|development] most likely this will be development for local machines and production otherwise"
+  exit 1
+fi
+
+process_pid=`ps aux | grep sidekiq | grep busy | grep -v grep | awk '{print $2}'`
+
+if [ ${#process_pid} -gt 0 ]
+  then
+    sleep 1;
+  else
+    echo "Hydra server $HOSTNAME did not have Sidekiq running.  Sidekiq has been automatically restarted and will be checked again in one hour." > /tmp/sidekiqalert
+    sleep 1
+    mail -s "Sidekiq restarted on $1" $RECIPIENTS < /tmp/sidekiqalert
+    $APP_DIRECTORY/script/restart_sidekiq.sh $1
+fi

--- a/script/kill_sidekiq.sh
+++ b/script/kill_sidekiq.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Kill the Sidekiq process if it exists
+
+function banner {
+  echo -e "$0 ↠ $1"
+}
+
+process_pid=`ps aux | grep sidekiq | grep busy | grep -v grep | awk '{print $2}'`
+
+if [ ${#process_pid} -gt 0 ]
+then
+  banner "killing Sidekiq"
+  kill $process_pid
+  sleep 5
+fi

--- a/script/release_embargo.sh
+++ b/script/release_embargo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Change and expired embargoed objects to open access
+# Runs as a cron job daily just after midnight
+
+cd /srv/apps/curate_uc
+bundle exec rake embargo_manager:release

--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Kill the Sidekiq process (if it exists) and restart it
+# script/restart_sidekiq.sh [production|development]
+
+ENVIRONMENT=$1
+APP_DIRECTORY="/srv/apps/curate_uc"
+
+function banner {
+    echo -e "$0 ↠ $1"
+}
+
+if [ $# -eq 0 ]; then
+    echo -e "ERROR: no environment argument [production|development] provided"
+    exit 1
+fi
+
+if [ $ENVIRONMENT != "production" ] && [ $ENVIRONMENT != "development" ]; then
+    echo -e "ERROR: environment argument must be either [production|development] most likely this will be development for local machines and production otherwise"
+    exit 1
+fi
+
+$APP_DIRECTORY/script/kill_sidekiq.sh
+
+banner "starting Sidekiq"
+export PATH=$PATH:/srv/apps/.gem/ruby/2.4.0/bin
+cd $APP_DIRECTORY
+bundle exec sidekiq -d -q ingest -q default -q event -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT

--- a/script/rotate_log.sh
+++ b/script/rotate_log.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Move the logs file to a new directory so it isn't lost during deploy
+
+file_name=/srv/apps/curate_uc/log/production.log
+current_time=$(date "+%Y.%m.%d-%H.%M.%S")
+new_fileName=/srv/apps/curate_uc-logs/production.log.$current_time
+
+if [ -f $file_name ];
+then
+
+  # Move the log file to a new directory and add timestamp
+  mv $file_name $new_fileName
+
+  # Compress the moved log file
+  gzip $new_fileName
+
+fi
+
+# Restart the app and generate a blank log file
+touch /srv/apps/curate_uc/tmp/restart.txt


### PR DESCRIPTION
Fixes #1061 

Migrates rotate_log.sh and release_embargo.sh from Scholar 2.x

Creates new scripts for managing Sidekiq (like our Resque scripts in 2.x)
* check_sidekiq_running.sh 
* kill_sidekiq.sh
* restart_sidekiq.sh

I can work with the reviewer to help test this PR.
