### PR TITLE
Fix proxy deposit error bug

### DIFF
--- a/app/controllers/concerns/scholar/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholar/works_controller_behavior.rb
@@ -14,7 +14,7 @@ module Scholar
     def create
       super
       # the to_s_u method must be implemented for every model
-      editors = params[curation_concern.class.to_s_u][:permissions_attributes]
+      editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
       queue_notifications_for_editors(editors) if editors
     rescue ActiveFedora::RecordInvalid # virus detected
       remove_infected_file_sets
@@ -25,7 +25,7 @@ module Scholar
     def update
       super
       # the to_s_u method must be implemented for every model
-      editors = params[curation_concern.class.to_s_u][:permissions_attributes]
+      editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
       queue_notifications_for_editors(editors) if editors
     rescue ActiveFedora::RecordInvalid # virus detected
       remove_infected_file_sets


### PR DESCRIPTION
Fixes #1566 

Rails 5 breaks our change-manager code because params now returns an ActionController::Parameters object with whitelisting instead of a straight hash. Since the parameters are nested, it is awkward to whitelist: opting to convert to a hash instead and circumvent whitelisting in this case, since the params are not user submitted.

[Rails 5: ActionController::Parameters Now Returns an Object Instead of a Hash](http://eileencodes.com/posts/actioncontroller-parameters-now-returns-an-object-instead-of-a-hash/)

Changes proposed in this pull request:
* Add `.to_unsafe_h` to params call in work controller behavior for permissions-check/proxy notification.
