### PR TITLE
Updates Gemfile.lock for BrowseEverything

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/uclibs/browse-everything.git
-  revision: 9e2cc163b8cd0087ac960ffa59464e0e0a169360
+  revision: 1e1e2db1522dcbab1233a30d959ce9564a294d23
   branch: master
   specs:
     browse-everything (0.14.2)
@@ -143,19 +143,19 @@ GEM
       rails (>= 4.2, < 6)
     arel (7.1.4)
     ast (2.3.0)
-    autoprefixer-rails (7.2.4)
+    autoprefixer-rails (8.0.0)
       execjs
     awesome_nested_set (3.1.3)
       activerecord (>= 4.0.0, < 5.2)
-    aws-partitions (1.53.0)
-    aws-sdk-core (3.13.0)
+    aws-partitions (1.67.0)
+    aws-sdk-core (3.17.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.3.0)
+    aws-sdk-kms (1.5.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.8.0)
+    aws-sdk-s3 (1.8.2)
       aws-sdk-core (~> 3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -312,18 +312,18 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.18)
+    ffi (1.9.23)
     figaro (1.1.1)
       thor (~> 0.14)
     flipflop (2.3.1)
       activesupport (>= 4.0)
     flot-rails (0.0.7)
       jquery-rails
-    font-awesome-rails (4.7.0.2)
+    font-awesome-rails (4.7.0.3)
       railties (>= 3.2, < 5.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.19.2)
+    google-api-client (0.19.8)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
@@ -354,7 +354,7 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_logger (0.5.1)
-    httparty (0.15.6)
+    httparty (0.16.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     hydra-access-controls (10.5.0)
@@ -445,7 +445,7 @@ GEM
       signet
       tinymce-rails (~> 4.1)
       tinymce-rails-imageupload (~> 4.0.17.beta)
-    i18n (0.9.4)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     iiif-presentation (0.2.0)
@@ -617,7 +617,7 @@ GEM
     posix-spawn (0.3.13)
     power_converter (0.1.2)
     powerpack (0.1.1)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     qa (1.2.0)
       activerecord-import
       deprecation


### PR DESCRIPTION
This is a follow up to allow the application to use the latest commits rom UC's BrowseEverything repo.