### PR TITLE
Allow Bamboo variables for MySQL database name and username

### DIFF
--- a/config/database.yml.bamboo
+++ b/config/database.yml.bamboo
@@ -26,17 +26,17 @@ mysql_settings: &mysql_settings
 local_user: &local_user
   <<: *mysql_settings
   <<: *mysql_connection
-  username: curate
+  username: bamboo_mysql_username
   password: bamboo_mysql_password
 
 development:
   <<: *local_user
-  database: curate
+  database: bamboo_mysql_database
   host: bamboo_mysql_host
   timeout: 5000
 
 production:
   <<: *local_user
-  database: curate
+  database: bamboo_mysql_database
   host: bamboo_mysql_host
   timeout: 5000


### PR DESCRIPTION
We need to start using Bamboo variables for the MySQL database name and the username so we can start to move away from "curate" and start using something like "scholar"
