### PR TITLE
Boost Collection work type

### DIFF
--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -100,17 +100,19 @@
             those searches. You may also be interested in:
             http://wiki.apache.org/solr/LocalParams
        -->
-        <str name="qf">
-          id
-          active_fedora_model_ssi
-          title_tesim
-          author_tesim
-          subject_tesim
-        </str>
-        <str name="pf">
-          all_text_timv^10
-        </str>
-
+       <str name="qf">
+         id
+         active_fedora_model_ssi
+         title_tesim
+         author_tesim
+         subject_tesim
+       </str>
+       <str name="pf">
+         all_text_timv^10
+       </str>
+       <str name="bq">
+         {!terms f=has_model_ssim}Collection^20
+       </str>
        <str name="author_qf">
           author_tesim
        </str>


### PR DESCRIPTION
Fixes #1778

This pull request boosts collection work types by increasing the ranking of the collection types in the solrconfig.xml file.

screenshot of an example search before making the changes to solr config

<img width="1052" alt="screen shot 2018-02-16 at 12 53 58 pm" src="https://user-images.githubusercontent.com/2188493/36443763-a32a9c58-1647-11e8-902f-ca5db0f2b8ce.png">

screenshot of an example search after making changes to the solr config file. Notice that collection is boosted.

<img width="1019" alt="screen shot 2018-02-16 at 12 57 06 pm" src="https://user-images.githubusercontent.com/2188493/36443779-abdfc4d6-1647-11e8-875f-08d71fdabfb7.png">

**Note**:
Copy solrconfig.xml file to the solr server and also solr reindexing is required for these changes to take effect.