### PR TITLE
Remove trailing whitespace from user input

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -3,6 +3,7 @@ require Hyrax::Engine.root.join('app/controllers/concerns/hyrax/collections_cont
 module Hyrax
   module CollectionsControllerBehavior
     def create
+      remove_trailing_whitespace
       @collection.apply_depositor_metadata(current_user.user_key)
       add_members_to_collection unless batch.empty?
       if @collection.save
@@ -36,6 +37,7 @@ module Hyrax
     end
 
     def update
+      remove_trailing_whitespace
       process_member_changes
       if @collection.update(collection_params.except(:members))
         after_update
@@ -59,6 +61,18 @@ module Hyrax
     end
 
     private
+
+      def remove_trailing_whitespace
+        params[:collection].each do |key, value|
+          if value.class == Array
+            value.each_index do |idx|
+              value[idx] = value[idx].rstrip if value[idx].respond_to? :rstrip
+            end
+          elsif value.respond_to? :rstrip
+            params[:collection][key] = value.rstrip
+          end
+        end
+      end
 
       def fetch_collection_avatar
         CollectionAvatar.find_by(collection_id: collection.id)

--- a/app/controllers/concerns/scholar/works_controller_behavior.rb
+++ b/app/controllers/concerns/scholar/works_controller_behavior.rb
@@ -12,6 +12,7 @@ module Scholar
     end
 
     def create
+      remove_trailing_whitespace
       super
       # the to_s_u method must be implemented for every model
       editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
@@ -23,6 +24,7 @@ module Scholar
     end
 
     def update
+      remove_trailing_whitespace
       super
       # the to_s_u method must be implemented for every model
       editors = params.to_unsafe_hash[curation_concern.class.to_s_u][:permissions_attributes]
@@ -40,6 +42,20 @@ module Scholar
     end
 
     private
+
+      def remove_trailing_whitespace
+        concern_type = curation_concern.class.to_s_u
+
+        params[concern_type].each do |key, value|
+          if value.class == Array
+            value.each_index do |idx|
+              value[idx] = value[idx].rstrip if value[idx].respond_to? :rstrip
+            end
+          elsif value.respond_to? :rstrip
+            params[concern_type][key] = value.rstrip
+          end
+        end
+      end
 
       def after_update_response
         temp_argument_error_fix

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -19,7 +19,7 @@ shared_examples 'work creation' do |work_class| # apply underscore for snake cas
     # checking for work creator auto-fill and also filling it in
 
     title_element = find_by_id("#{work_type}_title")
-    title_element.set("My Test Work")
+    title_element.set("My Test Work  ") # Add whitespace to test it getting removed
 
     college_element = find_by_id("#{work_type}_college")
     college_element.select("Business")


### PR DESCRIPTION
Fixes #871

Remove trailing whitespace from user input before saving it. This is applied to works and collections.

###### Changes proposed in this pull request:
* Remove trailing whitespace from user input