### PR TITLE
Disable filtering of users (performance problems)

### DIFF
--- a/app/controllers/hyrax/users_controller.rb
+++ b/app/controllers/hyrax/users_controller.rb
@@ -28,7 +28,11 @@ module Hyrax
     protected
 
       def base_query
-        filter_users_page(filter_unless_user_is_admin(exclude_admin_users_and_non_owners))
+        # filter_users_page(filter_unless_user_is_admin(exclude_admin_users_and_non_owners))
+
+        # Temporary change to fix performance issue with users search
+        # *ALL* users will be displayed
+        [nil]
       end
 
       def filter_users_page(query)

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -68,9 +68,10 @@ describe "User Profile", type: :feature do
 
     context "when the user doesn't own works" do
       it 'does not include the user in the display' do
+        skip # Feature is temporarily disabled
         visit profile_path
         click_link 'View People'
-        expect(page).not_to have_xpath("//td/a[@href='#{profile_path}']")
+        expect(page).not_to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
       end
     end
 


### PR DESCRIPTION
Temporarily takes care of #1775 and #1776 

(This has already been deployed as an emergency change on production)

This disables the filters we put in place to hide users who don't own content.  Performance is back to normal for now.  A permanent refactor is in the works.