### PR TITLE
Turn on all ffmpeg and derivatives/tmpfile config

### DIFF
--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -153,7 +153,7 @@ Hyrax.config do |config|
   # config.model_to_create = ->(_attributes) { Hyrax.primary_work_type.model_name.name }
 
   # Path to the ffmpeg tool
-  # config.ffmpeg_path = 'ffmpeg'
+  config.ffmpeg_path = 'ffmpeg'
 
   # Max length of FITS messages to display in UI
   # config.fits_message_length = 5

--- a/config/initializers/hyrax.rb.sample
+++ b/config/initializers/hyrax.rb.sample
@@ -116,12 +116,12 @@ Hyrax.config do |config|
 
   # Temporary paths to hold uploads before they are ingested into FCrepo
   # These must be lambdas that return a Pathname. Can be configured separately
-  #  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
-  #  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
+  config.upload_path = ->() { Rails.root + 'tmp' + 'uploads' }
+  config.cache_path = ->() { Rails.root + 'tmp' + 'uploads' + 'cache' }
 
   # Location on local file system where derivatives will be stored
   # If you use a multi-server architecture, this MUST be a shared volume
-  # config.derivatives_path = Rails.root.join('tmp', 'derivatives')
+  config.derivatives_path = Rails.root.join('tmp', 'derivatives')
 
   # Should schema.org microdata be displayed?
   # config.display_microdata = true
@@ -133,7 +133,7 @@ Hyrax.config do |config|
   # Location on local file system where uploaded files will be staged
   # prior to being ingested into the repository or having derivatives generated.
   # If you use a multi-server architecture, this MUST be a shared volume.
-  # config.working_path = Rails.root.join( 'tmp', 'uploads')
+  config.working_path = Rails.root.join( 'tmp', 'uploads')
 
   # Should the media display partial render a download link?
   # config.display_media_download_link = true
@@ -153,7 +153,7 @@ Hyrax.config do |config|
   # config.model_to_create = ->(_attributes) { Hyrax.primary_work_type.model_name.name }
 
   # Path to the ffmpeg tool
-  # config.ffmpeg_path = 'ffmpeg'
+  config.ffmpeg_path = 'ffmpeg'
 
   # Max length of FITS messages to display in UI
   # config.fits_message_length = 5


### PR DESCRIPTION
Refs #1632 

The app was failing to generate and serve video derivatives in the work show media viewer.

With these changes, derivatives will now generate and play __with sidekiq running__.

Changes proposed in this pull request:
* `config/initializers/hyrax.rb.sample` uncomment ffmpeg config as well as cache, upload, and derivative directory settings
* `config/initializers/hyrax.rb.bamboo` uncomment ffmpeg config setting

To test:
* You may want to clear your tmp files and untracked config files `git clean -xdf`
* run script/load_config_local.sh
* In `config/environments/development` Line 60, enable sidekiq:  
> config.active_job.queue_adapter = ~~:inline~~ :sidekiq
