### PR TITLE
Indexes journal_title correctly and removes source from show view.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -70,7 +70,7 @@ class SolrDocument
 
   # Added for Article Work Type
   def journal_title
-    self[Solrizer.solr_name('alternate_title')]
+    self[Solrizer.solr_name('journal_title')]
   end
 
   def issn

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -9,7 +9,6 @@
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim') %>
 <%= presenter.attribute_to_html(:alt_date_created, render_as: :faceted, label: "Date Created") %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link) %>
-<%= presenter.attribute_to_html(:source) %>
 <%= presenter.attribute_to_html(:alternate_title) %>
 <%= presenter.attribute_to_html(:journal_title) %>
 <%= presenter.attribute_to_html(:issn) %>

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -14,8 +14,6 @@ shared_examples 'submission form with form#fileupload' do |work_class|
 
   it "has metadata" do
     expect(page).to have_selector 'h1', text: 'Magnificent splendor'
-    expect(page).to have_selector 'li', text: 'The Internet'
-    expect(page).to have_selector 'th', text: 'Source'
 
     # Displays FileSets already attached to this work
     within '.related-files' do
@@ -34,8 +32,6 @@ shared_examples 'submission form without form#fileupload' do |work_class|
 
   it "has metadata" do
     expect(page).to have_selector 'h1', text: 'Magnificent splendor'
-    expect(page).to have_selector 'li', text: 'The Internet'
-    expect(page).to have_selector 'th', text: 'Source'
 
     # Doesn't have the upload form for uploading more files
     expect(page).not_to have_selector "form#fileupload"

--- a/spec/views/hyrax/base/_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_attributes.html.erb_spec.rb
@@ -6,6 +6,7 @@ describe 'hyrax/base/_attributes.html.erb' do
   let(:department) { 'Digital Repositories' }
   let(:related_url) { 'http://www.uc.edu' }
   let(:submitter) { FactoryGirl.create(:user) }
+  let(:journal_title) { 'UC Journal' }
 
   let(:solr_document) { SolrDocument.new(attributes) }
   let(:attributes) do
@@ -14,7 +15,8 @@ describe 'hyrax/base/_attributes.html.erb' do
       college_tesim: college,
       department_tesim: department,
       related_url_tesim: related_url,
-      depositor_tesim: submitter.email
+      depositor_tesim: submitter.email,
+      journal_title_tesim: journal_title
     }
   end
   let(:ability) { nil }


### PR DESCRIPTION
Fixes #1698 

Present short summary (50 characters or less)

This PR correctly indexes journal_title and removes the unnecessary source field from the work show view.

