### PR TITLE
Add screen reader text to rights links

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require Hyrax::Engine.root.join('app/helpers/hyrax/hyrax_helper_behavior.rb')
+module Hyrax
+  module HyraxHelperBehavior
+    # Uses Rails auto_link to add links to fields
+    #
+    # @param field [String,Hash] string to format and escape, or a hash as per helper_method
+    # @option field [SolrDocument] :document
+    # @option field [String] :field name of the solr field
+    # @option field [Blacklight::Configuration::IndexField, Blacklight::Configuration::ShowField] :config
+    # @option field [Array] :value array of values for the field
+    # @param show_link [Boolean]
+    # @return [ActiveSupport::SafeBuffer]
+    # @todo stop being a helper_method, start being part of the Blacklight render stack?
+    def iconify_auto_link(field, show_link = true)
+      if field.is_a? Hash
+        options = field[:config].separator_options || {}
+        text = field[:value].to_sentence(options)
+      else
+        text = field
+      end
+      # this block is only executed when a link is inserted;
+      # if we pass text containing no links, it just returns text.
+      auto_link(html_escape(text)) do |value|
+        if show_link
+          "<span class='glyphicon glyphicon-new-window'></span>#{('&nbsp;' + value)}"
+        else
+          %(<span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
+            <span class="sr-only">#{value}</span>)
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -151,4 +151,44 @@ describe HyraxHelper, type: :helper do
       expect(helper.user_department(other_object)).to eq("Marketing")
     end
   end
+
+  describe "#iconify_auto_link" do
+    let(:text)              { 'Foo < http://www.example.com. & More text' }
+    let(:linked_text)       { "Foo &lt; <a href=\"http://www.example.com\"><span class=\"glyphicon glyphicon-new-window\"></span> http://www.example.com</a>. &amp; More text" }
+    let(:document)          { SolrDocument.new(has_model_ssim: ['GenericWork'], id: 512, title_tesim: text, description_tesim: text) }
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    before do
+      allow(controller).to receive(:action_name).and_return('index')
+      allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+    end
+    it "boring String argument" do
+      expect(helper.iconify_auto_link('no escapes or links necessary')).to eq 'no escapes or links necessary'
+      expect(helper.iconify_auto_link('no escapes or links necessary', false)).to eq 'no escapes or links necessary'
+    end
+    context "interesting String argument" do
+      subject { helper.iconify_auto_link(text) }
+      it "escapes input" do
+        expect(subject).to start_with('Foo &lt;').and end_with('. &amp; More text')
+      end
+      it "adds links" do
+        expect(subject).to include('<a href="http://www.example.com">')
+      end
+      it "adds icons" do
+        expect(subject).to include('class="glyphicon glyphicon-new-window"')
+      end
+    end
+
+    context "when using a hash argument" do
+      subject { helper.iconify_auto_link(arg) }
+      describe "auto-linking in the title" do
+        let(:arg) { { document: document, value: [text], config: blacklight_config.index_fields['title_tesim'], field: 'title_tesim' } }
+        it { is_expected.to eq(linked_text) }
+      end
+
+      describe "auto-linking in the description" do
+        let(:arg) { { document: document, value: [text], config: blacklight_config.index_fields['description_tesim'], field: 'description_tesim' } }
+        it { is_expected.to eq(linked_text) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1689

On the collection view page there was a glyphicon with a link to view the license text. The glyphicon was the only content on the link and there was no text for a screen reader to tell a user what the link was.

Changes proposed in this pull request:
*  Add `sr-only` text to links generated with `iconify_auto_link` with no text
