### PR TITLE
Add depositor to collection show view and tweak alignment

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -54,6 +54,10 @@ div[class*="_admin_set_id"] {
   font-weight: normal;
 }
 
+.dl-horizontal dd {
+  padding-bottom: 6px;
+}
+
 .site-title h1 {
   color: #fff !important;
 }

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -21,13 +21,13 @@ module Hyrax
 
     # Metadata Methods
     delegate :title, :description, :creator, :contributor, :subject, :publisher, :keyword, :language,
-             :embargo_release_date, :lease_expiration_date, :rights, :date_created,
+             :embargo_release_date, :lease_expiration_date, :rights, :date_created, 
              :thumbnail_id, :resource_type, :based_near, :related_url, :identifier, to: :solr_document
 
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :size, :resource_type, :creator, :contributor, :keyword,
+      [:total_items, :size, :resource_type, :creator, :depositor, :contributor, :keyword,
        :rights, :publisher, :date_created, :subject, :language, :identifier,
        :based_near, :related_url]
     end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -33,6 +33,7 @@ describe 'collection', type: :feature, js: true do
       expect(page).to have_content title
       expect(page).to have_content description
       expect(page).to have_content 'User, New'
+      expect(page).to have_content "Depositor: #{User.email}"
     end
   end
 


### PR DESCRIPTION
Fixes #1629 

Add depositor field to collection show view.

Changes proposed in this pull request:
* Add :depositor to fields displayed in the collections presenter
* Tweak scholar stylesheet to adjust field alignment in collection show view
