### PR TITLE
Only show viewable images with UniversalViewer

### DIFF
--- a/app/presenters/concerns/displays_image.rb
+++ b/app/presenters/concerns/displays_image.rb
@@ -5,7 +5,7 @@ module DisplaysImage
   extend ActiveSupport::Concern
 
   def display_image
-    return nil unless FileSet.exists?(id) && image_modifier == true
+    return nil unless FileSet.exists?(id) && image_modifier == true && current_ability.can?(:read, id)
 
     # TODO: this is slow, find a better way (perhaps index iiif url):
 

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 class ImagePresenter < Hyrax::WorkShowPresenter
   delegate :alt_description, :alt_date_created, :college, :department, :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :geo_subject, :cultural_context, :doi, to: :solr_document
+
+  def members_include_viewable_image?
+    member_presenters.any? { |presenter| current_ability.can?(:read, presenter.id) }
+  end
 end

--- a/app/views/hyrax/file_sets/media_display/_universal_viewer.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_universal_viewer.html.erb
@@ -1,4 +1,4 @@
-  <% if file_set.mime_type == "image/gif" %>
+<% if file_set.mime_type == "image/gif" || !@presenter.members_include_viewable_image? %>
     <%= image_tag thumbnail_url(file_set),
           class: "representative-media",
           alt: "",

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::FileSetPresenter do
   let(:file_set) { FactoryBot.create(:file_set) }
   let(:solr_document) { SolrDocument.new(file_set.to_solr) }
   let(:request) { double(base_url: 'http://test.host') }
-  let(:presenter) { described_class.new(solr_document, nil, request) }
+  let(:ability) { double "Ability" }
+  let(:read_permission) { true }
+  let(:presenter) { described_class.new(solr_document, ability, request) }
   let(:id) { CGI.escape(file_set.original_file.id) }
   let(:file) { File.open(File.join(fixture_path, 'world.png')) }
 
@@ -14,6 +16,7 @@ RSpec.describe Hyrax::FileSetPresenter do
     Hydra::Works::AddFileToFileSet.call(file_set,
                                         file,
                                         :original_file)
+    allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
   end
 
   describe "display_image" do
@@ -21,6 +24,12 @@ RSpec.describe Hyrax::FileSetPresenter do
     it "creates a display image" do
       expect(subject).to be_instance_of IIIFManifest::DisplayImage
       expect(subject.url).to eq "http://test.host/images/#{id}/full/600,/0/default.jpg"
+    end
+
+    context "when the user doesn't have permission to view the image" do
+      let(:read_permission) { false }
+
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -16,4 +16,41 @@ RSpec.describe ImagePresenter do
   it { is_expected.to delegate_method(:note).to(:solr_document) }
   it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
   it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
+
+  describe '#members_include_viewable_image?' do
+    let(:user_key) { 'a_user_key' }
+    let(:attributes) do
+      { "id" => '888888',
+        "title_tesim" => ['foo', 'bar'],
+        "human_readable_type_tesim" => ["Generic Work"],
+        "has_model_ssim" => ["GenericWork"],
+        "date_created_tesim" => ['an unformatted date'],
+        "depositor_tesim" => user_key }
+    end
+    let(:solr_document) { SolrDocument.new(attributes) }
+    let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
+    let(:ability) { double Ability }
+    let(:presenter) { described_class.new(solr_document, ability, request) }
+    let(:file_set_presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+    let(:member_presenters) { [file_set_presenter] }
+
+    subject { presenter.members_include_viewable_image? }
+
+    before do
+      allow(presenter).to receive(:member_presenters).and_return(member_presenters)
+      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
+    end
+
+    context 'when the work has at least one viewable image' do
+      let(:read_permission) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the work has no viewable images' do
+      let(:read_permission) { false }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/views/hyrax/file_sets/media_display_spec.rb
+++ b/spec/views/hyrax/file_sets/media_display_spec.rb
@@ -41,6 +41,40 @@ describe 'hyrax/file_sets/media_display', type: :view do
                         solr_document: large_solr_document)
   end
 
+  describe 'universal viewer' do
+    let(:doc) do
+      SolrDocument.new(id: '12345678',
+                       title_tesim: ['Doc title'],
+                       has_model_ssim: ['GenericWork'])
+    end
+    let(:presenter) { ImagePresenter.new(doc, nil) }
+
+    context 'when there are viewable images' do
+      before do
+        allow(presenter).to receive(:members_include_viewable_image?).and_return(true)
+        @presenter = presenter
+        render 'hyrax/file_sets/media_display/universal_viewer', file_set: small_file
+      end
+
+      it 'renders the universal viewer' do
+        expect(rendered).to include 'embed.js'
+      end
+    end
+
+    context 'when there are no viewable images' do
+      before do
+        allow(presenter).to receive(:members_include_viewable_image?).and_return(false)
+        allow(view).to receive(:thumbnail_url).and_return('asdf')
+        @presenter = presenter
+        render 'hyrax/file_sets/media_display/universal_viewer', file_set: small_file
+      end
+
+      it 'does not render the universal viewer' do
+        expect(rendered).not_to include 'embed.js'
+      end
+    end
+  end
+
   describe 'image' do
     context 'when the image is smaller than the max download size' do
       before do


### PR DESCRIPTION
Fixes #1716 

Hides images from the UniversalViewer if the user does not have permission to view those images.

To test:

1. Create a public work that has all public images attached.  Make sure all the images show in the viewer when the owner is logged in and while not logged in.

2. Create a public work that has some public images and some private images attached.  Make sure all the images show in the viewer when the owner is logged in, but only the public images show in the viewer while not logged in.

3. Create a public work that has all private images attached.  Make sure all the images show in the viewer when the owner is logged in, but the viewer does now show at all while not logged in.
