### PR TITLE
Add new attribute renderer for line breaks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rb-readline'
   gem 'byebug'
+  gem 'equivalent-xml'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -942,6 +942,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.5)
   devise-multi_auth!
+  equivalent-xml
   factory_bot_rails
   fcrepo_wrapper
   hydra-remote_identifier!
@@ -983,4 +984,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/renderers/hyrax/renderers/note_renderer.rb
+++ b/app/renderers/hyrax/renderers/note_renderer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Renderers
+    class NoteRenderer < AttributeRenderer
+      def attribute_value_to_html(value)
+        if microdata_value_attributes(field).present?
+          "<div#{html_attributes(microdata_value_attributes(field))}>#{li_value(value)}</div>"
+        else
+          li_value(value)
+        end
+      end
+
+      def li_value(value)
+        auto_link(ERB::Util.h(simple_format(value)))
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -14,7 +14,7 @@
 <%= presenter.attribute_to_html(:issn) %>
 <%= presenter.attribute_to_html(:time_period) %>
 <%= presenter.attribute_to_html(:required_software) %>
-<%= presenter.attribute_to_html(:note) %>
+<%= presenter.attribute_to_html(:note, render_as: :note) %>
 <%= presenter.attribute_to_html(:genre) %>
 <%= presenter.attribute_to_html(:geo_subject, render_as: :faceted, label: "Geographic Subject") %>
 <%= presenter.attribute_to_html(:degree) %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,8 @@ Capybara.javascript_driver = :poltergeist
 ActiveRecord::Migration.maintain_test_schema!
 
 require 'shoulda/matchers'
+require 'equivalent-xml'
+require 'equivalent-xml/rspec_matchers'
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec

--- a/spec/renderers/hyrax/renderers/note_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/note_renderer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Hyrax::Renderers::NoteRenderer do
+  let(:field) { :note }
+  let(:renderer) { described_class.new(field, "Line 1\nLine 2\n\nLine 4") }
+
+  describe '#attribute_to_html' do
+    let(:subject) { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+
+    let(:tr_content) do
+      "<tr><th>Note</th>\n" \
+      "<td><ul class='tabular'><li class=\"attribute note\"><p>Line 1\n" \
+      "<br>Line 2</p>\n\n" \
+      "<p>Line 4</p></li></ul></td></tr>\n"
+    end
+
+    it { expect(subject).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
Fixes #1613 

Fixes line breaks not showing in the note attribute by adding a new attribute renderer that passes the content through the rails `simple_format` helper 

Changes proposed in this pull request:
* Adds a new attribute renderer which allow for line breaks to render 
