### PR TITLE
Don't add avatar link when user avatar is nil

### DIFF
--- a/app/views/hyrax/users/index.html.erb
+++ b/app/views/hyrax/users/index.html.erb
@@ -16,14 +16,17 @@
     <tbody>
         <% @users.each do |user| %>
             <tr>
-              <td><%= link_to hyrax.profile_path(user) do %>
-                    <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+              <td>
+                <% if user.avatar.file %>
+                  <%= link_to hyrax.profile_path(user) do %>
+                    <%= image_tag(user.avatar.url(:thumb), width: 30) %>
                   <% end %>
+                <% end %>
               </td>
-               <td><%= link_to user.name, hyrax.profile_path(user) %></td>
-               <td><%= link_to user.user_key, hyrax.profile_path(user) %></td>
-               <td><%= user.department %></td>
-               <td><%= number_of_works(user) %></td>
+              <td><%= link_to user.name, hyrax.profile_path(user) %></td>
+              <td><%= link_to user.user_key, hyrax.profile_path(user) %></td>
+              <td><%= user.department %></td>
+              <td><%= number_of_works(user) %></td>
             </tr>
          <% end %>
     </tbody>


### PR DESCRIPTION
Fixes #1683

To prevent adding an empty link to the page, check if avatar is nil before creating the link

Changes proposed in this pull request:
* Add avatar nil check before creating link rather than while adding content to link 
