### PR TITLE
Fix facet dropdowns on My Works/Collections pages

### DIFF
--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,0 +1,12 @@
+  <ul class="dropdown-menu facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
+    <% paginator = facet_paginator(facet_field, display_facet) %>
+    <%= render_facet_limit_list paginator, facet_field.key %>
+
+    <% unless paginator.last_page? || params[:action] == "facet" %>
+      <li role="separator" class="divider"></li>
+      <li class="more_facets_link">
+        <%= link_to t("more_#{field_name}_html", scope: 'blacklight.search.facets', default: :more_html, field_name: facet_field_label(facet_field.field).pluralize),
+          search_facet_path(id: facet_field.key), class: "more_facets_link" %>
+      </li>
+    <% end %>
+  </ul>

--- a/app/views/hyrax/my/_facet_limit.html.erb
+++ b/app/views/hyrax/my/_facet_limit.html.erb
@@ -1,4 +1,4 @@
-  <ul class="dropdown-menu facet-values" aria-labelledby="<%= facet_field.field.parameterize %>">
+  <ul class="facet-values list-unstyled" aria-labelledby="<%= facet_field.field.parameterize %>">
     <% paginator = facet_paginator(facet_field, display_facet) %>
     <%= render_facet_limit_list paginator, facet_field.key %>
 


### PR DESCRIPTION
Fixes #1666

Blacklight adds the `_facet_limit` view partial used to render each of the facet drop downs on the work catalog pages. Hyrax added two overrides of this partial: one for the catalog controller and one for the my/* controllers. The later of these adds a `dropdown-menu` css class to the list element. That class was responsible for the improper rendering of the facet drop downs on the my works and my collections pages. I have changed the styles on that list so that it matches the partial used with the catalog controller.

<img width="318" alt="image" src="https://user-images.githubusercontent.com/12132647/35705283-fe2237ce-076f-11e8-9015-0a232b532c51.png">


##### Changes proposed in this pull request:
* Add override of the `views/hyrax/my/_facet_limit.html.erb`
* Remove the `dropdown-menu` class from the facet list element
