### PR TITLE
SCHOLAR 2.X: Pin rails-observers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,3 +110,5 @@ gem 'omniauth-shibboleth', '1.2.1'
 gem 'feedjira', '2.1.0'
 
 gem 'rake', '11.2.2'
+
+gem 'rails-observers', '0.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: git://github.com/uclibs/hydra-remote_identifier.git
-  revision: c757c798eda1bc6d2bd847d308cf09ae36cef90b
-  branch: setting-status
+  revision: bbc060d2d054fd31225321d385cfcfd8d6e5b253
+  ref: bbc060d2d054fd31225321d385cfcfd8d6e5b253
   specs:
     hydra-remote_identifier (0.6.8)
       activesupport (>= 3.2.13, < 5.0)
@@ -53,8 +53,8 @@ GIT
 
 GIT
   remote: https://github.com/uclibs/curate.git
-  revision: 82447c79ce82036316dcba55af6343b906626c01
-  ref: 82447c79ce82036316dcba55af6343b906626c01
+  revision: 09fd89847fc397514814b546faeb4f38ea8b166f
+  ref: 09fd89847fc397514814b546faeb4f38ea8b166f
   specs:
     curate (0.6.6)
       active_attr
@@ -80,6 +80,7 @@ GIT
       rails (~> 4.0.2)
       rails_autolink
       rake (= 11.2.2)
+      resque (= 1.26.0)
       rubydora (~> 1.7.4)
       simple_form (~> 3.0.1)
       sufia-models (~> 3.4.0)
@@ -122,7 +123,7 @@ GEM
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.4)
-    activerecord-import (0.17.1)
+    activerecord-import (0.20.1)
       activerecord (>= 3.2)
     activeresource (4.1.0)
       activemodel (~> 4.0)
@@ -146,7 +147,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    backports (3.6.8)
+    backports (3.8.0)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -164,7 +165,7 @@ GEM
       sass-rails
     block_helpers (0.3.3)
       activesupport (>= 2.0)
-    bootstrap-datepicker-rails (1.6.4.1)
+    bootstrap-datepicker-rails (1.7.1.1)
       railties (>= 3.0)
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
@@ -172,7 +173,7 @@ GEM
       activesupport
       rack
     breadcrumbs_on_rails (3.0.1)
-    browser (2.3.0)
+    browser (2.5.1)
     builder (3.1.4)
     byebug (9.0.6)
     cancan (1.6.10)
@@ -183,7 +184,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    carrierwave (1.0.0)
+    carrierwave (1.1.0)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -194,7 +195,7 @@ GEM
     childprocess (0.6.1)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
-    climate_control (0.1.0)
+    climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -364,7 +365,7 @@ GEM
       rails (> 3.0.0)
     mappy (0.1.0)
       activesupport
-    marc (1.0.0)
+    marc (1.0.2)
       scrub_rb (>= 1.0.1, < 2)
       unf
     mediashelf-loggable (0.4.10)
@@ -582,7 +583,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.13)
-    stomp (1.4.3)
+    stomp (1.4.4)
     subexec (0.2.3)
     sufia-models (3.4.0)
       active-fedora (~> 6.7.0)
@@ -612,7 +613,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     vegas (0.1.11)
       rack (>= 1.0.0)
     virtus (1.0.5)
@@ -665,6 +666,7 @@ DEPENDENCIES
   poltergeist (= 1.13.0)
   quiet_assets (= 1.1.0)
   rails (= 4.0.13)
+  rails-observers (= 0.1.2)
   rake (= 11.2.2)
   resque (= 1.26.0)
   resque-scheduler (= 4.3.0)
@@ -679,4 +681,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.14.3
+   1.15.4


### PR DESCRIPTION
THIS IS FOR SCHOLAR 2.X

We need to pin down the rails-observers gem so our 2.x-stable branch can build properly.  

I don't think there's anything to test here other than making sure you can get scholar 2.x running in your local environment.  Travis has passed.  So you should be able to bundle and start the server.