### PR TITLE
add alt tags to featured work and collections

### DIFF
--- a/app/views/hyrax/homepage/_featured.html.erb
+++ b/app/views/hyrax/homepage/_featured.html.erb
@@ -1,6 +1,6 @@
 <% presenter = featured.presenter %>
 <li class="featured-item" data-id="<%= presenter.id %>">
   <div class="center-block main row featured-thumb">
-    <%= render_thumbnail_tag presenter %>
+    <%= render_thumbnail_tag presenter, { alt: "Featured work thumbnail: #{ presenter.title.first }" } %>
   </div>
 </li>

--- a/app/views/hyrax/homepage/_featured_collections.html.erb
+++ b/app/views/hyrax/homepage/_featured_collections.html.erb
@@ -2,7 +2,7 @@
   <p><%= t('hyrax.homepage.featured_collections.no_collections') %></p>
 <% else %>
   <p>  <%= link_to collection_path(FeaturedCollection.first.collection_id) do %>
-  <%= image_tag CollectionAvatar.find_by(collection_id: FeaturedCollection.first.collection_id).avatar.url(:featured) unless FeaturedCollection.count == 0 %></p>
+  <%= image_tag CollectionAvatar.find_by(collection_id: FeaturedCollection.first.collection_id).avatar.url(:featured), alt: "Featured collection thumbnail: #{Collection.find(FeaturedCollection.first.collection_id).title.first}" %></p>
   <% end %>
 <% end %>
 <p><%= t('hyrax.homepage.featured_collections.title') %></p>

--- a/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
+++ b/spec/views/hyrax/homepage/_featured_works.html.erb_spec.rb
@@ -24,7 +24,7 @@ describe "hyrax/homepage/_featured_works.html.erb", type: :view do
     let(:featured_work) { FeaturedWork.new }
     before do
       allow(view).to receive(:can?).with(:update, FeaturedWork).and_return(false)
-      allow(view).to receive(:render_thumbnail_tag).with(presenter)
+      allow(view).to receive(:render_thumbnail_tag).with(presenter, alt: "Featured work thumbnail: Doc title")
       allow(list).to receive(:empty?).and_return(false)
       allow(list).to receive(:featured_works).and_return([featured_work])
       allow(featured_work).to receive(:presenter).and_return(presenter)


### PR DESCRIPTION
Fixes #1344 

Add constructed alt tags to featured work and collection thumbs on splash page. 
Format: "Featured work thumb: <work title>"

