### PR TITLE
changes to allow works with a reserved DOI to be updated

### DIFF
--- a/app/models/concerns/remotely_identified_by_doi.rb
+++ b/app/models/concerns/remotely_identified_by_doi.rb
@@ -12,6 +12,7 @@ module RemotelyIdentifiedByDoi
       end
 
       property :identifier_url, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#doiManagementURI'), multiple: false
+      property :identifier_status, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#doiStatus'), multiple: false
       property :existing_identifier, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#unmanagedDOI'), multiple: false
 
       validates :publisher, presence: { message: 'is required for remote DOI minting', if: :remote_doi_assignment_strategy? }
@@ -22,7 +23,7 @@ module RemotelyIdentifiedByDoi
       def doi_status
         if visibility == Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           "public"
-        elsif locally_managed_remote_identifier?
+        elsif locally_managed_remote_identifier? && identifier_status != "reserved"
           "unavailable"
         else
           "reserved"

--- a/config/initializers/hydra_remote_identifier_config.rb
+++ b/config/initializers/hydra_remote_identifier_config.rb
@@ -13,6 +13,7 @@ Hydra::RemoteIdentifier.configure do |config|
       map.identifier_url :identifier_url
       # Make sure that this method both sets the identifier and persists the change!
       map.set_identifier do |o, value|
+        o.identifier_status = o.doi_status
         o.doi = value.fetch(:identifier)
         o.identifier_url = value.fetch(:identifier_url)
         o.save

--- a/spec/support/shared/is_remotely_identifiable_by_doi.rb
+++ b/spec/support/shared/is_remotely_identifiable_by_doi.rb
@@ -43,12 +43,22 @@ shared_examples 'is remotely identifiable by doi' do
       before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) }
       context 'and a DOI has already been minted' do
         before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
-        it 'is "unavailable"' do
-          expect(work.doi_status).to eq("unavailable")
+
+        context 'and the DOI is still reserved' do
+          before { work.stub(:identifier_status).and_return("reserved") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("reserved")
+          end
+        end
+        context 'and the DOI is not still reserved' do
+          before { work.stub(:identifier_status).and_return("public") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("unavailable")
+          end
         end
       end
 
-      context 'and a DOI has already been minted' do
+      context 'and a DOI has not already been minted' do
         before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
         it 'is "reserved"' do
           expect(work.doi_status).to eq("reserved")
@@ -60,8 +70,18 @@ shared_examples 'is remotely identifiable by doi' do
       before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
       context 'and a DOI has already been minted' do
         before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
-        it 'is "unavailable"' do
-          expect(work.doi_status).to eq("unavailable")
+
+        context 'and the DOI is still reserved' do
+          before { work.stub(:identifier_status).and_return("reserved") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("reserved")
+          end
+        end
+        context 'and the DOI is not still reserved' do
+          before { work.stub(:identifier_status).and_return("public") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("unavailable")
+          end
         end
       end
 
@@ -77,12 +97,22 @@ shared_examples 'is remotely identifiable by doi' do
       before { work.stub(:visibility).and_return(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
       context 'and a DOI has already been minted' do
         before { work.stub(:locally_managed_remote_identifier?).and_return(true) }
-        it 'is "unavailable"' do
-          expect(work.doi_status).to eq("unavailable")
+
+        context 'and the DOI is still reserved' do
+          before { work.stub(:identifier_status).and_return("reserved") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("reserved")
+          end
+        end
+        context 'and the DOI is not still reserved' do
+          before { work.stub(:identifier_status).and_return("public") }
+          it 'is "unavailable"' do
+            expect(work.doi_status).to eq("unavailable")
+          end
         end
       end
 
-      context 'and a DOI has already been minted' do
+      context 'and a DOI has not already been minted' do
         before { work.stub(:locally_managed_remote_identifier?).and_return(false) }
         it 'is "reserved"' do
           expect(work.doi_status).to eq("reserved")
@@ -102,6 +132,8 @@ shared_examples 'is remotely identifiable by doi' do
     it { should respond_to(:doi_assignment_strategy) }
     it { should respond_to(:identifier_url) }
     it { should respond_to(:identifier_url=) }
+    it { should respond_to(:identifier_status) }
+    it { should respond_to(:identifier_status=) }
 
     context 'with valid attributes' do
       let(:attributes) {
@@ -184,10 +216,16 @@ shared_examples 'is remotely identifiable by doi' do
               expect { |b| subject.apply_doi_assignment_strategy(&b) }.to yield_with_args(subject)
             end
 
-            it 'does not set doi attribute' do
+            it 'does not set identifier_url attribute' do
               expect {
                 subject.apply_doi_assignment_strategy(&perform_persistence_block)
               }.not_to change(subject, :identifier_url)
+            end
+
+            it 'does not set doi_status' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.not_to change(subject, :doi_status)
             end
           end
 
@@ -225,6 +263,12 @@ shared_examples 'is remotely identifiable by doi' do
                 subject.apply_doi_assignment_strategy(&perform_persistence_block)
               }.not_to change(subject, :identifier_url)
             end
+
+            it 'does not set doi_status' do
+              expect {
+                subject.apply_doi_assignment_strategy(&perform_persistence_block)
+              }.not_to change(subject, :doi_status)
+            end
           end
 
           context 'with request for minting' do
@@ -235,16 +279,12 @@ shared_examples 'is remotely identifiable by doi' do
               end
               it_behaves_like 'minting behavior returning value'
               let(:returning_value) { true }
+
+              ## These specs are odd - the real spec is the before block above
               it 'requests a minting' do
                 expect {
                   subject.apply_doi_assignment_strategy(&perform_persistence_block)
                 }.not_to change(subject, :doi).from(nil)
-              end
-              ## These specs are odd - the real spec is the before block above
-              it 'sets identifier_url attribute' do
-                expect {
-                  subject.apply_doi_assignment_strategy(&perform_persistence_block)
-                }.not_to change(subject, :identifier_url)
               end
             end
 


### PR DESCRIPTION
Fixes #1816 

When editing a work with a reserved DOI without changing the visibility, the DOI minting code was trying to update the DOI status from 'reserved' to 'unavailable', which is not allowed.

This PR introduces an `identifier_status` attribute which we will need to set for all works with DOIs, which helps target the logic of the `doi_status` function (which sets the DOI status when making an update).

Also cleaned up some spec examples which weren't doing anything. The DOI specs are really odd - ask me if you have any questions.