### PR TITLE
Adds faceting to geo_subject on work show, and adds the label for the field

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -17,7 +17,7 @@
 <%= presenter.attribute_to_html(:required_software) %>
 <%= presenter.attribute_to_html(:note) %>
 <%= presenter.attribute_to_html(:genre) %>
-<%= presenter.attribute_to_html(:geo_subject) %>
+<%= presenter.attribute_to_html(:geo_subject, render_as: :faceted, label: "Geographic Subject") %>
 <%= presenter.attribute_to_html(:degree) %>
 <%= presenter.attribute_to_html(:advisor) %>
 <%= presenter.attribute_to_html(:committee_member) %>

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -10,7 +10,6 @@ en:
     labels:
       generic_work:
         geo_subject:      "Geographic Subject"
-        geo_subject:       "Geographic Location"
         alt_description:      "Description"
         alt_date_created:     "Date Created"
         related_url:      "External Link"


### PR DESCRIPTION
closes #1725 

Adds faceting and adds label (previously was showing as "Geo subject:")