### PR TITLE
Fix video player column overlap

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,4 +1,4 @@
-  <video controls="controls" class="video-js vjs-default-skin" data-setup="{}" preload="auto">
+  <video controls="controls" class="img-responsive video-js vjs-default-skin" data-setup="{}" preload="auto">
     <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
     <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
     Your browser does not support the video tag.


### PR DESCRIPTION
Fixes #1640 

Video player was bleeding out of the column. Added img-responsive class to restrict player to column width.

Changes proposed in this pull request:
* Add img-responsive to video tag in`app/views/hyrax/file_sets/media_display/_video.html.erb`
