### PR TITLE
Adds riiif cache management.

### DIFF
--- a/config/initializers/riiif.rb.bamboo
+++ b/config/initializers/riiif.rb.bamboo
@@ -26,4 +26,5 @@ end
 
 # Riiif::Image.authorization_service = IIIFAuthorizationService
 
-Riiif::Engine.config.cache_duration_in_days = 365
+Riiif::Engine.config.cache_duration_in_days = 90
+Riiif::Image.file_resolver.cache_path = 'bamboo_riiif_cache'

--- a/config/initializers/riiif.rb.sample
+++ b/config/initializers/riiif.rb.sample
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+Riiif::Image.file_resolver = Riiif::HTTPFileResolver.new
+Riiif::Image.info_service = lambda do |id, _file|
+  # id will look like a path to a pcdm:file
+  # (e.g. rv042t299%2Ffiles%2F6d71677a-4f80-42f1-ae58-ed1063fd79c7)
+  # but we just want the id for the FileSet it's attached to.
+
+  # Capture everything before the first slash
+  fs_id = URI.decode(id).sub(/\A([^\/]*)\/.*/, '\1')
+  resp = ActiveFedora::SolrService.get("id:#{fs_id}")
+  doc = resp['response']['docs'].first
+  raise "Unable to find solr document with id:#{fs_id}" unless doc
+  { height: doc['height_is'], width: doc['width_is'] }
+end
+
+def logger
+  Rails.logger
+end
+
+Riiif::Image.file_resolver.id_to_uri = lambda do |id|
+  ActiveFedora::Base.id_to_uri(CGI.unescape(id)).tap do |url|
+    logger.info "Riiif resolved #{id} to #{url}"
+  end
+end
+# Riiif::Image.file_resolver.basic_auth_credentials = [ActiveFedora.fedora.user, ActiveFedora.fedora.password]
+
+# Riiif::Image.authorization_service = IIIFAuthorizationService
+
+Riiif::Engine.config.cache_duration_in_days = 90
+Riiif::Image.file_resolver.cache_path = 'tmp/network_files'

--- a/script/copy_config_bamboo.sh
+++ b/script/copy_config_bamboo.sh
@@ -13,3 +13,4 @@ cp /srv/apps/curate/curate_uc-STAGE/config/initializers/devise.rb.bamboo /srv/ap
 cp /srv/apps/curate/curate_uc-STAGE/config/environments/development.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/environments/development.rb
 cp /srv/apps/curate/curate_uc-STAGE/config/environments/production.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/environments/production.rb
 cp /srv/apps/curate/curate_uc-STAGE/config/authentication.yml.bamboo /srv/apps/curate/curate_uc-STAGE/config/authentication.yml
+cp /srv/apps/curate/curate_uc-STAGE/config/initializers/riiif.rb.bamboo /srv/apps/curate/curate_uc-STAGE/config/initializers/riiif.rb

--- a/script/copy_config_local.sh
+++ b/script/copy_config_local.sh
@@ -13,3 +13,4 @@ cp config/initializers/devise.rb.sample config/initializers/devise.rb
 cp config/environments/development.rb.sample config/environments/development.rb
 cp config/environments/production.rb.sample config/environments/production.rb
 cp config/authentication.yml.sample config/authentication.yml
+cp config/initializers/riiif.rb.sample config/initializers/riiif.rb

--- a/script/riiif_cache_clean.sh
+++ b/script/riiif_cache_clean.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#
+# riiif_cache_clean.sh
+# Cron script for maintaining the loris cache size.
+#
+# CAUTION - This script deletes files. Be careful where you point it!
+#
+
+LOG="log/riiif_cache_clean.log"
+
+# Check that the cache directories...
+IMG_CACHE_DIR="/srv/apps/scholar-riiif-cache"
+
+# ...is below a certain size...
+REDUCE_TO=500000 #500 mb
+# REDUCE_TO=1048576 #1 gb
+# REDUCE_TO=1073741824 # 1 TB
+# REDUCE_TO=2147483648 # 2 TB
+
+# ...and when it is larger, start deleting files accessed more than a certain 
+# number of days ago until the cache is smaller than the configured size.
+
+# Note the name of the variable __REDUCE_TO__: this should not be the total 
+# amount of space you can afford for the cache, but instead the total space 
+# you can afford MINUS the amount you expect the cache to grow in between 
+# executions of this script.
+
+current_usage () {
+	du -sk $IMG_CACHE_DIR | cut -f 1
+}
+
+delete_total=0
+max_age=90 # days
+usage=$(current_usage)
+start_size=$usage
+run=1
+while [ $usage -gt $REDUCE_TO ] && [ $max_age -ge -1 ]; do
+	run=0
+
+	# files. loop (instead of -delete) so that we can keep count
+	for f in $(find $IMG_CACHE_DIR -type f -atime +$max_age); do
+		rm $f
+		let delete_total+=1
+	done
+
+	# empty directories
+	find $IMG_CACHE_DIR -mindepth 1 -type d -empty -delete
+
+	let max_age-=1
+	usage=$(current_usage)
+done
+
+echo -ne "$(date +[%c]) " >> $LOG
+if [ $run == 0 ]; then
+	echo -ne "Deleted $delete_count files to " >> $LOG
+	echo "get cache from $start_size kb to $usage kb." >> $LOG
+else
+	echo "Cache at $usage kb (no deletes required)." >> $LOG
+fi
+
+
+
+


### PR DESCRIPTION
Fixes #1387 

Present short summary (50 characters or less)

Sets the riiif cache duration for 90 days.
Sets the riiif cache location to tmp/network_files
Adds a cache clean up script.  (parameters: size, duration, and log output)

Description can have multiple paragraphs and you can use code examples inside:

config/initializers/riiif.rb
