### PR TITLE
Add content freeze message to 404 page

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -54,6 +54,20 @@
 The page you are looking for may have been removed, had its name changed, or is temporarily unavailable.
 </p>
 
+<h2>Temporary Content Freeze</h2>
+<p>
+  In preparation for a major upgrade to Scholar@UC, we have temporarily put all content in view-only mode in order to ensure your data stays consistent through the upgrade.<br>
+  While Scholar@UC is in view-only mode, users will not be able to:
+  <ul>
+    <li>Create or edit works</li>
+    <li>Create or edit collections</li>
+    <li>Create or edit groups</li>
+    <li>Edit their profile page</li>
+  </ul>
+  Users that have never logged into Scholar@UC in the past will not be able to log in while the site is in view-only mode.
+  <br><br>
+  If you feel this does not apply to the page you are trying to access, please try the tips below.
+</p>
 <h2>Please try the following:</h2>
 <ul>
   <li>If you typed the page address in the Address bar, make sure that it is spelled correctly. </li>

--- a/public/404.html
+++ b/public/404.html
@@ -42,6 +42,31 @@
 </header>
 
 <div id="main" role="main" class="container ">
+
+    <!-- Content Freeze message -->
+
+    <div class="help-alert" role="alert">
+
+        <h2 style="color:#c09853">Temporary Content Freeze!</h2>
+
+      <p>
+        In preparation for a major upgrade to Scholar@UC, we have temporarily put all content in view-only mode in order to ensure your data stays consistent through the upgrade.<br>
+        While Scholar@UC is in view-only mode, users will not be able to:
+      </p>
+      <ul>
+        <li>Create or edit works</li>
+        <li>Create or edit collections</li>
+        <li>Create or edit groups</li>
+        <li>Edit their profile page</li>
+      </ul>
+      Users that have never logged into Scholar@UC in the past will not be able to log in while the site is in view-only mode.
+      <br><br>
+      <p>If you feel this does not apply to the page you are trying to access, please try the tips below.</p>
+        
+    </div>
+
+    <!-- End Content Freeze message -->
+
     <div class="row">
       <div class="span12 main-header ">
           <h1>Page Not Found</h1>
@@ -54,20 +79,6 @@
 The page you are looking for may have been removed, had its name changed, or is temporarily unavailable.
 </p>
 
-<h2>Temporary Content Freeze</h2>
-<p>
-  In preparation for a major upgrade to Scholar@UC, we have temporarily put all content in view-only mode in order to ensure your data stays consistent through the upgrade.<br>
-  While Scholar@UC is in view-only mode, users will not be able to:
-  <ul>
-    <li>Create or edit works</li>
-    <li>Create or edit collections</li>
-    <li>Create or edit groups</li>
-    <li>Edit their profile page</li>
-  </ul>
-  Users that have never logged into Scholar@UC in the past will not be able to log in while the site is in view-only mode.
-  <br><br>
-  If you feel this does not apply to the page you are trying to access, please try the tips below.
-</p>
 <h2>Please try the following:</h2>
 <ul>
   <li>If you typed the page address in the Address bar, make sure that it is spelled correctly. </li>


### PR DESCRIPTION
Fixes #1694 
Adds text explaining the temporary content freeze to the 404 page.