### PR TITLE
Add script to delete old temporary uploaded files

### DIFF
--- a/script/delete_old_temp_uploads.sh
+++ b/script/delete_old_temp_uploads.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+UPLOADS_DIRECTORY=/mnt/common/scholar-temp-uploads/hyrax/uploaded_file/file
+MAXIMUM_DAYS_TO_KEEP_FILES=30
+
+find $UPLOADS_DIRECTORY/* -maxdepth 0 -type d -ctime +$MAXIMUM_DAYS_TO_KEEP_FILES -exec rm -rf {} \;


### PR DESCRIPTION
Fixes #1779 

This script will delete any directories older than 30 days from the temporary uploads folder in our server environments.

After this is deployed, we can add a cron job that runs this nightly.

I've already tested this script in our QA environment.