### PR TITLE
fix routing from contribute button to proper login form

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,15 +14,20 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  before_action :store_current_location, unless: :devise_controller?
+
+  before_action :store_current_location
 
   private
+
+    def auth_shib_user!
+      redirect_to login_path unless user_signed_in?
+    end
 
     # override devise helper and route to CC.new when parameter is set
     def after_sign_in_path_for(_resource)
       cookies[:login_type] = "local"
       return root_path unless parameter_set?
-      route_to_classify_concerns_path
+      route_to_correct_path
     end
 
     def after_sign_out_path_for(_resource_or_scope)
@@ -33,17 +38,16 @@ class ApplicationController < ActionController::Base
       end
     end
 
-    # store paramater in request
-    def store_current_location
-      store_location_for(:user, request.url)
+    # these are empty by default. implement these methods to change routing functionality after sign up
+    # per controller. see hyrax/homepages_controller.rb in the app for an example
+
+    def route_to_correct_path
+      new_classify_concern_path
     end
+
+    def store_current_location; end
 
     def parameter_set?
-      return false if session['user_return_to'].nil?
-      session['user_return_to'].include? '/classify_concerns/new'
-    end
-
-    def route_to_classify_concerns_path
-      session['user_return_to']
+      session['user_return_to'] == '/'
     end
 end

--- a/app/controllers/classify_concerns_controller.rb
+++ b/app/controllers/classify_concerns_controller.rb
@@ -2,7 +2,7 @@
 class ClassifyConcernsController < ApplicationController
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
-  before_action :authenticate_user!
+  before_action :auth_shib_user!
   load_and_authorize_resource
 
   add_breadcrumb 'Submit a work', (->(controller) { controller.request.path })

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class Hyrax::HomepageController < ApplicationController
+  include Hyrax::HomepageControllerBehavior
+
+  private
+
+    # store paramater in request
+    def store_current_location
+      store_location_for(:user, '/')
+    end
+end

--- a/spec/controllers/classify_concerns_controller_spec.rb
+++ b/spec/controllers/classify_concerns_controller_spec.rb
@@ -9,7 +9,7 @@ describe ClassifyConcernsController, type: :controller do
   describe '#new' do
     it 'requires authentication' do
       get :new
-      expect(response).to redirect_to(main_app.user_session_path)
+      expect(response).to redirect_to(login_path)
     end
     it 'renders when signed in' do
       sign_in(user)
@@ -22,7 +22,7 @@ describe ClassifyConcernsController, type: :controller do
     context 'without logging in' do
       it 'redirect to login page if user is not logged in' do
         post :create, params: { classify: { curation_concern_type: 'GenericWork' } }
-        expect(response).to redirect_to(main_app.user_session_path)
+        expect(response).to redirect_to(login_path)
       end
     end
 

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'the homepage', type: :feature do
     end
     it 'redirects the user to the new work landing page after sign in' do
       click_on 'contribute'
+      click_on 'log in using a local account'
       within '.new_user' do
         fill_in('Email', with: user.email)
         fill_in('Password', with: user.password)


### PR DESCRIPTION
Fixes #1664 

Fiddles with devise routing behavior. Ensures that a user is redirected to the shib form when they click 'contribute' while not authenticated.