### PR TITLE
correct tinymce display

### DIFF
--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -7,7 +7,7 @@
 <div class="row home-content">
   <%= render 'layouts/scholar/home_content' %>
 </div>
-<%= tinymce_assets if can? :update, ContentBlock%>
+<%= tinymce if can? :update, ContentBlock %>
 
 <%= render 'layouts/scholar/links' %>
 


### PR DESCRIPTION
closes #1717 

Changed the tag from one which adds the js include, to one that actually initializes the editor and loads our config.