### PR TITLE
People toolbar item highlighted in mobile view

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -339,10 +339,6 @@ label[for=user_password] {
     text-shadow: 2px 2px 2px #000;
   }
 
-  .mobile-controls li:first-child {
-    background-color: rgba(255, 255, 255, 0.4)
-  }
-
   .scholar-footer {
     text-align: center !important;
   }


### PR DESCRIPTION
Fixes #1323 

In mobile view the "People" toolbar item on the homepage was highlighted. Now it is not.