### PR TITLE
add contextual help for attaching files to work

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,3 +31,4 @@
 //= require lodash
 //= require license-selector
 //= require select-license
+//= require file_plug

--- a/app/assets/javascripts/file_plug.js
+++ b/app/assets/javascripts/file_plug.js
@@ -1,0 +1,9 @@
+$(document).on('turbolinks:load', function() {
+  var filePlug = $('a[href="#files"]').last();
+
+  filePlug.on('click', function() {
+    $('.active').first().removeClass('active');
+    $('a[href="#files"]').first().parent().addClass('active');
+  });
+});
+

--- a/app/views/hyrax/base/_form_files.html.erb
+++ b/app/views/hyrax/base/_form_files.html.erb
@@ -1,0 +1,58 @@
+<div id="fileupload">
+  <!-- Redirect browsers with JavaScript disabled to the origin page -->
+  <noscript><input type="hidden" name="redirect" value="<%= main_app.root_path %>"></noscript>
+  <!-- The table listing the files available for upload/download -->
+  <table role="presentation" class="table table-striped"><tbody class="files"></tbody></table>
+
+  <h2><%= t('hyrax.base.form_files.local_upload') %></h2>
+  <div class="contextual-help-cont">
+    <p>
+      Attaching a file is highly recommended but not required. Pre-prints are encouraged if a publisher does not 
+      permit sharing a published article. Use the External Link field on the Metadata tab to point to related content 
+      found outside of Scholar@UC.
+    </p>
+  </div>
+  <!-- The fileupload-buttonbar contains buttons to add/delete files and start/cancel the upload -->
+  <div class="row fileupload-buttonbar">
+      <div class="col-xs-7">
+          <!-- The fileinput-button span is used to style the file input field as button -->
+          <span class="btn btn-success fileinput-button">
+              <span class="glyphicon glyphicon-plus"></span>
+              <span>Add files...</span>
+              <input type="file" name="files[]" multiple>
+          </span>
+          <% if browser_supports_directory_upload? %>
+          <!-- The fileinput-button span is used to style the file input field as button -->
+          <span class="btn btn-success fileinput-button">
+              <span class="glyphicon glyphicon-plus"></span>
+              <span>Add folder...</span>
+              <input type="file" name="files[]" multiple directory webkitdirectory>
+          </span>
+          <% end %>
+          <button type="reset" class="btn btn-warning cancel hidden">
+              <span class="glyphicon glyphicon-ban-circle"></span>
+              <span>Cancel upload</span>
+          </button>
+          <!-- The global file processing state -->
+          <span class="fileupload-process"></span>
+      </div>
+      <!-- The global progress state -->
+      <div class="col-xs-5 fileupload-progress fade">
+          <!-- The global progress bar -->
+          <div class="progress progress-striped active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+              <div class="progress-bar progress-bar-success" style="width:0%;"></div>
+          </div>
+          <!-- The extended global progress state -->
+          <div class="progress-extended">&nbsp;</div>
+      </div>
+  </div>
+  <div class="dropzone">
+    <%= t('hyrax.base.form_files.dropzone') %>
+  </div>
+     </div>
+
+<%= render 'hyrax/uploads/js_templates' %>
+<% if Hyrax.config.browse_everything? %>
+  <h2><%= t('hyrax.base.form_files.external_upload') %></h2>
+  <%= render 'browse_everything', f: f %>
+<% end %>

--- a/app/views/hyrax/base/_form_metadata.html.erb
+++ b/app/views/hyrax/base/_form_metadata.html.erb
@@ -2,6 +2,9 @@
         <div class="form-instructions">
           <p>The more descriptive information you provide the better we can serve your needs.</p>
         </div>
+        <div class="contextual-help">
+          <p><a href="#files" aria-controls="files" data-toggle="tab">Attaching a file</a> is highly recommended but not required.</p>
+        </div>
         <div class="base-terms">
           <% f.object.primary_terms.each do |term| %>
             <%= render_edit_field_partial(term, f: f) %>


### PR DESCRIPTION
Fixes #1452 

After segmenting the text as agreed yesterday, I found that a tad of javascript was required to properly transition from metadata to the files tab.

Also, includes a new override of the `_form_files.html.erb` partial.
