### PR TITLE
Improves on work type presenter specs.

### DIFF
--- a/spec/presenters/article_presenter_spec.rb
+++ b/spec/presenters/article_presenter_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe ArticlePresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:journal_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:issn).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
 end

--- a/spec/presenters/dataset_presenter_spec.rb
+++ b/spec/presenters/dataset_presenter_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe DatasetPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
+  it { is_expected.to delegate_method(:genre).to(:solr_document) }
 end

--- a/spec/presenters/document_presenter_spec.rb
+++ b/spec/presenters/document_presenter_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe DocumentPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:genre).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
 end

--- a/spec/presenters/etd_presenter_spec.rb
+++ b/spec/presenters/etd_presenter_spec.rb
@@ -8,4 +8,16 @@ RSpec.describe EtdPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
+  it { is_expected.to delegate_method(:etd_publisher).to(:solr_document) }
+  it { is_expected.to delegate_method(:degree).to(:solr_document) }
+  it { is_expected.to delegate_method(:advisor).to(:solr_document) }
+  it { is_expected.to delegate_method(:committee_member).to(:solr_document) }
 end

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe GenericWorkPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
 end

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe ImagePresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
 end

--- a/spec/presenters/medium_presenter_spec.rb
+++ b/spec/presenters/medium_presenter_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe MediumPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
 end

--- a/spec/presenters/student_work_presenter_spec.rb
+++ b/spec/presenters/student_work_presenter_spec.rb
@@ -8,4 +8,13 @@ RSpec.describe StudentWorkPresenter do
   subject { described_class.new(double, double) }
   it { is_expected.to delegate_method(:college).to(:solr_document) }
   it { is_expected.to delegate_method(:department).to(:solr_document) }
+  it { is_expected.to delegate_method(:title).to(:solr_document) }
+  it { is_expected.to delegate_method(:alternate_title).to(:solr_document) }
+  it { is_expected.to delegate_method(:geo_subject).to(:solr_document) }
+  it { is_expected.to delegate_method(:time_period).to(:solr_document) }
+  it { is_expected.to delegate_method(:required_software).to(:solr_document) }
+  it { is_expected.to delegate_method(:note).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
+  it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
+  it { is_expected.to delegate_method(:advisor).to(:solr_document) }
 end


### PR DESCRIPTION
Fixes #1247 

Present short summary (50 characters or less)

This improves the work_type presenter specs to include all the fields that get solarized.
