### PR TITLE
Use pathname objects for upload paths

### DIFF
--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -116,8 +116,8 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  config.upload_path = ->() { 'bamboo_upload_path' }
-  config.cache_path = ->() {  'bamboo_cache_path' }
+  config.upload_path = ->() { Pathname('bamboo_upload_path') }
+  config.cache_path = ->() { Pathname('bamboo_cache_path') }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
@@ -133,7 +133,7 @@ Hyrax.config do |config|
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  config.working_path = 'bamboo_upload_path'
+  config.working_path = Pathname('bamboo_upload_path')
 
   # Should the media display partial render a download link?
   # config.display_media_download_link = true


### PR DESCRIPTION
This is a bug fix to PR #1624.  That PR set the paths for temporary uploads, but those config options need to be pathname objects instead of strings.  This PR fixes that.

I've deployed this branch to scholar-dev and tested that this change works as expected.

Assigning this to @crowesn since he merged #1624.