### PR TITLE
Set the number of concurrent background workers

### DIFF
--- a/config/database.yml.bamboo
+++ b/config/database.yml.bamboo
@@ -21,7 +21,7 @@ mysql_settings: &mysql_settings
   adapter:   mysql2
   encoding:  utf8
   reconnect: false
-  pool:      5
+  pool:      10
 
 local_user: &local_user
   <<: *mysql_settings

--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -25,4 +25,4 @@ $APP_DIRECTORY/script/kill_sidekiq.sh
 banner "starting Sidekiq"
 export PATH=$PATH:/srv/apps/.gem/ruby/2.4.0/bin
 cd $APP_DIRECTORY
-bundle exec sidekiq -d -q ingest -q default -q event -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT
+bundle exec sidekiq -d -c 8 -q ingest -q default -q event -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Fixes #1633 

Reduces the number of Sidekiq workers from the default 25 down to 8.  This ended up being the safe number of processes for our servers.  It matches the number of Resque workers we use for Scholar 2.x

The number of concurrent connections to our MySQL database is also increased to 10 to handle the Sidekiq workers plus our main application.

These settings were tested on scholar-qa.  Ingesting large batches ran fine without any Sidekiq errors.