### PR TITLE
Use shared storage for temp directories on servers

### DIFF
--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -116,8 +116,8 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
-  #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
+  config.upload_path = ->() { 'bamboo_upload_path' }
+  config.cache_path = ->() {  'bamboo_cache_path' }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
@@ -133,7 +133,7 @@ Hyrax.config do |config|
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  # config.working_path = Rails.root.join( 'tmp', 'uploads')
+  config.working_path = 'bamboo_upload_path'
 
   # Should the media display partial render a download link?
   # config.display_media_download_link = true


### PR DESCRIPTION
Fixes #1619 

This will allow us to use Bamboo to set the uploads and cache paths to locations outside of the application directory.  We want these locations to be on a partition that has enough space to handle large files.
