### PR TITLE
Change email/name block size

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -197,6 +197,10 @@ label[for=user_password] {
   }
 }
 
+.panel-user>.panel-heading>h3 {
+  font-size: 1.2em;
+}
+
 /* Medium devices */
 @media (min-width: 768px) and (max-width: 991px) {
 


### PR DESCRIPTION
Fixes #1564 

Make email/name block size smaller.

![screen shot 2017-08-01 at 12 09 36 pm](https://user-images.githubusercontent.com/1069588/28835108-5219c670-76b2-11e7-9e49-c06b415ac4e8.png)


