### PR TITLE
Removes Dropbox and Google providers.

### DIFF
--- a/config/browse_everything_providers.yml
+++ b/config/browse_everything_providers.yml
@@ -3,15 +3,9 @@
 # The file_system provider can be a path to any directory on the server where your application is running.
 #
 ---
- dropbox:
-   :app_key: bamboo_browse_everything_dropbox_id
-   :app_secret: bamboo_browse_everything_dropbox_secret
  box:
    :client_id: bamboo_browse_everything_box_id
    :client_secret: bamboo_browse_everything_box_secret
- google_drive:
-   :client_id: bamboo_browse_everything_gdrive_id
-   :client_secret: bamboo_browse_everything_gdrive_secret
  kaltura:
    :partner_id: bamboo_browse_everything_kaltura_id
    :administrator_secret: bamboo_browse_everything_kaltura_secret


### PR DESCRIPTION
Fixes #1670, Fixes #1675 

We need to remove both of these providers until their APIs and ruby libraries stabilize.

