### PR TITLE
Connect label and search field on collection view

### DIFF
--- a/app/views/hyrax/collections/_search_form.html.erb
+++ b/app/views/hyrax/collections/_search_form.html.erb
@@ -1,0 +1,11 @@
+  <%= form_for presenter, method: :get, class: "well form-search" do |f| %>
+      <label for="collection_search" class="sr-only"><%= t('hyrax.collections.search_form.label', title: presenter.to_s) %></label>
+      <div class="input-group">
+        <%= text_field_tag :cq, params[:cq], class: "collection-query form-control", placeholder: t('hyrax.collections.search_form.placeholder'), size: '30', type: "search", id: "collection_search" %>
+        <div class="input-group-btn">
+          <button type="submit" class="btn btn-primary" id="collection_submit"><i class="glyphicon glyphicon-search"></i> Go</button>
+        </div>
+      </div>
+      <%= hidden_field_tag :sort, params[:sort], id: 'collection_sort' %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:cq, :sort, :qt, :page)) %>
+  <% end %>


### PR DESCRIPTION
Fixes #1690 

There was a `sr-only` label for the search bar but the were not explicitly connected for the screen reader to truly know what is was reading  

Changes proposed in this pull request:
* Add an attribute to the label for the search bar on the collection view page
