### PR TITLE
Add script to check status of sidekiq queue

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'sidekiq/web'
+require 'sidekiq/api'
 Rails.application.routes.draw do
   resources :collection_avatars
   resource :featured_collection, only: [:create, :destroy]
@@ -54,6 +55,18 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all
   match '/422', to: 'errors#unprocessable', via: :all
   match '/500', to: 'errors#server_error', via: :all
+
+  # Routes for sidekiq monitoring
+  match "queue-status" => proc {
+    [200,
+     { "Content-Type" => "text/plain" },
+     [Sidekiq::Queue.new.size.to_s]]
+  }, via: :get
+  match "queue-latency" => proc {
+    [200,
+     { "Content-Type" => "text/plain" },
+     [Sidekiq::Queue.new.latency.to_s]]
+  }, via: :get
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
     concerns :exportable

--- a/script/sidekiq_monitor.sh
+++ b/script/sidekiq_monitor.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+HOSTNAME=$( hostname )
+
+BACKLOG_MAX=100 # Number of allowed jobs in queue before warning is sent
+LATENCY_MAX=2000  # Amount of time (in seconds) between when the oldest job was enqueued and the current time before a warning is sent
+
+BACKLOG=$( curl -s http://${HOSTNAME}.private/queue-status )
+TEMP=$( curl -s http://${HOSTNAME}.private/queue-latency )
+LATENCY=${TEMP%.*}
+
+if [ $BACKLOG -gt $BACKLOG_MAX ] && [ $LATENCY -gt $LATENCY_MAX ]; then
+  mail -s "Scholar Sidekiq Backlog/Latency warning" scholar@uc.edu <<< "The web server ${HOSTNAME} currently has a sidekiq backlog of ${BACKLOG} and a latency of ${LATENCY}. Your desired maximums for these values are BACKLOG: ${BACKLOG_MAX} and LATENCY: ${LATENCY_MAX}"
+elif [ $BACKLOG -gt $BACKLOG_MAX ]; then
+  mail -s "Scholar Sidekiq Backlog warning" scholar@uc.edu <<< "The web server ${HOSTNAME} currently has a sidekiq backlog of ${BACKLOG} which is above your desired ${BACKLOG_MAX} maximum. To assist in troubleshooting the sidekiq latency currently is ${LATENCY} seconds."
+  echo "BACKLOG ${BACKLOG}"
+elif [ $LATENCY -gt $LATENCY_MAX ]; then
+  mail -s "Scholar Sidekiq Latency warning" scholar@uc.edu <<< "The web server ${HOSTNAME} currently has a sidekiq latency of ${LATENCY} which is above your desired maximum latency of ${LATENCY_MAX}. To assist in troubleshooting the sidekiq backlog is currently ${BACKLOG} jobs." 
+fi


### PR DESCRIPTION
Fixes #1743

Adds rails routes to get basic queue information from sidekiq then send a warning email if the queue has too many job backed up or has jobs stuck in the queue

the script can simply be run by `bash script/sidekiq_monitor.sh`

Changes proposed in this pull request:
* Adds two routes to the application to get backlog and latency information from sidekiq
* Send a warning message to scholar@uc.edu if either or both values are high
