### PR TITLE
Add screen reader text to cellection thumbnail

### DIFF
--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -3,7 +3,8 @@
         <% if CollectionAvatar.find_by(collection_id: document.id) != nil %>
           <%= image_tag CollectionAvatar.find_by(collection_id: document.id).avatar.url(:medium) %>
         <% else %>
-          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
+          <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search" aria-hidden="true" title="collection"></span>
+          <span class="sr-only">Collection</span>
         <% end %>
       <% end %>
     </div>

--- a/app/views/hyrax/collections/_media_display.html.erb
+++ b/app/views/hyrax/collections/_media_display.html.erb
@@ -1,5 +1,6 @@
 <% if @collection_avatar.nil? %>
-  <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search"></span>
+  <span class="<%= Hyrax::ModelIcon.css_class_for(Collection) %> collection-icon-search" aria-hidden="true" title="collection"></span>
+  <span class="sr-only">Collection</span>
 <% else %>
   <%= image_tag @collection_avatar.avatar.url(:medium), class: 'collection-avatar' %>
 <% end %>


### PR DESCRIPTION
Fixes #1688

Added text to the default collection thumbnails so that screen readers can tell users what the link does. 

The text just says `collection` which is consistent with how we are doing this for works (just adding the word `work`)
