### PR TITLE
Accessibility/#1587 contrast violations

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -1,3 +1,31 @@
+.label-default {
+  background-color: #757575;
+}
+
+.label-info {
+  background-color: #20809d;
+}
+
+.label-success {
+  background-color: #388038;
+}
+
+.label-danger {
+  background-color: #d33b36;
+}
+
+.badge {
+  background-color: #757575;
+}
+
+legend small {
+  color: #757575;
+}
+
+.select2-default {
+  color: #444 !important;
+}
+
 .doi-strike {
   background-color: #f2dede;
 }
@@ -31,6 +59,14 @@ div[class*="_admin_set_id"] {
 
 #masthead a {
   color: #fff;
+}
+
+.navbar-default .navbar-nav > li > a {
+  color: #6b6b6b;
+}
+
+.navbar-default .navbar-nav > li > a:hover {
+  color: #252525;
 }
 
 #top-navbar-collapse > div > ul > li.dropdown.open > ul > li > a {
@@ -372,4 +408,3 @@ label[for=user_password] {
     margin-bottom: 20px;
   }
 }
-


### PR DESCRIPTION
Fixes #1587

Fixes contrast issues from accessibility scan.

#### Contrast Accessibility Issues

- **Issues with Beta Tags** - Total Issues 12/83:
  - Issues can be ignored, tags will be removed once in production.
  - No changes needed
- **Issues with notification badge** - Total Issues 12/83:
  - Slightly darkened badge background color.
  - Before: ![alt text](http://i.imgur.com/exEh8dt.png "notifications before")
  - After: ![alt text](http://i.imgur.com/tqA8Vmn.png "notifications after")
- **Issues with Navbar** - Total Issues 44/83:
  - Darkened text on Navbar elements (Darkened text on `:hover` as well to keep aesthetic).
  - Before: ![alt text](http://i.imgur.com/Z7Y5jwa.png "navbar before")
  - After: ![alt text](http://i.imgur.com/62iKQ6U.png "navbar after")
- **Issues with Dashboard badges** - Total Issues 4/83:
  - Same issue as notification badge, same fix
  - Before: ![alt text](http://i.imgur.com/CdTu8NU.png "badges before")
  - After: ![alt text](http://i.imgur.com/lsYPPc0.png "badges after")
- **Issues with New Collection Form Labels** - Total Issues 7/83:
  - The Labels of the 'New Collection' form were too bright, darkened them.
  - Before: ![alt text](http://i.imgur.com/I4eJoRx.png "labels before")
  - After: ![alt text](http://i.imgur.com/9EDL8B4.png "labels after")
- **Issues with Visibility help text** - Total Issues 1/83:
  - The text was too faint, made darker.
  - Before: ![alt text](http://i.imgur.com/kvCVZUy.png "visibility before")
  - After: ![alt text](http://i.imgur.com/PHod7Qo.png "visibility after")
- **Issues with Search for User Dropdown** - Total issues 1/83:
  - Text in dropdown menu on dashboard was way too faint, made darker.
  - Before: ![alt text](http://i.imgur.com/yQIJRg5.png "dropdown before")
  - After: ![alt text](http://i.imgur.com/H80jEtp.png "dropdown after")
- **Issues with 'Delete All' notifications button** - Total Issues 1/83:
  - Same Issue as form labels, same fix
  - Before: ![alt text](http://i.imgur.com/3ghxBUk.png "delete before")
  - After: ![alt text](http://i.imgur.com/KX74pJX.png "delete after")
- **Issues with "contact scholar team" link** - Total Issues 1/83:
  - Appears to be a false positive, 1/8 links on the about page with the same styling caused this issue.
  - By my calculation current contrast ratio (5:1) meets requirement (4.5:1)
  - No changes needed
