### PR TITLE
change lib path from autoload to eager_load

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module ScholarUc
     config.exceptions_app = self.routes
 
     config.application_root_url = 'http://localhost:3000'
-    config.autoload_paths << Rails.root.join('lib')
+    config.eager_load_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join('services')
     config.autoload_paths << Rails.root.join('jobs')
   end


### PR DESCRIPTION
closes #1723 

For some reason, autoload_paths wasn't making this the `lib/scholar.rb` module accessible. It's working with the change to eager_load_paths.