### PR TITLE
Fix Meta Tag violations from accessibility scan

### DIFF
--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -2,7 +2,7 @@
 <meta charset="utf-8" />
 
 <!-- added for use on small devices like phones -->
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="resourcesync" href="<%= hyrax.capability_list_url %>"/>
 
 <!-- Mendeley metadata -->


### PR DESCRIPTION
Fixes #1588 

Removed meta tag attribute which was causing issues in the accessibility scan.

We had an attribute in our `<meta name="viewport">` tag ('maximum-scale') which prevented users on mobile devices from being able to zoom in on our pages. The main effect of the attribute (other than disabling zooming) is on Mobile Safari because Safari handles screen rotation rather poorly. [From MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag): 

> Not all mobile browsers handle orientation changes in the same way. For example, Mobile Safari often just zooms the page when changing from portrait to landscape, instead of laying out the page as it would if originally loaded in landscape. If web developers want their scale settings to remain consistent when switching orientations on the iPhone, they must add a maximum-scale value to prevent this zooming, which has the sometimes-unwanted side effect of preventing users from zooming in.

I looked and was not able to find a way to fix the scaling issue in Mobile Safari while still enabling mobile users to zoom on our site. 

###### Changes proposed in this pull request:
* Remove `maximum-scale` attribute from `viewport` tag
