### PR TITLE
Add Fits path to Sidekiq process

### DIFF
--- a/script/restart_sidekiq.sh
+++ b/script/restart_sidekiq.sh
@@ -24,5 +24,7 @@ $APP_DIRECTORY/script/kill_sidekiq.sh
 
 banner "starting Sidekiq"
 export PATH=$PATH:/srv/apps/.gem/ruby/2.4.0/bin
+export FITS_HOME=/opt/fits/fits
+export PATH=$PATH:/opt/fits/fits
 cd $APP_DIRECTORY
 bundle exec sidekiq -d -c 8 -q ingest -q default -q event -q change -L log/sidekiq.log -C config/sidekiq.yml -e $ENVIRONMENT


### PR DESCRIPTION
Fixes #1772 

Adds the Fits path to `script/restart_sidekiq.sh` so the Sidekiq process can find Fits.