### PR TITLE
override date_created to return alt_date_created

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -59,6 +59,10 @@ class Article < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'article'
   end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -54,6 +54,10 @@ class Dataset < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'dataset'
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -54,6 +54,10 @@ class Document < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'document'
   end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -70,6 +70,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'etd'
   end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -58,6 +58,10 @@ class GenericWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'generic_work'
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -54,6 +54,10 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'image'
   end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -54,6 +54,10 @@ class Medium < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'medium'
   end

--- a/app/models/student_work.rb
+++ b/app/models/student_work.rb
@@ -62,6 +62,10 @@ class StudentWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  def date_created
+    alt_date_created
+  end
+
   def self.to_s_u
     'student_work'
   end


### PR DESCRIPTION
Fixes #1413 

Make `:alt_date_create` available to citations by overriding `:date_created` in work models.

@jamesvanmil suggested an override for the citations controller but I think this alternative approach reduces debt. ( but it's also easier too?)

@uclibs/developers opinions welcome.

Changes proposed in this pull request:
* override `:date_created` to return `:alt_date_created` in work models
