### PR TITLE
install sitemap builder and associated specs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,6 +11,7 @@ Metrics/BlockLength:
     - 'app/models/concerns/remotely_identified_by_doi.rb'
     - 'config/initializers/simple_form_bootstrap.rb'
     - 'config/routes.rb'
+    - 'app/views/sitemaps/index.xml.builder'
 
 Metrics/CyclomaticComplexity:
   Exclude:

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+class SitemapsController < ApplicationController
+  def index
+    work_types = Hyrax.config.registered_curation_concern_types.append('Collection')
+
+    @root_url = strip_locale_from_url root_url
+    @catalog_urls = []
+    @resources = []
+
+    @static_pages = StaticController.instance_methods(false).map { |action| get_static_url action }
+    @catalog_urls.append strip_locale_from_url search_catalog_url
+
+    work_types.each do |work_type|
+      @catalog_urls << retrieve_facet_urls(work_type)
+      retrieve_works_from_solr work_type
+    end
+
+    @static_pages.map! { |page_url| strip_locale_from_url page_url }
+
+    respond_to do |format|
+      format.xml
+    end
+  end
+
+  private
+
+    def retrieve_works_from_solr(work_type)
+      ActiveFedora::SolrService.query("has_model_ssim:#{work_type}", rows: 1_000_000).each do |work|
+        next if work[:read_access_group_ssim] != ['public']
+        work_metadata = {}
+        work_metadata[:url] = sans_fedora_poly_url(work_type, work[:id])
+        work_metadata[:lastmod] = work[:system_modified_dtsi].gsub(/T[0-9]{2}:[0-9]{2}:[0-9]{2}Z/, '')
+        @resources << work_metadata
+      end
+    end
+
+    def strip_locale_from_url(url_with_locale)
+      url_with_locale.gsub('?locale=en', '')
+    end
+
+    def sans_fedora_poly_url(work_type, work_id)
+      strip_locale_from_url(root_url + "concern/#{work_type.underscore}/#{work_id}")
+    end
+
+    def retrieve_facet_urls(work_type)
+      strip_locale_from_url(root_url + "catalog?f[human_readable_type_sim][]=#{work_type}")
+    end
+
+    def get_static_url(action)
+      send "#{action}_url"
+    end
+end

--- a/app/views/sitemaps/index.xml.builder
+++ b/app/views/sitemaps/index.xml.builder
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+xml.instruct! :xml, version: '1.0'
+xml.tag! 'urlset', 'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+                   'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+                   'xmlns:image' => 'http://www.google.com/schemas/sitemap-image/1.1',
+                   'xmlns:video' => 'http://www.google.com/schemas/sitemap-video/1.1',
+                   'xmlns:geo' => 'http://www.google.com/geo/schemas/sitemap/1.0',
+                   'xmlns:news' => 'http://www.google.com/schemas/sitemap-news/0.9',
+                   'xmlns:mobile' => 'http://www.google.com/schemas/sitemap-mobile/1.0',
+                   'xmlns:pagemap' => 'http://www.google.com/schemas/sitemap-pagemap/1.0',
+                   'xmlns:xhtml' => 'http://www.w3.org/1999/xhtml',
+                   'xsi:schemaLocation' => 'http://www.sitemaps.org/schemas/sitemap/0.9 ' \
+         'http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd' do
+
+  xml.url do
+    xml.loc @root_url
+    xml.changefreq "always"
+    xml.priority 1.0
+  end
+
+  @static_pages.each do |url|
+    xml.url do
+      xml.loc url
+      xml.changefreq "monthly"
+      xml.priority 0.8
+    end
+  end
+
+  @catalog_urls.each do |url|
+    xml.url do
+      xml.loc url
+      xml.lastmod Time.zone.now.strftime "%Y-%d-%m"
+      xml.changefreq "daily"
+      xml.priority 1.0
+    end
+  end
+
+  @resources.each do |work|
+    xml.url do
+      xml.loc work[:url]
+      xml.lastmod work[:lastmod]
+      xml.changefreq "weekly"
+      xml.priority 0.8
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   get 'doi_help' => 'static#doi_help'
   get 'login' => 'static#login'
 
+  get 'sitemap.xml' => 'sitemaps#index', format: 'xml', as: :sitemap
   # route for custom error pages issue #1056
   match '/404', to: 'errors#not_found', via: :all
   match '/422', to: 'errors#unprocessable', via: :all

--- a/spec/features/sitemap_spec.rb
+++ b/spec/features/sitemap_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+shared_examples 'sitemap' do |work_class|
+  let!(:work_type) { work_class.name.underscore }
+  let!(:private_work) { FactoryGirl.create(work_type.to_sym) }
+  let!(:public_work) { FactoryGirl.create("public_#{work_type}".to_sym) }
+  let(:xml) { Capybara.string(page.body) }
+
+  before { visit sitemap_path }
+
+  it "indexes public #{work_class}s" do
+    expect(xml).to have_content build_test_path(work_type, public_work.id)
+  end
+
+  it "does not index private #{work_class}s" do
+    expect(xml).not_to have_content build_test_path(work_type, private_work.id)
+  end
+
+  it "indexes the catalog facet for #{work_class}s" do
+    expect(xml).to have_content build_facet_path(work_class)
+  end
+end
+
+feature 'Viewing the sitemap', :js, :workflow do
+  let!(:static_paths) { StaticController.instance_methods(false) }
+  let(:xml) { Capybara.string(page.body) }
+
+  before { visit sitemap_path }
+
+  Hyrax.config.registered_curation_concern_types.append('Collection').each do |type|
+    it_behaves_like 'sitemap', type.constantize
+  end
+
+  it 'displays the root URL' do
+    expect(xml).to have_content(root_path)
+  end
+
+  it 'displays the catalog URL' do
+    expect(xml).to have_content(search_catalog_path)
+  end
+
+  it 'displays all static URLs in the application' do
+    static_paths.each { |static_path| expect(xml).to have_content(send("#{static_path}_path")) }
+  end
+end
+
+private
+
+  def build_facet_path(work_class)
+    "/catalog?f[human_readable_type_sim][]=#{work_class}"
+  end
+
+  def build_test_path(work_type, work_id)
+    "/concern/#{work_type}/#{work_id}"
+  end


### PR DESCRIPTION
Fixes #984 

This PR adds an XML builder and controller to Scholar 3 that does the following things:
* Collects all static urls (login page, about, doi help, etc.) in a dynamic way, in that, when adding future static pages, they will be automatically added to the sitemap, and tested for in the specs.
* Collects all publicly available resources in the application (Works/Collections)
* Builds a standard XML sitemap containing these things, displaying it from the `/sitemap.xml` route
* Bypasses Fedora entirely, allowing us to generate it on the fly per-request.

This has several improvements over the system implemented in Scholar 2 (and personally for me, a measure of professional development from two years ago till now):
* No long running nightly rake tasks
* Sitemap is updated immediately whenever a work is added, allowing for more accurate listing in search engines
* No 3rd-party gem that could introduce security vulnerabilities
* Greater support for local environments.
