### PR TITLE
Add submitter to collection show view

### DIFF
--- a/app/assets/stylesheets/scholar.scss
+++ b/app/assets/stylesheets/scholar.scss
@@ -196,6 +196,10 @@ div[class*="_admin_set_id"] {
    text-decoration: none;
 }
 
+.dl-horizontal dd {                                                                                                                                                         
+  padding-bottom: 6px;
+}
+
 .people {
   margin-top: 2em;
 }

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -27,7 +27,7 @@ module Hyrax
     # Terms is the list of fields displayed by
     # app/views/collections/_show_descriptions.html.erb
     def self.terms
-      [:total_items, :size, :resource_type, :creator, :contributor, :keyword,
+      [:total_items, :size, :resource_type, :creator, :contributor, :submitter, :keyword,
        :rights, :publisher, :date_created, :subject, :language, :identifier,
        :based_near, :related_url]
     end
@@ -40,11 +40,17 @@ module Hyrax
       case key
       when :size
         size
+      when :submitter
+        submitter
       when :total_items
         total_items
       else
         solr_document.send key
       end
+    end
+
+    def submitter
+      @solr_document.fetch('depositor_ssim', [])
     end
 
     def size

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::CollectionPresenter do
+  describe ".terms" do
+    subject { described_class.terms }
+
+    it do
+      is_expected.to eq [:total_items, :size, :resource_type, :creator,
+                         :contributor, :submitter, :keyword, :rights, :publisher,
+                         :date_created, :subject, :language, :identifier,
+                         :based_near, :related_url]
+    end
+  end
+
+  let(:collection) do
+    build(:collection,
+          id: 'adc12v',
+          description: ['a nice collection'],
+          based_near: ['Over there'],
+          title: ['A clever title'],
+          keyword: ['neologism'],
+          resource_type: ['Collection'],
+          related_url: ['http://example.com/'],
+          date_created: ['some date'])
+  end
+  let(:ability) { double }
+  let(:presenter) { described_class.new(solr_doc, ability) }
+  let(:solr_doc) { SolrDocument.new(collection.to_solr) }
+
+  # Mock bytes so collection does not have to be saved.
+  before { allow(collection).to receive(:bytes).and_return(0) }
+
+  describe "#resource_type" do
+    subject { presenter.resource_type }
+
+    it { is_expected.to eq ['Collection'] }
+  end
+
+  describe "#terms_with_values" do
+    subject { presenter.terms_with_values }
+
+    it do
+      is_expected.to eq [:total_items,
+                         :size,
+                         :resource_type,
+                         :keyword,
+                         :date_created,
+                         :based_near,
+                         :related_url]
+    end
+  end
+
+  describe '#to_s' do
+    subject { presenter.to_s }
+
+    it { is_expected.to eq 'A clever title' }
+  end
+
+  describe "#title" do
+    subject { presenter.title }
+
+    it { is_expected.to eq ['A clever title'] }
+  end
+
+  describe '#keyword' do
+    subject { presenter.keyword }
+
+    it { is_expected.to eq ['neologism'] }
+  end
+
+  describe "#based_near" do
+    subject { presenter.based_near }
+
+    it { is_expected.to eq ['Over there'] }
+  end
+
+  describe "#related_url" do
+    subject { presenter.related_url }
+
+    it { is_expected.to eq ['http://example.com/'] }
+  end
+
+  describe '#to_key' do
+    subject { presenter.to_key }
+
+    it { is_expected.to eq ['adc12v'] }
+  end
+
+  describe "#size", :clean_repo do
+    subject { presenter.size }
+
+    it { is_expected.to eq '0 Bytes' }
+  end
+
+  describe "#total_items", :clean_repo do
+    subject { presenter.total_items }
+
+    context "empty collection" do
+      it { is_expected.to eq 0 }
+    end
+
+    context "collection with work" do
+      skip ":total_count is not ticking up see https://github.com/uclibs/scholar_uc/issues/1671" do
+        let(:work) { create(:work, title: ['unimaginitive title']) }
+
+        before do
+          work.member_of_collections << collection
+          work.save!
+        end
+
+        it { is_expected.to eq 1 }
+      end
+    end
+
+    context "null members" do
+      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), nil) }
+
+      it { is_expected.to eq 0 }
+    end
+  end
+
+  subject { presenter }
+
+  it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
+  it { is_expected.to delegate_method(:based_near).to(:solr_document) }
+  it { is_expected.to delegate_method(:related_url).to(:solr_document) }
+  it { is_expected.to delegate_method(:identifier).to(:solr_document) }
+  it { is_expected.to delegate_method(:date_created).to(:solr_document) }
+end


### PR DESCRIPTION
Fixes #1629 

Add :submitter to collection show view.

Changes proposed in this pull request:
* Add style to collection show view metadata table
* Add depositor field and re-lable as submitter on collection show view.
