### PR TITLE
Git ignore development.rb and production.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ config/initializers/devise.rb
 config/initializers/scholar_uc.rb
 config/initializers/hyrax.rb
 config/authentication.yml
+config/environments/development.rb
+config/environments/production.rb


### PR DESCRIPTION
No issue

The `config/environments/development.rb` and `config/environments/production.rb` files are now generated by script from .sample and .bamboo files.  So they should be ignored in git or developers will see them as untracked files.