### PR TITLE
Remove user join date from User Profile page

### DIFF
--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -1,0 +1,14 @@
+<div class="list-group-item">
+  <span class="badge"><%= number_of_collections(user) %></span>
+  <span class="glyphicon glyphicon-folder-open"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.collections"), generic_type: "Collection") %>
+</div>
+
+<div class="list-group-item">
+  <span class="badge"><%= number_of_works(user) %></span>
+  <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
+
+  <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
+      <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
+  </ul>
+</div>


### PR DESCRIPTION
Fixes #1736 

Override Vitals view to remove the user join date field from user profile.

**Before**:
![image](https://user-images.githubusercontent.com/2188493/33033631-10536a82-cdf3-11e7-8218-5da53adc8073.png)

**After**:
![screen shot 2017-11-20 at 1 01 46 pm](https://user-images.githubusercontent.com/2188493/33033649-22ff925a-cdf3-11e7-8415-d60ebef64f72.png)

