### PR TITLE
Solr 7 compliance

### DIFF
--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -334,12 +334,6 @@
    -->
  <uniqueKey>id</uniqueKey>
 
- <!-- field for the QueryParser to use when an explicit fieldname is absent -->
- <!--  <defaultSearchField>text</defaultSearchField> -->
-
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
- <solrQueryParser defaultOperator="OR"/>
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->


### PR DESCRIPTION
Fixes #1650 

For Solr 7 compliance, remove defaultOperator attribute.

Changes proposed in this pull request:
* Remove defaultOperator from `solr/config/schema.xml`
