### PR TITLE
Add College to department in user index

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,11 @@ class User < ApplicationRecord
     ucdepartment
   end
 
+  def full_department
+    return college if department == "Unknown"
+    "#{college}: #{department}"
+  end
+
   private
 
     def user_colleges

--- a/app/views/hyrax/users/index.html.erb
+++ b/app/views/hyrax/users/index.html.erb
@@ -9,7 +9,7 @@
             <th scope="col">Avatar</th>
             <th class="sorts" scope="col"><i id="name" class="<%=params[:sort].blank? ? 'caret up' : params[:sort]== "name desc" ? 'caret' : params[:sort]== "name" ? 'caret up' : ''%>"></i> User Name</th>
             <th class="sorts" scope="col"><i id="login" class="<%=params[:sort]== "login desc" ? 'caret' : params[:sort]== "login" ? 'caret up' : ''%>"></i> User Id</th>
-            <th class="sorts" scope="col"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> Department</th>
+            <th class="sorts" scope="col"><i id="department" class="<%=params[:sort]== "department desc" ? 'caret' : params[:sort]== "department" ? 'caret up' : ''%>"></i> College & Department</th>
             <th scope="col">Works Created</th>
         </tr>
     </thead>
@@ -26,7 +26,7 @@
             </td>
             <td><%= link_to user.name, hyrax.profile_path(user) %></td>
             <td><%= link_to user.user_key, hyrax.profile_path(user) %></td>
-            <td><%= user.department %></td>
+            <td><%= user.full_department %></td>
             <td><%= number_of_works(user) %></td>
 	  </tr>
 	<% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -166,4 +166,29 @@ describe User do
       end
     end
   end
+
+  describe "college and department" do
+    subject { described_class.new }
+
+    context "when the user doesn't have a department" do
+      it "returns Other" do
+        subject.ucdepartment = nil
+        expect(subject.full_department).to eq "Other"
+      end
+    end
+
+    context "when the user has a department that starts with a college abbreviation" do
+      it "returns College: Departmant" do
+        subject.ucdepartment = "UCL Test Department"
+        expect(subject.full_department).to eq "Libraries: Test Department"
+      end
+    end
+
+    context "when the user has a department that doesn't start with a college abbreviation" do
+      it "returns Other: Department" do
+        subject.ucdepartment = "Test Department"
+        expect(subject.full_department).to eq "Other: Test Department"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1784

Updates the user index page to show both college and department as `College: Department`

Changes proposed in this pull request:
* Add a method to the user class to get college and department
* Show both college and department on the user index page