### PR TITLE
Refactor user filter on /users page

### DIFF
--- a/app/controllers/display_users_controller.rb
+++ b/app/controllers/display_users_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class DisplayUsersController < Hyrax::UsersController
+  def index
+    all_users = search(params[:uq])
+    filtered_users = exclude_admins_and_non_owners(all_users)
+    @users = get_current_page(filtered_users)
+  end
+
+  def search(query)
+    clause = query.blank? ? nil : "%" + query.downcase + "%"
+    base = ::User.where(*base_query)
+    if clause.present?
+      base = base.where("#{Devise.authentication_keys.first} like lower(?)
+                           OR display_name like lower(?)
+                           OR first_name like lower(?)
+                           OR last_name like lower(?)", clause, clause, clause, clause)
+    end
+    base.where("#{Devise.authentication_keys.first} not in (?)",
+               [::User.batch_user_key, ::User.audit_user_key])
+        .where(guest: false)
+        .references(:trophies)
+        .order(sort_value)
+  end
+
+  protected
+
+    def exclude_admins_and_non_owners(users)
+      users.to_a.delete_if do |user|
+        !(current_user && current_user.admin?) && (user_work_count(user).zero? || user.admin?)
+      end
+    end
+
+    def get_current_page(users)
+      ::User.where(id: users.map(&:id)).page(params[:page]).per(10)
+    end
+end

--- a/app/views/display_users/index.html.erb
+++ b/app/views/display_users/index.html.erb
@@ -15,24 +15,22 @@
     </thead>
     <tbody>
       <% @users.each do |user| %>
-        <% if (current_user && current_user.admin?) || (number_of_works(user) > 0 && !user.admin?) %>
-          <tr>
-            <td>
-              <% if user.avatar.file %>
-                <%= link_to hyrax.profile_path(user) do %>
-                  <%= image_tag(user.avatar.url(:thumb), width: 30) %>
-                <% end %>
+        <tr>
+          <td>
+            <% if user.avatar.file %>
+              <%= link_to hyrax.profile_path(user) do %>
+                <%= image_tag(user.avatar.url(:thumb), width: 30) %>
               <% end %>
-            </td>
-            <td><%= link_to user.name, hyrax.profile_path(user) %></td>
-            <td><%= link_to user.user_key, hyrax.profile_path(user) %></td>
-            <td><%= user.full_department %></td>
-            <td><%= number_of_works(user) %></td>
-	  </tr>
-	<% end %>
+            <% end %>
+          </td>
+          <td><%= link_to user.name, hyrax.profile_path(user) %></td>
+          <td><%= link_to user.user_key, hyrax.profile_path(user) %></td>
+          <td><%= user.full_department %></td>
+          <td><%= number_of_works(user) %></td>
+	      </tr>
       <% end %>
     </tbody>
 </table>
 <div class="pager">
-  <%= paginate @users, theme: 'blacklight', route_set: hyrax %>
+  <%= paginate @users, theme: 'blacklight' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
 
   mount Hydra::RoleManagement::Engine => '/'
 
+  resources :users, only: [:index], constraints: { format: :html }, controller: 'display_users'
+
   resources :welcome, only: 'index'
   resources :welcome_page, only: [:index, :create]
   root 'hyrax/homepage#index'

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,129 +1,157 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "User Profile", type: :feature do
-  before do
-    sign_in user
-  end
-  let(:user) { create(:user) }
-  let(:profile_path) { Hyrax::Engine.routes.url_helpers.profile_path(user) }
-
-  context 'when visiting user profile' do
-    it 'renders page properly' do
-      visit profile_path
-      expect(page).to have_content(user.email)
-      expect(page).to have_content('Edit Profile')
-      expect(page).to have_content('View People')
+describe "Users Spec", type: :feature do
+  describe "User Profile", type: :feature do
+    before do
+      sign_in user
     end
-  end
+    let(:user) { create(:user) }
+    let(:profile_path) { Hyrax::Engine.routes.url_helpers.profile_path(user) }
 
-  context 'when editing user' do
-    it 'renders identity and contact fields' do
-      visit profile_path
-      click_link('Edit Profile', match: :first)
-      expect(page).to have_field('First name', with: user.first_name)
-      expect(page).to have_field('Last name', with: user.last_name)
-      expect(page).to have_field('Job title')
-      expect(page).to have_field('Department')
-      expect(page).to have_field('UC affiliation')
-      expect(page).to have_field('Email', with: user.email)
-      expect(page).to have_field('Alternate email')
-      expect(page).to have_field('Campus phone number')
-      expect(page).to have_field('Alternate phone number')
-      expect(page).to have_field('Personal webpage')
-      expect(page).to have_field('Blog')
+    context 'when visiting user profile' do
+      it 'renders page properly' do
+        visit profile_path
+        expect(page).to have_content(user.email)
+        expect(page).to have_content('Edit Profile')
+        expect(page).to have_content('View People')
+      end
     end
 
-    it 'renders manage proxies partial' do
-      visit profile_path
-      click_link('Edit Profile', match: :first)
-      expect(page).to have_content('Manage Proxies')
-      expect(page).to have_content("Please Note: Your proxies can do anything on your behalf in Scholar@UC.")
-    end
-
-    it 'renders ORCID connector' do
-      skip "Needs orcid gem upgrade" do
+    context 'when editing user' do
+      it 'renders identity and contact fields' do
         visit profile_path
         click_link('Edit Profile', match: :first)
-        expect(page).to have_content('Create or Connect your ORCID iD')
+        expect(page).to have_field('First name', with: user.first_name)
+        expect(page).to have_field('Last name', with: user.last_name)
+        expect(page).to have_field('Job title')
+        expect(page).to have_field('Department')
+        expect(page).to have_field('UC affiliation')
+        expect(page).to have_field('Email', with: user.email)
+        expect(page).to have_field('Alternate email')
+        expect(page).to have_field('Campus phone number')
+        expect(page).to have_field('Alternate phone number')
+        expect(page).to have_field('Personal webpage')
+        expect(page).to have_field('Blog')
+      end
+
+      it 'renders manage proxies partial' do
+        visit profile_path
+        click_link('Edit Profile', match: :first)
+        expect(page).to have_content('Manage Proxies')
+        expect(page).to have_content("Please Note: Your proxies can do anything on your behalf in Scholar@UC.")
+      end
+
+      it 'renders ORCID connector' do
+        skip "Needs orcid gem upgrade" do
+          visit profile_path
+          click_link('Edit Profile', match: :first)
+          expect(page).to have_content('Create or Connect your ORCID iD')
+        end
+      end
+    end
+
+    context 'when clicking view people' do
+      # TODO: Move this to a view test
+
+      before do
+        visit profile_path
+        click_link 'View People'
+      end
+
+      it "has a Search People field label" do
+        expect(page).to have_css("label", text: "Search People")
+      end
+
+      it "has People in the heading" do
+        expect(page).to have_css("h1", text: "People")
+      end
+    end
+
+    context 'when visiting user profile' do
+      it 'page should be editable' do
+        visit profile_path
+        click_link('Edit Profile', match: :first)
+        fill_in 'Campus phone number', with: '513-867-5309'
+        click_button 'Save Profile'
+        expect(page).to have_content 'Your profile has been updated'
+        expect(page).to have_link('513-867-5309', href: 'wtai://wp/mc;513-867-5309')
+      end
+    end
+
+    context 'user profile' do
+      let!(:dewey) { create(:user, display_name: 'Melvil Dewey') }
+      let(:dewey_path) { Hyrax::Engine.routes.url_helpers.profile_path(dewey) }
+      let!(:work) { FactoryBot.create(:work, user: user) }
+      let!(:work2) { FactoryBot.create(:work, user: dewey) }
+
+      it 'is searchable' do
+        visit profile_path
+        click_link 'View People'
+        expect(page).to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
+        expect(page).to have_xpath("//td/a[@href='#{dewey_path}?locale=en']")
+        fill_in 'user_search', with: 'Dewey'
+        click_button "user_submit"
+        expect(page).not_to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
+        expect(page).to have_xpath("//td/a[@href='#{dewey_path}?locale=en']")
       end
     end
   end
 
-  context 'when clicking view people' do
-    # TODO: Move this to a view test
-
-    before do
-      visit profile_path
-      click_link 'View People'
-    end
-
-    it "has a Search People field label" do
-      expect(page).to have_css("label", text: "Search People")
-    end
-
-    it "has People in the heading" do
-      expect(page).to have_css("h1", text: "People")
-    end
+  describe "People Page", type: :feature do
+    let!(:user) { create(:user) }
+    let(:profile_path) { Hyrax::Engine.routes.url_helpers.profile_path(user) }
+    let(:profiles_path) { Hyrax::Engine.routes.url_helpers.profiles_path }
 
     context "when the user doesn't own works" do
+      before do
+        visit profiles_path
+      end
+
       it 'does not include the user in the display' do
-        skip # Feature is temporarily disabled
-        visit profile_path
-        click_link 'View People'
         expect(page).not_to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
       end
     end
 
     context "when the user owns works" do
       let!(:work) { FactoryBot.create(:work, user: user) }
+
+      before do
+        visit profiles_path
+      end
+
       it 'includes the user in the display' do
-        visit profile_path
-        click_link 'View People'
         expect(page).to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
       end
     end
 
-    context "when the user is an admin" do
+    context "when the user owns works and is an admin (not logged in)" do
+      let!(:work) { FactoryBot.create(:work, user: user) }
+
       before do
         admin = Role.create(name: "admin")
         admin.users << user
         admin.save
+        visit profiles_path
       end
+
+      it 'does not include the user in the display' do
+        expect(page).not_to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
+      end
+    end
+
+    context "when the logged in user is an admin" do
+      before do
+        admin = Role.create(name: "admin")
+        admin.users << user
+        admin.save
+        sign_in user
+        visit profiles_path
+      end
+
       it 'includes the user without works in the display' do
-        visit profile_path
-        click_link 'View People'
         expect(page).to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
       end
-    end
-  end
-
-  context 'when visiting user profile' do
-    it 'page should be editable' do
-      visit profile_path
-      click_link('Edit Profile', match: :first)
-      fill_in 'Campus phone number', with: '513-867-5309'
-      click_button 'Save Profile'
-      expect(page).to have_content 'Your profile has been updated'
-      expect(page).to have_link('513-867-5309', href: 'wtai://wp/mc;513-867-5309')
-    end
-  end
-
-  context 'user profile' do
-    let!(:dewey) { create(:user, display_name: 'Melvil Dewey') }
-    let(:dewey_path) { Hyrax::Engine.routes.url_helpers.profile_path(dewey) }
-    let!(:work) { FactoryBot.create(:work, user: user) }
-    let!(:work2) { FactoryBot.create(:work, user: dewey) }
-
-    it 'is searchable' do
-      visit profile_path
-      click_link 'View People'
-      expect(page).to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
-      expect(page).to have_xpath("//td/a[@href='#{dewey_path}?locale=en']")
-      fill_in 'user_search', with: 'Dewey'
-      click_button "user_submit"
-      expect(page).not_to have_xpath("//td/a[@href='#{profile_path}?locale=en']")
-      expect(page).to have_xpath("//td/a[@href='#{dewey_path}?locale=en']")
     end
   end
 end


### PR DESCRIPTION
Fixes #1883

This isn't a complicated pull request, but the reasons for resolving the bug this way are a little complicated.  So I'm happy walk the reviewer through it if requested.

This PR fixes the problem where the /users page would display a different number of users on each page.  It was a side effect of putting code in the view to hide admin users and users without content.

The fix required moving the user filter from the view back to the controller.  However, the UsersController is used for more than just displaying users on the /users page.  The controller also gets called when searching for users to add as a proxy, searching for users to transfer a work to, etc.  So applying a filter to the UsersController would affect things we don't want to change.  (E.g. we don't want to hide any users when searching for a proxy.)

* This code is deployed on scholar-qa.  I generated 1000 users and assigned works to 200 of them to verify there's no lag when viewing and filtering large numbers of users. See http://scholar-qa.uc.edu/users

Changes:

1. Created a DisplayUsersController that inherits from UsersController.  This allowed me to apply a filter to the #index action without affecting everything else that uses the UsersController.  Existing code in UserController remains unchanged.  The filter retrieves ALL users from the database, converts it into an array, filters out the users we don't want to display (this is fast because it doesn't involve database calls), and then converts the list of users back to an ActiveRelation (needed for pagination to work properly).

2. Removed the old filtering code we were using in views/hyrax/users/index.html.erb and moved the view to views/display_users/index.html.erb.

3. Adjusted the #index route for /users to use the DisplayUsersController instead of UsersController.  Included a constraint so this route is only used for HTML requests.  Other user lookups will still use the old route to UsersController.

4. Refactored the tests we already had for the user filter and added a new test.  All tests for filtering users are now located at the bottom of spec/features/users_spec.rb.