### PR TITLE
Update Learn More link on homepage

### DIFF
--- a/app/views/layouts/scholar/_scholar_headline.html.erb
+++ b/app/views/layouts/scholar/_scholar_headline.html.erb
@@ -6,8 +6,11 @@
     <div class="col-sm-6 col-sm-offset-3">
       Scholar@UC enables the UC community to share research and scholarly works with
       a worldwide audience. The University of Cincinnati Libraries and IT@UC, with support from the Office of Research, are partnering to support Scholar@UC.
-
-      <p><a href="#"><i>Learn more about Scholar@UC</i></a></p>
+      <p>
+        <%= link_to about_path do %>
+          <i>Learn more about Scholar@UC</i>
+        <% end %>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #1808

Adds a path the the "learn more" link on the Scholar homepage.
The link will now direct to the about page. 
