### PR TITLE
Add Shibboleth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ config/blacklight.yml
 config/initializers/devise.rb
 config/initializers/scholar_uc.rb
 config/initializers/hyrax.rb
+config/authentication.yml

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -96,3 +96,7 @@ RSpec/AnyInstance:
 RSpec/ImplicitExpect:
   Exclude:
     - 'spec/**/*'
+
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/controllers/callbacks_controller_spec.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
   - "cp config/solr.yml.sample config/solr.yml"
   - "cp config/initializers/hyrax.rb.sample config/initializers/hyrax.rb"
   - "cp config/initializers/devise.rb.sample config/initializers/devise.rb"
+  - "cp config/authentication.yml.sample config/authentication.yml"
 
 notifications:
   slack: uc-libraries-digital:7gc9gvfCKedkWXORxCo5Hndx

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem 'hydra-remote_identifier', github: 'uclibs/hydra-remote_identifier', branch:
 gem 'browse-everything', git: 'https://github.com/uclibs/browse-everything.git', ref: 'be25819f14d485768698d27a3a35deaa7f60d5c7'
 gem 'kaltura', '0.1.1'
 
+# Shibboleth
+gem 'omniauth-openid'
+gem 'omniauth-shibboleth'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.0.3'
 # Use sqlite3 as the database for Active Record
@@ -93,6 +97,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'poltergeist'
   gem 'shoulda-matchers', '~> 3.1.1'
+  gem 'show_me_the_cookies'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,9 +536,14 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    omniauth-openid (1.0.1)
+      omniauth (~> 1.0)
+      rack-openid (~> 1.3.1)
     omniauth-orcid (0.6)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
+    omniauth-shibboleth (1.2.1)
+      omniauth (>= 1.0.0)
     openseadragon (0.3.3)
       rails (> 3.2.0)
     orm_adapter (0.5.0)
@@ -561,6 +566,9 @@ GEM
       rails (>= 4.2.0, < 6.0)
       rdf
     rack (2.0.3)
+    rack-openid (1.3.1)
+      rack (>= 1.1.0)
+      ruby-openid (>= 2.1.8)
     rack-protection (2.0.0)
       rack
     rack-test (0.6.3)
@@ -684,6 +692,7 @@ GEM
       json
       multipart-post
       oauth2
+    ruby-openid (2.7.0)
     ruby-progressbar (1.8.1)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
@@ -704,6 +713,8 @@ GEM
       rubyzip (~> 1.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    show_me_the_cookies (3.1.0)
+      capybara (~> 2.0)
     sidekiq (5.0.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -835,6 +846,8 @@ DEPENDENCIES
   jquery-rails
   kaltura (= 0.1.1)
   mysql2
+  omniauth-openid
+  omniauth-shibboleth
   orcid!
   poltergeist
   rails (= 5.0.3)
@@ -851,6 +864,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   selenium-webdriver
   shoulda-matchers (~> 3.1.1)
+  show_me_the_cookies
   sidekiq
   solr_wrapper (>= 0.13)
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,17 @@ class ApplicationController < ActionController::Base
 
     # override devise helper and route to CC.new when parameter is set
     def after_sign_in_path_for(_resource)
+      cookies[:login_type] = "local"
       return root_path unless parameter_set?
       route_to_classify_concerns_path
+    end
+
+    def after_sign_out_path_for(_resource_or_scope)
+      if cookies[:login_type] == "shibboleth"
+        "/Shibboleth.sso/Logout?return=https%3A%2F%2Fbamboo_shibboleth_logout"
+      else
+        root_path
+      end
     end
 
     # store paramater in request

--- a/app/controllers/callbacks_controller.rb
+++ b/app/controllers/callbacks_controller.rb
@@ -5,4 +5,90 @@ class CallbacksController < Devise::OmniauthCallbacksController
     Devise::MultiAuth.capture_successful_external_authentication(current_user, omni)
     redirect_to root_path, notice: "You have successfully connected with your ORCID record"
   end
+
+  def shibboleth
+    if current_user
+      redirect_to landing_page
+    else
+      retrieve_shibboleth_attributes
+      create_or_update_user
+      sign_in_shibboleth_user
+    end
+  end
+
+  private
+
+    def retrieve_shibboleth_attributes
+      @omni = request.env["omniauth.auth"]
+      @email = use_uid_if_email_is_blank
+    end
+
+    def create_or_update_user
+      if user_exists?
+        update_shibboleth_attributes if user_has_never_logged_in?
+      else
+        create_user
+        send_welcome_email
+      end
+    end
+
+    def sign_in_shibboleth_user
+      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      cookies[:login_type] = "shibboleth"
+      flash[:notice] = "You are now signed in as #{@user.name} (#{@user.email})"
+    end
+
+    def use_uid_if_email_is_blank
+      # If user has no email address use their sixplus2@uc.edu instead
+      # Some test accounts on QA/dev don't have email addresses
+      @email = if defined?(@omni.extra.raw_info.mail)
+                 if @omni.extra.raw_info.mail.blank?
+                   @omni.uid
+                 else
+                   @omni.extra.raw_info.mail
+                 end
+               else
+                 @omni.uid
+               end
+    end
+
+    def user_exists?
+      @user = find_by_provider_and_uid
+      return true unless @user.nil?
+    end
+
+    def find_by_provider_and_uid
+      User.where(provider: @omni['provider'], uid: @omni['uid']).first
+    end
+
+    def update_shibboleth_attributes
+      update_user_shibboleth_attributes
+    end
+
+    def user_has_never_logged_in?
+      @user.sign_in_count.zero?
+    end
+
+    def create_user
+      @user = User.create provider: @omni.provider,
+                          uid: @omni.uid,
+                          email: @email,
+                          password: Devise.friendly_token[0, 20],
+                          profile_update_not_required: false
+      update_user_shibboleth_attributes
+    end
+
+    def update_user_shibboleth_attributes
+      @user.title              = @omni.extra.raw_info.title
+      @user.telephone          = @omni.extra.raw_info.telephoneNumber
+      @user.first_name         = @omni.extra.raw_info.givenName
+      @user.last_name          = @omni.extra.raw_info.sn
+      @user.uc_affiliation     = @omni.extra.raw_info.uceduPrimaryAffiliation
+      @user.ucdepartment       = @omni.extra.raw_info.ou
+      @user.save
+    end
+
+    def send_welcome_email
+      WelcomeMailer.welcome_email(@user).deliver
+    end
 end

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require Devise::Engine.root.join('app/controllers/devise/passwords_controller.rb')
+class Devise::PasswordsController
+  # POST /resource/password
+  def create
+    if resource_params['email'].end_with? '@uc.edu'
+      redirect_to login_path
+      flash[:notice] = "You cannot reset passwords for @uc.edu accounts.  Use your UC Central Login instead."
+    else
+      self.resource = resource_class.send_reset_password_instructions(resource_params)
+      yield resource if block_given?
+
+      if successfully_sent?(resource)
+        respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+      else
+        respond_with(resource)
+      end
+    end
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -48,4 +48,14 @@ class StaticController < ApplicationController
   def doi_help
     render "static/doi_help"
   end
+
+  def login
+    if current_user
+      redirect_to landing_page
+    elsif AUTH_CONFIG['shibboleth_enabled']
+      render "static/login"
+    else
+      redirect_to new_user_session_path
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:orcid]
+         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:orcid, :shibboleth]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,32 @@
+<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+    <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+    <% if user_signed_in? %>
+    <li>
+      <%= link_to hyrax.notifications_path do %>
+        <%= t("hyrax.toolbar.notifications") %>
+        <%= render 'hyrax/users/notify_number' %>
+      <% end %>
+    </li>
+    <li class="dropdown">
+      <%= link_to hyrax.profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t("hyrax.toolbar.profile.view"), hyrax.profile_path(current_user) %></li>
+        <li><%= link_to t("hyrax.toolbar.profile.edit"), hyrax.edit_profile_path(current_user) %></li>
+        <li class="divider"></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+      </ul>
+    </li><!-- /.btn-group -->
+  <% else %>
+    <li>
+      <%= link_to main_app.login_path do %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > <%= t("hyrax.toolbar.profile.login") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,0 +1,17 @@
+<h2>Forgot your password?</h2>
+
+<p>Note: If you have a <strong>uc.edu</strong> email address, do <strong>not</strong> use this form to reset your password. Use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= devise_error_messages! %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="actions">
+    <p><%= f.submit "Send me reset password instructions" %></p>
+  </div>
+<% end %>
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,31 @@
+<h2>Sign up</h2>
+
+<% if AUTH_CONFIG['signups_enabled'] %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= devise_error_messages! %>
+
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password %>
+      <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %><br />
+      <%= f.password_field :password, autocomplete: "off" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    </div>
+
+    <div class="actions">
+      <%= f.submit "Sign up" %>
+    </div>
+  <% end %>
+<% else %>
+  <p>To request an account, <a href="/contact">use the contact page</a>.</p> 
+<% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,34 @@
+<h2>Local Account Log in</h2>
+
+<% if AUTH_CONFIG['shibboleth_enabled'] %>
+  <p>Note: If you are affiliated with UC, use the <a href="/users/auth/shibboleth">Central Login form</a> instead.</p>
+<% end %>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "off" %>
+  </div>
+
+  <% if devise_mapping.rememberable? -%>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end -%>
+
+  <div class="actions">
+    <p><%= f.submit "Log in" %></p>
+  </div>
+<% end %>
+
+<% if AUTH_CONFIG['signups_enabled'] %>
+  <a href="/users/sign_up">Sign up</a><br />
+<% end %>
+
+<p><a href="/users/password/new">Reset/Forgot your password?</a></p>

--- a/app/views/hyrax/users/_edit_primary.html.erb
+++ b/app/views/hyrax/users/_edit_primary.html.erb
@@ -55,14 +55,14 @@
     <div class="form-group">
       <%= f.label :ucdepartment, 'Department', class: 'col-xs-4 control-label' %>
       <div class="col-xs-8">
-         <%= f.text_field :ucdepartment, class: "form-control" %>
+         <%= f.text_field :ucdepartment, class: "form-control", readonly: true %>
       </div>
     </div><!-- .form-group -->
 
     <div class="form-group">
       <%= f.label :uc_affiliation, 'UC affiliation', class: 'col-xs-4 control-label' %>
       <div class="col-xs-8">
-         <%= f.text_field :uc_affiliation, class: "form-control" %>
+         <%= f.text_field :uc_affiliation, class: "form-control", readonly: true %>
       </div>
     </div><!-- .form-group -->
 
@@ -73,7 +73,7 @@
     <div class="form-group">
       <%= f.label :email, 'Email', class: 'col-xs-4 control-label' %>
       <div class="col-xs-8">
-         <%= f.text_field :email, class: "form-control" %>
+         <%= f.text_field :email, class: "form-control", readonly: true %>
       </div>
     </div><!-- .form-group -->
 

--- a/app/views/static/login.html.erb
+++ b/app/views/static/login.html.erb
@@ -1,0 +1,12 @@
+<h2>Log In</h2>
+
+<div id="central-login">
+  <p>If you have a <a href="https://www.uc.edu/distance/Student_Orientation/One_Stop_Student_Resources/central-log-in-.html">UC Central Login username</a>, you can use it to log in to Scholar@UC.</p>
+  <p><%= link_to 'Log in using your UC Central Login', '/users/auth/shibboleth', class: 'btn btn-primary', style: 'font-size: larger' %></p>
+</div>
+
+<div id="local-login">
+  &nbsp;<br />
+  <h3>Other Users</h3>
+  <p>If you're not affiliated with UC, but have been given an account for Scholar@UC, you can <strong><%= link_to 'log in using a local account', new_user_session_path %></strong>.  To request an account, <a href="/contact">use the contact page</a>.</p>
+</div>

--- a/config/authentication.yml.bamboo
+++ b/config/authentication.yml.bamboo
@@ -1,0 +1,11 @@
+development:
+  shibboleth_enabled: true
+  signups_enabled:    true
+
+test:
+  shibboleth_enabled: true
+  signups_enabled:    false
+
+production:
+  shibboleth_enabled: true
+  signups_enabled:    false

--- a/config/authentication.yml.sample
+++ b/config/authentication.yml.sample
@@ -1,0 +1,11 @@
+development:
+  shibboleth_enabled: false
+  signups_enabled:    true
+
+test:
+  shibboleth_enabled: true
+  signups_enabled:    false
+
+production:
+  shibboleth_enabled: false
+  signups_enabled:    true

--- a/config/initializers/authentication_config.rb
+++ b/config/initializers/authentication_config.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+AUTH_CONFIG = YAML.load_file(Rails.root.join('config', 'authentication.yml'))[Rails.env]

--- a/config/initializers/devise.rb.bamboo
+++ b/config/initializers/devise.rb.bamboo
@@ -12,6 +12,35 @@ Devise.setup do |config|
                     token_url: Orcid.provider.token_url
                   })
 
+  config.omniauth :shibboleth, {
+      :shib_session_id_field => "Shib-Session-ID",
+      :shib_application_id_field => "Shib-Application-ID",
+      :uid_field => "eppn",
+      :name_field=> "displayName",
+      :debug => false,
+      :extra_fields => [
+        :cn,
+        :eppn,
+        :givenName,
+        :ou,
+        :'persistent-id',
+        :sn,
+        :street,
+        :title,
+        :uceduAffiliation,
+        :uceduPrimaryAffiliation,
+        :uceduUCID,
+        :mail,
+        :affiliation,
+        :remoteuser,
+        :telephoneNumber,
+        :uceduAcademicProgram,
+        :uceduFERPACode,
+        :uceduPrimaryCollege,
+        :uceduSISPersonID,
+      ]
+    }
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/initializers/devise.rb.sample
+++ b/config/initializers/devise.rb.sample
@@ -12,6 +12,35 @@ Devise.setup do |config|
                     token_url: Orcid.provider.token_url
                   })
 
+  config.omniauth :shibboleth, {
+      :shib_session_id_field => "Shib-Session-ID",
+      :shib_application_id_field => "Shib-Application-ID",
+      :uid_field => "eppn",
+      :name_field=> "displayName",
+      :debug => false,
+      :extra_fields => [
+        :cn,
+        :eppn,
+        :givenName,
+        :ou,
+        :'persistent-id',
+        :sn,
+        :street,
+        :title,
+        :uceduAffiliation,
+        :uceduPrimaryAffiliation,
+        :uceduUCID,
+        :mail,
+        :affiliation,
+        :remoteuser,
+        :telephoneNumber,
+        :uceduAcademicProgram,
+        :uceduFERPACode,
+        :uceduPrimaryCollege,
+        :uceduSISPersonID,
+      ]
+    }
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
   get 'advisor_guidelines' => 'static#advisor_guidelines'
   get 'student_instructions' => 'static#student_instructions'
   get 'doi_help' => 'static#doi_help'
+  get 'login' => 'static#login'
 
   # route for custom error pages issue #1056
   match '/404', to: 'errors#not_found', via: :all

--- a/db/migrate/20170718204534_add_columns_to_users.rb
+++ b/db/migrate/20170718204534_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170518142744) do
+ActiveRecord::Schema.define(version: 20170718204534) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer  "user_id",       null: false
@@ -587,6 +587,8 @@ ActiveRecord::Schema.define(version: 20170518142744) do
     t.boolean  "waived_welcome_page"
     t.boolean  "profile_update_not_required"
     t.string   "ucdepartment"
+    t.string   "provider"
+    t.string   "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/script/copy_config_bamboo.sh
+++ b/script/copy_config_bamboo.sh
@@ -12,3 +12,4 @@ cp /srv/apps/curate/curate_uc-STAGE/config/initializers/hyrax.rb.bamboo /srv/app
 cp /srv/apps/curate/curate_uc-STAGE/config/initializers/devise.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/initializers/devise.rb
 cp /srv/apps/curate/curate_uc-STAGE/config/environments/development.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/environments/development.rb
 cp /srv/apps/curate/curate_uc-STAGE/config/environments/production.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/environments/production.rb
+cp /srv/apps/curate/curate_uc-STAGE/config/authentication.yml.bamboo /srv/apps/curate/curate_uc-STAGE/config/authentication.yml

--- a/script/copy_config_local.sh
+++ b/script/copy_config_local.sh
@@ -12,3 +12,4 @@ cp config/initializers/hyrax.rb.sample config/initializers/hyrax.rb
 cp config/initializers/devise.rb.sample config/initializers/devise.rb
 cp config/environments/development.rb.sample config/environments/development.rb
 cp config/environments/production.rb.sample config/environments/production.rb
+cp config/authentication.yml.sample config/authentication.yml

--- a/spec/controllers/callbacks_controller_spec.rb
+++ b/spec/controllers/callbacks_controller_spec.rb
@@ -2,11 +2,11 @@
 require 'rails_helper'
 
 describe CallbacksController do
-  context 'omniauth-orcid' do
+  describe 'omniauth-orcid' do
     let(:uid) { 'sixplus2@test.com' }
     let(:provider) { :orcid }
     before do
-      @request.env["devise.mapping"] = Devise.mappings[:user] # rubocop:disable RSpec/InstanceVariable
+      @request.env["devise.mapping"] = Devise.mappings[:user]
       omniauth_hash_orcid = { "provider": "orcid",
                               "uid": "0000-0003-2012-0010",
                               "info": {
@@ -36,6 +36,110 @@ describe CallbacksController do
         expect(response).to redirect_to(root_path)
         expect(flash[:notice]).to match(/You have successfully connected with your ORCID record/)
       end
+    end
+  end
+
+  describe 'omniauth-shibboleth' do
+    let(:uid) { 'sixplus2@test.com' }
+    let(:provider) { :shibboleth }
+
+    before do
+      @request.env["devise.mapping"] = Devise.mappings[:user]
+      omniauth_hash = { provider: 'shibboleth',
+                        uid: uid,
+                        extra: {
+                          raw_info: {
+                            mail: uid,
+                            title: 'title',
+                            telephoneNumber: '123-456-7890',
+                            givenName: 'Fake',
+                            sn: 'User',
+                            uceduPrimaryAffiliation: 'staff',
+                            ou: 'department'
+                          }
+                        } }
+      OmniAuth.config.add_mock(provider, omniauth_hash)
+      request.env["omniauth.auth"] = OmniAuth.config.mock_auth[provider]
+    end
+
+    context 'with a user who is already logged in' do
+      let(:user) { FactoryGirl.create(:user) }
+      before do
+        controller.stub(:current_user).and_return(user)
+      end
+      it 'redirects to the dashboard' do
+        get provider
+        response.should redirect_to(Hyrax::Engine.routes.url_helpers.dashboard_index_path)
+      end
+    end
+
+    shared_examples 'Shibboleth login' do
+      it 'assigns the user and redirects' do
+        get provider
+        expect(flash[:notice]).to match(/You are now signed in as */)
+        expect(assigns(:user).email).to eq(email)
+        expect(response).to be_redirect
+      end
+    end
+
+    context 'with a brand new user' do
+      let(:email) { uid }
+      it_behaves_like 'Shibboleth login'
+    end
+
+    context 'with a brand new user when Shibboleth email is not defined' do
+      before do
+        omniauth_hash = { provider: 'shibboleth',
+                          uid: uid,
+                          extra: {
+                            raw_info: {
+                              title: 'title',
+                              telephoneNumber: '123-456-7890',
+                              givenName: 'Fake',
+                              sn: 'User',
+                              uceduPrimaryAffiliation: 'staff',
+                              ou: 'department'
+                            }
+                          } }
+        OmniAuth.config.add_mock(provider, omniauth_hash)
+        request.env["omniauth.auth"] = OmniAuth.config.mock_auth[provider]
+      end
+      let(:email) { uid }
+      it_behaves_like 'Shibboleth login'
+    end
+
+    context 'with a brand new user when Shibboleth email is blank' do
+      before do
+        omniauth_hash = { provider: 'shibboleth',
+                          uid: uid,
+                          extra: {
+                            raw_info: {
+                              mail: '',
+                              title: 'title',
+                              telephoneNumber: '123-456-7890',
+                              givenName: 'Fake',
+                              sn: 'User',
+                              uceduPrimaryAffiliation: 'staff',
+                              ou: 'department'
+                            }
+                          } }
+        OmniAuth.config.add_mock(provider, omniauth_hash)
+        request.env["omniauth.auth"] = OmniAuth.config.mock_auth[provider]
+      end
+      let(:email) { uid }
+      it_behaves_like 'Shibboleth login'
+    end
+
+    context 'with a registered user who has previously logged in' do
+      let!(:user) { FactoryGirl.create(:shibboleth_user, count: 1) }
+      let(:email) { user.email }
+      it_behaves_like 'Shibboleth login'
+    end
+
+    context 'with a registered user who has never logged in' do
+      let!(:user) { FactoryGirl.create(:shibboleth_user, count: 0) }
+      let(:email) { user.email }
+      it_behaves_like 'Shibboleth login'
     end
   end
 end

--- a/spec/controllers/static_controller_spec.rb
+++ b/spec/controllers/static_controller_spec.rb
@@ -88,4 +88,15 @@ describe StaticController do
       expect(response).to render_template('static/doi_help')
     end
   end
+
+  describe '#login' do
+    let(:user) { FactoryGirl.create(:user) }
+    before do
+      controller.stub(:current_user).and_return(user)
+    end
+    it 'redirects to dashboard when already logged in' do
+      get :login
+      response.should redirect_to(Hyrax::Engine.routes.url_helpers.dashboard_index_path)
+    end
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -25,6 +25,21 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :shibboleth_user, class: 'User' do
+    ignore do
+      count 1
+      person_pid nil
+    end
+    email 'sixplus2@test.com'
+    first_name 'Fake'
+    last_name 'User'
+    password '12345678'
+    password_confirmation '12345678'
+    sign_in_count { count.to_s }
+    provider 'shibboleth'
+    uid 'sixplus2@test.com'
+  end
 end
 
 class MockFile

--- a/spec/features/uc_shibboleth_spec.rb
+++ b/spec/features/uc_shibboleth_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'UC account workflow', type: :feature do
+  let(:user) { FactoryGirl.create(:user) }
+  let(:password) { FactoryGirl.attributes_for(:user).fetch(:password) }
+
+  filepath = "config/authentication.yml"
+  yaml = YAML.load_file(filepath)
+
+  describe 'overridden devise password reset page' do
+    email_address = 'fake.user@uc.edu'
+    it 'rejects password reset for @.uc.edu user' do
+      visit new_user_password_path
+      fill_in('user[email]', with: email_address)
+      click_on('Send me reset password instructions')
+      page.should have_content('You cannot reset passwords for @uc.edu accounts. Use your UC Central Login instead')
+    end
+  end
+
+  describe 'overridden devise password reset page' do
+    it 'shows a Central Login option' do
+      visit new_user_password_path
+      if yaml['test']['shibboleth_enabled'] == true
+        page.should have_content('Central Login form')
+      else
+        page.should_not have_content('Central Login form')
+      end
+    end
+
+    it 'does not display the Shared links at the bottom' do
+      visit new_user_password_path
+      expect(page).not_to have_link('Sign in', href: '/users/sign_in')
+      expect(page).not_to have_link('Sign up', href: '/users/sign_up')
+    end
+  end
+
+  describe 'overridden devise registration page' do
+    it 'shows a sign up form if signups are enabled or a request link if signups are disabled' do
+      visit new_user_registration_path
+      if yaml['test']['signups_enabled'] == true
+        page.should have_field('user[email]')
+      else
+        expect(page).to have_link('use the contact page', href: '/contact')
+      end
+    end
+  end
+
+  describe 'overridden devise sign-in page' do
+    it 'shows a shibboleth login link if shibboleth is enabled' do
+      visit new_user_session_path
+      if yaml['test']['shibboleth_enabled'] == true
+        expect(page).to have_link('Central Login form', href: '/users/auth/shibboleth')
+      else
+        expect(page).not_to have_link('Central Login form', href: '/users/auth/shibboleth')
+      end
+    end
+
+    it 'shows a signup link if signups are enabled' do
+      visit new_user_session_path
+      if yaml['test']['signups_enabled'] == true
+        page.should have_link('Sign up', new_user_registration_path)
+      else
+        page.should_not have_link('Sign up', new_user_registration_path)
+      end
+    end
+  end
+
+  describe 'shibboleth login page' do
+    it 'shows a shibboleth login link and local login link if shibboleth is enabled' do
+      visit login_path
+      if yaml['test']['shibboleth_enabled'] == true
+        expect(page).to have_link('UC Central Login username', href: 'https://www.uc.edu/distance/Student_Orientation/One_Stop_Student_Resources/central-log-in-.html')
+        expect(page).to have_link('log in using a local account', new_user_session_path)
+      else
+        page.should have_field('user[email]')
+      end
+    end
+  end
+
+  describe 'overridden form profile form attributes page' do
+    it 'shows read only form fields' do
+      login_as(user)
+      user.provider = 'shibboleth'
+      visit hyrax.edit_profile_path(user)
+      if yaml['test']['shibboleth_enabled'] == true
+        page.should have_field("user[ucdepartment]")
+        page.should have_field("user[uc_affiliation]")
+      else
+        page.should_not have_field("ucdepartment")
+        page.should_not have_field("uc_affiliation")
+      end
+    end
+  end
+
+  describe 'shibboleth password management' do
+    it 'hides the password change fields for shibboleth users' do
+      login_as(user)
+      user.provider = 'shibboleth'
+      visit hyrax.edit_profile_path(user)
+      page.should_not have_field("user[password]")
+      page.should_not have_field("user[password_confirmation]")
+    end
+  end
+
+  describe 'home page login button' do
+    it 'shows the correct login link for users' do
+      visit root_path
+      if yaml['test']['shibboleth_enabled'] == true
+        expect(page).to have_link('Login', login_path)
+      else
+        expect(page).to have_link('Login', new_user_session_path)
+      end
+    end
+  end
+
+  describe 'a user using a UC Shibboleth login' do
+    it "redirects to the UC Shibboleth logout page after logout" do
+      create_cookie('login_type', 'shibboleth')
+      visit('/users/sign_out')
+      page.should have_content("You have been logged out of the University of Cincinnati's Login Service")
+    end
+  end
+
+  describe 'a user using a local login' do
+    it "redirects to the home page after logout" do
+      create_cookie('login_type', 'local')
+      visit('/users/sign_out')
+      page.should have_title("Scholar@UC")
+    end
+  end
+end

--- a/spec/features/welcome_mailer_spec.rb
+++ b/spec/features/welcome_mailer_spec.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
-require 'spec_helper'
+require 'rails_helper'
 
 describe WelcomeMailer do
   let(:user_email) { 'example@test.com' }
   let(:user_password) { 'really_good_password' }
   let(:email) { ActionMailer::Base.deliveries.last }
   before do
+    AUTH_CONFIG['signups_enabled'] = true
     visit new_user_registration_path
 
     fill_in 'user_email', with: user_email

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -142,6 +142,9 @@ RSpec.configure do |config|
       page.driver.resize_window_to(handle, 2000, 2000)
     end
   end
+
+  # Allow cookies to be set in feature tests (for UC Shibboleth testing)
+  config.include ShowMeTheCookies, type: :feature
 end
 
 VCR.configure do |c|

--- a/spec/support/test_routes.rb
+++ b/spec/support/test_routes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class ShibbolethLogoutController < ActionController::Base
+  def show
+    render text: "You have been logged out of the University of Cincinnati's Login Service"
+  end
+end
+
+test_routes = proc do
+  get '/Shibboleth.sso/Logout' => 'shibboleth_logout#show'
+end
+
+Rails.application.routes.send :eval_block, test_routes


### PR DESCRIPTION
Fixes #937

Fully migrates all the Shibboleth features from Scholar 2.x.

This PR does the following:
* New /login screen
* Users can sign in with their UC six+two
* Implements authentication.yml for turning Shibboleth and signups on/off
* UC users cannot use the password reset feature
* Department, affiliation, and email fields cannot be edited on the profile form

https://scholar-dev.uc.edu is running all of this code.  So it can be tested there if you have a UC *test* Shibboleth account.