### PR TITLE
Add metatags for GScholar, Twitter, and Meneley

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require Hyrax::Engine.root.join('app/presenters/hyrax/work_show_presenter.rb')
+module Hyrax
+  class WorkShowPresenter
+    # @return [String] a download URL, if work has representative media, or a blank string
+    def download_url
+      return '' if representative_presenter.nil?
+      Hyrax::Engine.routes.url_helpers.download_url(representative_presenter, host: request.host)
+    end
+  end
+end

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,7 @@
 <% provide :page_title, @presenter.page_title %>
+
+<%= render 'shared/citations' %>
+
 <div itemscope itemtype="http://schema.org/CreativeWork" class="row">
   <div class="col-xs-12">
     <header>

--- a/app/views/hyrax/citations/work.html.erb
+++ b/app/views/hyrax/citations/work.html.erb
@@ -1,0 +1,13 @@
+<h4>Citation Formats</h4>
+
+<h4>MLA</h4>
+<span class="mla-citation"><%= export_as_mla_citation(@presenter) %></span>
+<br/><br/>
+
+<h4>APA</h4>
+<span class="apa-citation"><%= export_as_apa_citation(@presenter) %></span>
+<br/><br/>
+
+<h4>Chicago</h4>
+<span class="chicago-citation"><%= export_as_chicago_citation(@presenter) %></span>
+<br/><br/>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -1,0 +1,18 @@
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-xs-12 col-sm-4">
+      <%= media_display @presenter %>
+      <%= render 'show_actions', presenter: @presenter %>
+      <%= render 'single_use_links', presenter: @presenter if @presenter.editor? %>
+    </div>
+    <div itemscope itemtype="<%= @presenter.itemtype %>" class="col-xs-12 col-sm-8">
+      <header>
+        <%= render 'work_title', presenter: @presenter %>
+      </header>
+
+      <%# TODO: render 'show_descriptions' See https://github.com/projecthydra/hyrax/issues/1481 %>
+      <%= render 'show_details' %>
+      <%= render 'hyrax/users/activity_log', events: @presenter.events %>
+    </div><!-- /columns second -->
+  </div> <!-- /.row -->
+</div><!-- /.container-fluid -->

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -1,0 +1,29 @@
+<%= csrf_meta_tag %>
+<meta charset="utf-8" />
+
+<!-- added for use on small devices like phones -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<link rel="resourcesync" href="<%= hyrax.capability_list_url %>"/>
+
+<!-- Mendeley metadata -->
+<%= yield :mendeley_meta %>
+<!-- Twitter card metadata -->
+<%= yield :twitter_meta %>
+<!-- Google Scholar metadata -->
+<%= yield :gscholar_meta %>
+
+<title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
+
+<!-- application css -->
+<%= stylesheet_link_tag 'application' %>
+
+<!-- application js -->
+<%= javascript_include_tag 'application' %>
+<%= tinymce_assets if can? :update, ContentBlock %>
+
+
+<!-- Google Analytics -->
+<%= render partial: '/ga', formats: [:html] %>
+
+<!-- for extras, e.g., a favicon -->
+<%= render partial: '/head_tag_extras', formats: [:html] %>

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -1,0 +1,40 @@
+<% content_for(:mendeley_meta) do %>
+  <meta name='DC.Title' content="<%= @presenter.title.first %>"/>
+  <% @presenter.creator.each do |creator| %>
+  <meta name='DC.Creator' content="<%= creator %>"/>
+  <% end %>
+  <meta name='DC.Description' content="<%= @presenter.alt_description.first.truncate(200) rescue @presenter.title.first %>"/>
+<% end %>
+
+<% content_for(:twitter_meta) do %>
+  <meta name="twitter:card" content="product">
+  <meta name="twitter:site" content="<%= t('hyrax.product_twitter_handle') %>"/>
+  <meta name="twitter:creator" content="<%= @presenter.tweeter %>"/>
+  <meta property="og:site_name" content="<%= application_name %>"/>
+  <meta property="og:type" content="object"/>
+  <meta property="og:title" content="<%= @presenter.title.first %>"/>
+  <meta property="og:description" content="<%= @presenter.alt_description.first.truncate(200) rescue @presenter.title.first %>"/>
+  <meta property="og:image" content="<%= @presenter.download_url %>"/>
+  <meta property="og:url" content="<%= polymorphic_url([main_app, @presenter]) %>"/>
+  <meta name="twitter:data1" content="<%= @presenter.keyword.join(', ') %>"/>
+  <meta name="twitter:label1" content="Keywords"/>
+  <meta name="twitter:data2" content="<%= @presenter.rights.first %>"/>
+  <meta name="twitter:label2" content="Rights Statement"/>
+<% end %>
+
+<% content_for(:gscholar_meta) do %>
+  <meta name="citation_title" content="<%= @presenter.title.first %>"/>
+  <% @presenter.creator.each do |creator| %>
+  <meta name="citation_author" content="<%= creator %>"/>
+  <% end %>
+  <meta name="citation_publication_date" content="<%= @presenter.date_created.first %>"/>
+  <meta name="citation_pdf_url" content="<%= @presenter.download_url %>"/>
+  <!-- Hyrax does not yet support these metadata -->
+  <!--
+    <meta name="citation_journal_title" content=""/>
+    <meta name="citation_volume" content=""/>
+    <meta name="citation_issue" content=""/>
+    <meta name="citation_firstpage" content=""/>
+    <meta name="citation_lastpage" content=""/>
+  -->
+<% end %>

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -31,5 +31,12 @@ FactoryGirl.define do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
       visibility_after_embargo Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
+
+    factory :work_with_representative_file do
+      before(:create) do |work, evaluator|
+        work.ordered_members << FactoryGirl.create(:file_set, user: evaluator.user, title: ['A Contained FileSet'])
+        work.representative_id = work.members[0].id
+      end
+    end
   end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -98,5 +98,24 @@ describe Hyrax::WorkShowPresenter do
         expect(subject).to be_kind_of Hyrax::FileSetPresenter
       end
     end
+
+    describe "#download_url" do
+      subject { presenter.download_url }
+
+      let(:solr_document) { SolrDocument.new(work.to_solr) }
+      let(:request) { double(host: 'example.org') }
+
+      context "with a representative" do
+        let(:work) { create(:work_with_representative_file) }
+
+        it { is_expected.to eq "http://#{request.host}/downloads/#{work.representative_id}" }
+      end
+
+      context "without a representative" do
+        let(:work) { create(:work) }
+
+        it { is_expected.to eq '' }
+      end
+    end
   end
 end

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'hyrax/base/show.html.erb', type: :view do
+  let(:work_solr_document) do
+    SolrDocument.new(id: '999',
+                     title_tesim: ['My Title'],
+                     creator_tesim: ['Doe, John', 'Doe, Jane'],
+                     date_modified_dtsi: '2011-04-01',
+                     has_model_ssim: ['GenericWork'],
+                     depositor_tesim: depositor.user_key,
+                     description_tesim: ['Lorem ipsum lorem ipsum.'],
+                     keyword_tesim: ['bacon', 'sausage', 'eggs'],
+                     rights_tesim: ['http://example.org/rs/1'],
+                     date_created_tesim: ['1984-01-02'])
+  end
+
+  let(:file_set_solr_document) do
+    SolrDocument.new(id: '123',
+                     title_tesim: ['My FileSet'],
+                     depositor_tesim: depositor.user_key)
+  end
+
+  let(:ability) { double }
+
+  let(:presenter) do
+    Hyrax::WorkShowPresenter.new(work_solr_document, ability, request)
+  end
+
+  let(:representative_presenter) do
+    Hyrax::FileSetPresenter.new(file_set_solr_document, ability)
+  end
+
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  let(:request) { double('request', host: 'test.host') }
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:search_state) { double('SearchState', params_for_search: {}) }
+
+  before do
+    allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
+    allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
+    allow(presenter).to receive(:alt_description).and_return(['Lorem ipsum lorem ipsum.'])
+    allow(presenter).to receive(:doi).and_return("doi:12.3456/FK2")
+    allow(controller).to receive(:current_user).and_return(depositor)
+    allow(User).to receive(:find_by_user_key).and_return(depositor.user_key)
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:on_the_dashboard?).and_return(false)
+    allow(view).to receive(:search_state).and_return(search_state)
+    stub_template 'hyrax/base/_metadata.html.erb' => ''
+    stub_template 'hyrax/base/_relationships.html.erb' => ''
+    stub_template 'hyrax/base/_show_actions.html.erb' => ''
+    stub_template 'hyrax/base/_representative_media.html.erb' => ''
+    stub_template 'hyrax/base/_social_media.html.erb' => ''
+    stub_template 'hyrax/base/_citations.html.erb' => ''
+    stub_template 'hyrax/base/_items.html.erb' => ''
+    stub_template 'hyrax/base/_workflow_actions_widget.html.erb' => ''
+    stub_template '_masthead.html.erb' => ''
+    assign(:presenter, presenter)
+    render template: 'hyrax/base/show.html.erb', layout: 'layouts/hyrax/1_column'
+  end
+
+  describe 'Mendeley' do
+    it 'appears in meta tags' do
+      mendeley_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'DC.')]")
+      expect(mendeley_meta_tags.count).to be >= 3
+    end
+
+    it 'displays title' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='DC.Title']")
+      expect(tag.attribute('content').value).to eq('My Title')
+    end
+
+    it 'displays authors' do
+      tags = Nokogiri::HTML(rendered).xpath("//meta[@name='DC.Creator']")
+      expect(tags.first.attribute('content').value).to eq('Doe, John')
+      expect(tags.last.attribute('content').value).to eq('Doe, Jane')
+    end
+
+    it 'displays description' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='DC.Description']")
+      expect(tag.attribute('content').value).to eq('Lorem ipsum lorem ipsum.')
+    end
+  end
+
+  describe 'google scholar' do
+    it 'appears in meta tags' do
+      gscholar_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'citation_')]")
+      expect(gscholar_meta_tags.count).to eq(5)
+    end
+
+    it 'displays title' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_title']")
+      expect(tag.attribute('content').value).to eq('My Title')
+    end
+
+    it 'displays authors' do
+      tags = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_author']")
+      expect(tags.first.attribute('content').value).to eq('Doe, John')
+      expect(tags.last.attribute('content').value).to eq('Doe, Jane')
+    end
+
+    it 'displays publication date' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publication_date']")
+      expect(tag.attribute('content').value).to eq('1984-01-02')
+    end
+
+    it 'displays download URL' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_pdf_url']")
+      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
+    end
+  end
+
+  describe 'twitter cards' do
+    it 'appears in meta tags' do
+      twitter_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'twitter:') or contains(@property, 'og:')]")
+      expect(twitter_meta_tags.count).to eq(13)
+    end
+
+    it 'displays twitter:card' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:card']")
+      expect(tag.attribute('content').value).to eq('product')
+    end
+
+    it 'displays twitter:site' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:site']")
+      expect(tag.attribute('content').value).to eq('@Scholar@UC')
+    end
+
+    it 'displays twitter:creator' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:creator']")
+      expect(tag.attribute('content').value).to eq('@bot4lib')
+    end
+
+    it 'displays og:site_name' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:site_name']")
+      expect(tag.attribute('content').value).to eq('Scholar@UC')
+    end
+
+    it 'displays og:type' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:type']")
+      expect(tag.attribute('content').value).to eq('object')
+    end
+
+    it 'displays og:title' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:title']")
+      expect(tag.attribute('content').value).to eq('My Title')
+    end
+
+    it 'displays og:description' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:description']")
+      expect(tag.attribute('content').value).to eq('Lorem ipsum lorem ipsum.')
+    end
+
+    it 'displays og:image' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:image']")
+      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
+    end
+
+    it 'displays og:url' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:url']")
+      expect(tag.attribute('content').value).to eq('http://test.host/concern/generic_works/999')
+    end
+
+    it 'displays twitter:data1' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data1']")
+      expect(tag.attribute('content').value).to eq('bacon, sausage, eggs')
+    end
+
+    it 'displays twitter:label1' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label1']")
+      expect(tag.attribute('content').value).to eq('Keywords')
+    end
+
+    it 'displays twitter:data2' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data2']")
+      expect(tag.attribute('content').value).to eq('http://example.org/rs/1')
+    end
+
+    it 'displays twitter:label2' do
+      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label2']")
+      expect(tag.attribute('content').value).to eq('Rights Statement')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1484 

This pulls in code from Hyrax 2.x (https://github.com/samvera/hyrax/pull/1324/files) that adds metatags to support Google Scholar indexing and Twitter badges.  I then added additional metatags to support Mendeley import.  So most of the code and views in this PR comes straight from Hyrax.

To test with Mendeley, add the Mendeley web importer to your browser, create a Mendeley account, and then use the importer on a work show page.  Mendeley should pick up the title, author(s), and description.  Before this PR Mendeley only found the title.

I can also just show you the Mendeley import on my machine if you don't want to go through the hassle on yours.