### PR TITLE
Update TargetRubyVersion for rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-rspec
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   Include:
     - '**/Rakefile'


### PR DESCRIPTION
Updates the TargetRubyVersion in .rubocop.yml to ruby 2.4.  Other pull requests are having rubocop errors on Travis and this should fix it.