### PR TITLE
Adds URI.decode to remove slashes in RIIIF url.

### DIFF
--- a/config/initializers/riiif.rb
+++ b/config/initializers/riiif.rb
@@ -6,7 +6,7 @@ Riiif::Image.info_service = lambda do |id, _file|
   # but we just want the id for the FileSet it's attached to.
 
   # Capture everything before the first slash
-  fs_id = id.sub(/\A([^\/]*)\/.*/, '\1')
+  fs_id = URI.decode(id).sub(/\A([^\/]*)\/.*/, '\1')
   resp = ActiveFedora::SolrService.get("id:#{fs_id}")
   doc = resp['response']['docs'].first
   raise "Unable to find solr document with id:#{fs_id}" unless doc


### PR DESCRIPTION
Fixes #1537 

This is needed for hosted Apache environments.  RIIIF needs encoded slashes removed.  We will also need set this in the apache conf.d.

https://github.com/curationexperts/riiif#special-note-for-passenger-and-apache-users

