### PR TITLE
Remove beta tag

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -196,11 +196,6 @@ div[class*="_admin_set_id"] {
    text-decoration: none;
 }
 
-.beta-tag {
-  color: #e00122;
-  font-size: 12px;
-}
-
 .people {
   margin-top: 2em;
 }
@@ -335,7 +330,6 @@ label[for=user_password] {
   .clear-button-wrapper {
     margin-top: 20px;
     position: relative;
-    right:30px;
   }
 
   .clear-button {

--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -11,7 +11,7 @@
       </button>
       <%= render '/logo' %>
       <% unless controller_name == 'homepage' %>
-        <a class="navbar-brand" href ="/"><b> | <%= image_tag 'scholar-logo.png', id: 'scholar-nav-logo', alt: 'scholar@uc' %> <span class="beta-tag">BETA</span></b></a>
+        <a class="navbar-brand" href ="/"><b> | <%= image_tag 'scholar-logo.png', id: 'scholar-nav-logo', alt: 'scholar@uc' %> </b></a>
       <% end %>
     </div>
 

--- a/app/views/layouts/scholar/_jumbotron.html.erb
+++ b/app/views/layouts/scholar/_jumbotron.html.erb
@@ -2,7 +2,7 @@
   <div class="container">
     <div class="jumbo-text">
       <div class="header-title">
-        <%= image_tag 'scholar-logo.png', id: 'jumbo-scholar-logo', alt: 'scholar@uc' %><span class="beta-tag">BETA</span>
+        <%= image_tag 'scholar-logo.png', id: 'jumbo-scholar-logo', alt: 'scholar@uc' %>
       </div>
       <div class="clear-button-wrapper">
         <div class="row visible-xs">


### PR DESCRIPTION
Fixes #1616 
Remove beta tag and associated styling.

Changes proposed in this pull request:
* Remove beta tag spans from views
* Remove associated style

![screen shot 2017-09-13 at 11 23 11 am](https://user-images.githubusercontent.com/1069588/30385790-341504d8-9876-11e7-875e-20bdc13987f4.png)

![Uploading Screen Shot 2017-09-13 at 11.25.15 AM.png…]()

