### PR TITLE
Boost Collection work type

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -107,6 +107,9 @@
           author_tesim
           subject_tesim
         </str>
+        <str name="bq">
+          {!terms f=has_model_ssim}Collection^50
+        </str>
         <str name="pf">
           all_text_timv^10
         </str>


### PR DESCRIPTION
Fixes #1778 

Present short summary (50 characters or less)

This pull request boosts collection work types by increasing the ranking of the collection types in the solrconfig.xml file. 

screenshot of an example search **before** making the changes to solr config

<img width="1052" alt="screen shot 2018-02-16 at 12 53 58 pm" src="https://user-images.githubusercontent.com/2188493/36321966-b2c7c7c0-1319-11e8-9433-4f97021ba8f4.png">

screenshot of an example search **after** making changes to the solr config file. Notice that collection is boosted.

<img width="1019" alt="screen shot 2018-02-16 at 12 57 06 pm" src="https://user-images.githubusercontent.com/2188493/36322003-d05061b2-1319-11e8-8913-8fe7c3f86e5d.png">


**Note**:
Copy solrconfig.xml file to the solr server for these changes to take effect.
