### PR TITLE
Fix line breaks not displaying on works page

### DIFF
--- a/app/views/hyrax/base/_work_description.erb
+++ b/app/views/hyrax/base/_work_description.erb
@@ -1,3 +1,3 @@
 <% presenter.alt_description.each do |description| %>
-  <p class="work_description"><%= iconify_auto_link(description) %></p>
+  <%= simple_format(iconify_auto_link(description), class: 'work_description') %>
 <% end %>


### PR DESCRIPTION
Fixes #1613 

Use Rail's [`simple_format`](https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format) method to generate html tags around line breaks.

`simple_format` generates `<br>` tags for single line breaks and `<p>` tags for double breaks.

###### Changes proposed in this pull request:
* Use `simple_format` to format the description text 