### PR TITLE
set version 6.6.0 for rake.ci

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -2,6 +2,7 @@
 # version: 6.0.0
 # port: 8983
 instance_dir: tmp/solr-development
+version: 6.6.0
 collection:
   persist: true
   dir: solr/config/


### PR DESCRIPTION
Fixes #1648 

Hardcode solr version 6.6.0 for rake.ci.

Changes proposed in this pull request:
* Add version 6.6.0 to `.solr_wrapper` yaml
