### PR TITLE
Improve work relationship UX

### DIFF
--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -1,0 +1,7 @@
+<h2><%= t("hyrax.works.form.in_collections") %></h2>
+<div id="collection-widget">
+  <%= f.input :member_of_collection_ids,
+              as: :select,
+              collection: f.object.collections_for_select,
+              input_html: { class: 'form-control', multiple: true } %>
+</div>

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -1,4 +1,5 @@
 <h2><%= t("hyrax.works.form.in_collections") %></h2>
+<p>To select or de-select one or more collections, hold Control or Command while clicking.</p>
 <div id="collection-widget">
   <%= f.input :member_of_collection_ids,
               as: :select,


### PR DESCRIPTION
Fixes #1765 

Adds help text to the relationships tab of the edit work page.

Changes proposed in this pull request:
* Adds override of `_form_member_of_collections.html.erb`
* Adds help text to assist users in managing their works in collections
* 
