### PR TITLE
Add bamboo files for analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,9 +1,9 @@
 #
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
-# analytics:
-#   app_name: GOOGLE_OAUTH_APP_NAME
-#   app_version: GOOGLE_OAUTH_APP_VERSION
-#   privkey_path: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-#   privkey_secret: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-#   client_email: GOOGLE_OAUTH_CLIENT_EMAIL
+analytics:
+  app_name: Scholar@UC
+  app_version: 3.0
+  privkey_path: bamboo_analytics_privkey_path
+  privkey_secret: bamboo_analytics_privkey_secret
+  client_email: bamboo_analytics_client_email

--- a/config/analytics.yml.bamboo
+++ b/config/analytics.yml.bamboo
@@ -1,0 +1,9 @@
+#
+# To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
+#
+analytics:
+  app_name: Scholar@UC
+  app_version: 3.0
+  privkey_path: bamboo_analytics_privkey_path
+  privkey_secret: bamboo_analytics_privkey_secret
+  client_email: bamboo_analytics_client_email

--- a/config/analytics.yml.bamboo
+++ b/config/analytics.yml.bamboo
@@ -1,9 +1,0 @@
-#
-# To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
-#
-analytics:
-  app_name: Scholar@UC
-  app_version: 3.0
-  privkey_path: bamboo_analytics_privkey_path
-  privkey_secret: bamboo_analytics_privkey_secret
-  client_email: bamboo_analytics_client_email

--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -36,15 +36,15 @@ Hyrax.config do |config|
   # Enable displaying usage statistics in the UI
   # Defaults to false
   # Requires a Google Analytics id and OAuth2 keyfile.  See README for more info
-  # config.analytics = false
+  config.analytics = true
 
   # Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
+  config.google_analytics_id = 'bamboo_google_analytics_id'
 
   # Date you wish to start collecting Google Analytic statistics for
   # Leaving it blank will set the start date to when ever the file was uploaded by
   # NOTE: if you have always sent analytics to GA for downloads and page views leave this commented out
-  # config.analytic_start_date = DateTime.new(2014, 9, 10)
+  config.analytic_start_date = DateTime.new(2017, 10, 31)
 
   # Enables a link to the citations page for a work
   # Default is false


### PR DESCRIPTION
fixes #1065 

Adds a bamboo file from configuring google analytics and update the hyrax config to enable analytics

Changes proposed in this pull request:
* Add bamboo file to set google analytics config options
* Change config options in `hyrax.rb.bamboo` to enable analytics
