### PR TITLE
Set path for LibreOffice in server environments

### DIFF
--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -79,7 +79,7 @@ Hyrax.config do |config|
   # config.fits_path = "fits.sh"
 
   # Path to the file derivatives creation tool
-  # config.libreoffice_path = "soffice"
+  config.libreoffice_path = "/opt/libreoffice5.4/program/soffice"
 
   # How many seconds back from the current time that we should show by default of the user's activity on the user's dashboard
   # config.activity_to_show_default_seconds_since_now = 24*60*60


### PR DESCRIPTION
We need to set the path to LibreOffice in the hyrax.rb initializer.  The servers are not finding the soffice executable without setting this.