### PR TITLE
Handle google analytics error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - 'app/services/report.rb'
     - 'app/services/work_loader.rb'
     - 'app/services/hyrax/actor_factory.rb'
+    - 'app/services/hyrax/user_stat_importer.rb'
     - 'spec/services/hyrax/actor_factory_spec.rb'
     - 'db/**/*'
     - 'lib/tasks/batch.rake'

--- a/app/services/hyrax/user_stat_importer.rb
+++ b/app/services/hyrax/user_stat_importer.rb
@@ -2,27 +2,8 @@
 require Hyrax::Engine.root.join('app/services/hyrax/user_stat_importer.rb')
 module Hyrax
   class UserStatImporter
-    private
-
-      def process_files(stats, user, start_date)
-        file_ids_for_user(user).each do |file_id|
-          file = ::FileSet.find(file_id)
-          view_stats = rescue_and_retry("Retried FileViewStat on #{user} for file #{file_id} too many times.") { FileViewStat.statistics(file, start_date, user.id) }
-          stats = tally_results(view_stats, :views, stats) unless (view_stats.blank? || view_stats)
-          delay
-          dl_stats = rescue_and_retry("Retried FileDownloadStat on #{user} for file #{file_id} too many times.") { FileDownloadStat.statistics(file, start_date, user.id) }
-          stats = tally_results(dl_stats, :downloads, stats) unless (dl_stats.blank? || dl_stats)
-          delay
-        end
-      end
-
-      def process_works(stats, user, start_date)
-        work_ids_for_user(user).each do |work_id|
-          work = Hyrax::WorkRelation.new.find(work_id)
-          work_stats = rescue_and_retry("Retried WorkViewStat on #{user} for work #{work_id} too many times.") { WorkViewStat.statistics(work, start_date, user.id) }
-          stats = tally_results(work_stats, :work_views, stats) unless (work_stats.blank? || work_stats)
-          delay
-        end
-      end
+    require 'legato'
+    require 'hyrax/pageview'
+    require 'hyrax/download'
   end
 end

--- a/app/services/hyrax/user_stat_importer.rb
+++ b/app/services/hyrax/user_stat_importer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require Hyrax::Engine.root.join('app/services/hyrax/user_stat_importer.rb')
+module Hyrax
+  class UserStatImporter
+    private
+
+      def process_files(stats, user, start_date)
+        file_ids_for_user(user).each do |file_id|
+          file = ::FileSet.find(file_id)
+          view_stats = rescue_and_retry("Retried FileViewStat on #{user} for file #{file_id} too many times.") { FileViewStat.statistics(file, start_date, user.id) }
+          stats = tally_results(view_stats, :views, stats) unless (view_stats.blank? || view_stats)
+          delay
+          dl_stats = rescue_and_retry("Retried FileDownloadStat on #{user} for file #{file_id} too many times.") { FileDownloadStat.statistics(file, start_date, user.id) }
+          stats = tally_results(dl_stats, :downloads, stats) unless (dl_stats.blank? || dl_stats)
+          delay
+        end
+      end
+
+      def process_works(stats, user, start_date)
+        work_ids_for_user(user).each do |work_id|
+          work = Hyrax::WorkRelation.new.find(work_id)
+          work_stats = rescue_and_retry("Retried WorkViewStat on #{user} for work #{work_id} too many times.") { WorkViewStat.statistics(work, start_date, user.id) }
+          stats = tally_results(work_stats, :work_views, stats) unless (work_stats.blank? || work_stats)
+          delay
+        end
+      end
+  end
+end

--- a/lib/tasks/stats_tasks.rake
+++ b/lib/tasks/stats_tasks.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+namespace :hyrax do
+  namespace :stats do
+    desc "Cache work view, file view & file download stats for all users"
+    task user_stats: :environment do
+      importer = Hyrax::UserStatImporter.new(verbose: true, logging: true, delay_secs: 1)
+      importer.import
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1767

Adds an additional condition before running the tally_results method, to handle the case where additional retries don't succeed (in this case the rescue_and_retry returns True)