### PR TITLE
Add the 'change' queue to Sidekiq process

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -25,4 +25,4 @@ $APP_DIRECTORY/script/kill_sidekiq.sh
 banner "starting Sidekiq"
 export PATH=$PATH:/srv/apps/.gem/ruby/2.4.0/bin
 cd $APP_DIRECTORY
-bundle exec sidekiq -d -c 8 -q ingest -q default -q event -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT
+bundle exec sidekiq -d -c 8 -q ingest -q default -q event -q change -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Fixes #1732

When Sidekiq is started or restarted, it will now process jobs in the `change` queue as well.