### PR TITLE
Resolve ARIA accessibility issues

### DIFF
--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,1 +1,3 @@
-<%= f.input :creator, as: :multi_value, input_html: { class: 'form-control'  }, required: true %>
+
+<%= f.label :creator, id: "#{(@collection || curation_concern).class.to_s.underscore}_creator_label" %>
+<%= f.input :creator, as: :multi_value, input_html: { class: 'form-control' }, required: true, label: false %>

--- a/app/views/records/edit_fields/_rights.html.erb
+++ b/app/views/records/edit_fields/_rights.html.erb
@@ -1,6 +1,6 @@
 <% license_service = Hyrax::LicenseService.new %>
 <label class="control-label select required" for="work_rights">
-  Rights  
+  Rights
   <span class="label label-info required-tag">required</span>
 </label>
 <div class="license-wrapper">
@@ -11,7 +11,8 @@
           include_blank: 'Use License Wizard or choose directly from the dropdown.',
           item_helper: license_service.method(:include_current_value),
           input_html: { class: 'rights rights-selector', multiple: false },
-          label: false
+          label: false,
+          required: true
         %>
     </div>
   </div>


### PR DESCRIPTION
Fixes #1589 

Edited ARIA attributes to hold proper values.

---
##### Changes Proposed
* Explicitly define the 'Rights' input field on works and collections as required so ARIA attribute will have right value. 

* Explicitly make the label for the 'Creator' field on works and collections so that the id attribute will match what simple form is expecting when it creates the input element. 
