### PR TITLE
Expose share tab with default workflow

### DIFF
--- a/app/views/hyrax/batch_uploads/_form.html.erb
+++ b/app/views/hyrax/batch_uploads/_form.html.erb
@@ -7,7 +7,7 @@
     <p class="instructions"><%= t("hyrax.batch_uploads.files.instructions") %></p>
     <p class="switch-upload-type">Note: To create a single work for all the files, go to the <%= link_to "Add New " + @form.payload_concern.constantize.model_name.human.titleize, main_app.new_polymorphic_path(@form.payload_concern.constantize) %> page.</p>
   <% end %>
-  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: %w[files metadata relationships] do %>
   <% end %>
   <%= f.hidden_field :payload_concern, value: @form.payload_concern %>
 <% end %>

--- a/config/workflows/default_workflow.json
+++ b/config/workflows/default_workflow.json
@@ -4,7 +4,7 @@
             "name": "default",
             "label": "Default workflow",
             "description": "A single submission step, default workflow",
-            "allows_access_grant": false,
+            "allows_access_grant": true,
             "actions": [
                 {
                     "name": "deposit",

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -57,6 +57,10 @@ shared_examples 'work creation' do |work_class| # apply underscore for snake cas
 
     select 'Attribution-ShareAlike 4.0 International', from: "#{work_type}_rights"
     choose("#{work_type}_visibility_open")
+
+    click_link('Share')
+    expect(page).to have_content("Share work with other users")
+
     check('agreement')
     click_on('Save')
     expect(page).to have_content('My Test Work')
@@ -116,6 +120,10 @@ shared_examples 'proxy work creation' do |work_class|
 
     select 'Attribution-ShareAlike 4.0 International', from: "#{work_type}_rights"
     choose("#{work_type}_visibility_open")
+
+    click_link('Share')
+    expect(page).to have_content("Share work with other users")
+
     select(second_user.user_key, from: 'On behalf of')
     check('agreement')
     click_on('Save')
@@ -138,6 +146,8 @@ feature 'Creating a new work', :js, :workflow do
   # let!(:uploaded_file2) { UploadedFile.create(file: file2, user: user) }
 
   before do
+    AdminSet.find_or_create_default_admin_set_id
+    Hyrax::Workflow::WorkflowImporter.load_workflows
     allow(CharacterizeJob).to receive(:perform_later)
     page.driver.browser.js_errors = false
     page.current_window.resize_to(2000, 2000)


### PR DESCRIPTION
Fixes #1600 

Changes proposed in this pull request:

* Change default workflow to expose share tab
* Remove hard-coded share tab from batch form
* Load default workflow and admin set in create work feature spec
* Add feature specs to look for share tab on work creation
