### PR TITLE
Adjust rotate_log.sh for new log locations

### DIFF
--- a/script/rotate_log.sh
+++ b/script/rotate_log.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-# Move the logs file to a new directory so it isn't lost during deploy
-
-file_name=/srv/apps/curate_uc/log/production.log
+hostname=$1
+file_name=/mnt/common/scholar-logs/${hostname}_production.log
 current_time=$(date "+%Y.%m.%d-%H.%M.%S")
-new_fileName=/srv/apps/curate_uc-logs/production.log.$current_time
+new_fileName=/mnt/common/scholar-logs/${hostname}_archive/${hostname}_production.log.$current_time
 
 if [ -f $file_name ];
 then
@@ -12,10 +11,12 @@ then
   # Move the log file to a new directory and add timestamp
   mv $file_name $new_fileName
 
+  # Restart the app and generate a blank log file
+  touch $file_name
+  touch /srv/apps/curate_uc/tmp/restart.txt
+  
   # Compress the moved log file
   gzip $new_fileName
 
 fi
 
-# Restart the app and generate a blank log file
-touch /srv/apps/curate_uc/tmp/restart.txt


### PR DESCRIPTION
Fixes #1657 

The production log files on QA and production servers have been moved to Isilon shares.  So this rotate_log.sh script needs to be adjusted to use those new paths.

FYI, log/production.log and log/sidekiq.log are now just symlinks to files in /mnt/common/scholar-logs.  The application *thinks* it's still writing logs to the same place, but they are actually residing on the shared Isilon drive.
