### PR TITLE
Resolve table header accessibility violations

### DIFF
--- a/app/views/hyrax/mailbox/_notifications.html.erb
+++ b/app/views/hyrax/mailbox/_notifications.html.erb
@@ -1,0 +1,27 @@
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col"><%= t('hyrax.mailbox.date') %></th>
+      <th scope="col"><%= t('hyrax.mailbox.subject') %></th>
+      <th scope="col"><%= t('hyrax.mailbox.message') %></th>
+      <th scope="col"><span class="sr-only"><%= t('hyrax.mailbox.delete') %></span></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% messages.each do |msg| %>
+      <tr>
+        <td><%= (time_ago_in_words(msg.last_message.created_at) + " ago") %></td>
+        <td><%= msg.last_message.subject.html_safe %></td>
+        <td><%= msg.last_message.body.html_safe %></td>
+        <td>
+          <%= link_to hyrax.notification_path(msg.id),
+                      class: "itemicon itemtrash",
+                      title: "Delete Message",
+                      method: :delete do %>
+            <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/my/_index_partials/_default_group.html.erb
+++ b/app/views/hyrax/my/_index_partials/_default_group.html.erb
@@ -1,0 +1,24 @@
+<table class="table table-striped works-list">
+  <caption class="sr-only"><%= t("hyrax.dashboard.my.sr.listing") %> <%= application_name %></caption>
+  <% unless params[:display_type] == 'list' %>
+    <thead>
+    <tr>
+      <th class="check-all" scope="col"><label for="check_all" class="sr-only"><%= t("hyrax.dashboard.my.sr.check_all_label") %></label><%= render_check_all %></th>
+      <th scope="col"><%= t("hyrax.dashboard.my.heading.title") %></th>
+      <th class="sorts-dash" scope="col"><i id="<%= CatalogController.uploaded_field %>" class="<%= params[:sort] == "#{CatalogController.uploaded_field} desc" ? 'caret' : params[:sort] == "#{CatalogController.uploaded_field} asc" ? 'caret up' : ''%>"></i><%= t("hyrax.dashboard.my.heading.date_uploaded") %></th>
+      <th scope="col"><%= t("blacklight.search.fields.facet.suppressed_bsi") %></th>
+      <th scope="col"><%= t("hyrax.dashboard.my.heading.visibility") %></th>
+      <th scope="col"><%= t("hyrax.dashboard.my.heading.action") %></th>
+    </tr>
+    </thead>
+  <% end %>
+  <tbody>
+  <% docs.each_with_index do |document, counter| %>
+    <% if document.collection? %>
+      <%= render 'hyrax/my/_index_partials/list_collections', document: document, counter: counter %>
+    <% else %>
+      <%= render 'hyrax/my/_index_partials/list_works', document: document, counter: counter, presenter: Hyrax::WorkShowPresenter.new(document, current_ability) %>
+    <% end %>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/users/index.html.erb
+++ b/app/views/hyrax/users/index.html.erb
@@ -6,11 +6,11 @@
 <table class="table table-striped people">
     <thead>
         <tr>
-            <th>Avatar</th>
-            <th class="sorts"><i id="name" class="<%=params[:sort].blank? ? 'caret up' : params[:sort]== "name desc" ? 'caret' : params[:sort]== "name" ? 'caret up' : ''%>"></i> User Name</th>
-            <th class="sorts"><i id="login" class="<%=params[:sort]== "login desc" ? 'caret' : params[:sort]== "login" ? 'caret up' : ''%>"></i> User Id</th>
-            <th class="sorts"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> Department</th>
-            <th>Works Created</th>
+            <th scope="col">Avatar</th>
+            <th class="sorts" scope="col"><i id="name" class="<%=params[:sort].blank? ? 'caret up' : params[:sort]== "name desc" ? 'caret' : params[:sort]== "name" ? 'caret up' : ''%>"></i> User Name</th>
+            <th class="sorts" scope="col"><i id="login" class="<%=params[:sort]== "login desc" ? 'caret' : params[:sort]== "login" ? 'caret up' : ''%>"></i> User Id</th>
+            <th class="sorts" scope="col"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> Department</th>
+            <th scope="col">Works Created</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Fixes #1591

Added attributes to html `<th>` elements to directly relate them with their columns

Two of the problem tables were defined in Hyrax, I added overrides for those partials in order to add the needed attributes. The affected files were:
 * [`_default_group.html.erb`](https://github.com/samvera/hyrax/blob/v1.0.1/app/views/hyrax/my/_index_partials/_default_group.html.erb)
 * [`_notifications.html.erb`](https://github.com/samvera/hyrax/blob/v1.0.1/app/views/hyrax/mailbox/_notifications.html.erb)

The third partial was already one of ours so I simply added the missing attributes

##### Changes proposed in this pull request:
* Override [`_notifications.html.erb`](https://github.com/samvera/hyrax/blob/v1.0.1/app/views/hyrax/mailbox/_notifications.html.erb) and [`_default_group.html.erb`](https://github.com/samvera/hyrax/blob/v1.0.1/app/views/hyrax/my/_index_partials/_default_group.html.erb) from Hyrax to add accessibility attributes 
* Add accessibility attributes to notifications table
