### PR TITLE
Fix Blacklight pagination problems

### DIFF
--- a/app/views/kaminari/blacklight/_first_page.html.erb
+++ b/app/views/kaminari/blacklight/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/blacklight/_gap.html.erb
+++ b/app/views/kaminari/blacklight/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/blacklight/_last_page.html.erb
+++ b/app/views/kaminari/blacklight/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>&nbsp;
+</span>

--- a/app/views/kaminari/blacklight/_next_page.html.erb
+++ b/app/views/kaminari/blacklight/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/blacklight/_page.html.erb
+++ b/app/views/kaminari/blacklight/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/blacklight/_paginator.html.erb
+++ b/app/views/kaminari/blacklight/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/blacklight/_prev_page.html.erb
+++ b/app/views/kaminari/blacklight/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/spec/features/pagination_spec.rb
+++ b/spec/features/pagination_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'Blacklight pagination', type: :feature do
+  let(:user)   { create :user }
+  let!(:work)  { create :public_work, user: user }
+  let!(:work2) { create :public_work, user: user }
+
+  context 'when there are more page(s) after this one' do
+    before do
+      visit '/catalog?per_page=1&page=1'
+    end
+
+    it 'displays a Next link' do
+      expect(page).to have_css('span.next', text: 'Next »')
+    end
+
+    it 'displays a Last link' do
+      expect(page).to have_css('span.last', text: 'Last »')
+    end
+  end
+
+  context 'when there are more page(s) before this one' do
+    before do
+      visit '/catalog?per_page=1&page=2'
+    end
+
+    it 'displays a Previous link' do
+      expect(page).to have_css('span.prev', text: '« Previous')
+    end
+
+    it 'displays a First link' do
+      expect(page).to have_css('span.first', text: '« First')
+    end
+  end
+
+  context 'when on the first page' do
+    before do
+      visit '/catalog?per_page=1&page=1'
+    end
+
+    it 'does not display a Previous link' do
+      expect(page).not_to have_css('span.prev', text: '« Previous')
+    end
+
+    it 'does not display a First link' do
+      expect(page).not_to have_css('span.first', text: '« First')
+    end
+  end
+
+  context 'when on the last page' do
+    before do
+      visit '/catalog?per_page=1&page=2'
+    end
+
+    it 'does not display a Next link' do
+      expect(page).not_to have_css('span.next', text: 'Next »')
+    end
+
+    it 'does not display a Last link' do
+      expect(page).not_to have_css('span.last', text: 'Last »')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1890 

This bug exists because Hyrax 1.x has outdated overridden partials in https://github.com/samvera/hyrax/tree/v1.0.5/app/views/kaminari/blacklight.  Hyrax 2.x fixes the problem by just removing those partials since they are no longer needed.  To fix it within Scholar, however, we must pull in the updated partials from the karminari gem.