### PR TITLE
Temporary fix to ArgumentError bug when adding Relationships to a work

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Lint/Debugger:
 Lint/HandleExceptions:
   Exclude:
     - 'spec/features/doi_validation_spec.rb'
+    - 'app/controllers/concerns/scholar/works_controller_behavior.rb'
 
 Metrics/LineLength:
   Max: 400

--- a/app/controllers/concerns/scholar/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholar/works_controller_behavior.rb
@@ -41,6 +41,18 @@ module Scholar
 
     private
 
+      def after_update_response
+        temp_argument_error_fix
+        super
+      end
+
+      # We added this method to fix ArgumentError (uclibs/scholar_uc#1611) bug when adding relationships to a work.
+      # Delete this method after Hyrax upgrade to 2.0.0
+      def temp_argument_error_fix
+        curation_concern.file_sets.present?
+      rescue ArgumentError
+      end
+
       def remove_infected_file_sets
         curation_concern.reload
         curation_concern.file_sets.each do |file_set|


### PR DESCRIPTION
Fixes #1611  

Though the application breaks when an existing work is updated to add a new child relationship to a work, the association does work and if we refresh the work page, we can see that is added as a child.

We get an ArgumentError when adding a relationship and this has been fixed in 2.0.0 but it is not back-ported to 1.0.4. @hortongn suggested that it is a good idea to just override the method after_update_response in app/controllers/concerns/scholar/works_controller_behavior.rb to call the same twice where in the first call, we just rescue the call to that method and bypassing ArgumentError.

Modified .rubocop.yml to bypass the "app/controllers/concerns/scholar/works_controller_behavior.rb:53:7: W: Lint/HandleExceptions: Do not suppress exceptions."