### PR TITLE
Fix bug for UV on non-image work types

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -7,5 +7,9 @@ module Hyrax
       return '' if representative_presenter.nil?
       Hyrax::Engine.routes.url_helpers.download_url(representative_presenter, host: request.host)
     end
+
+    def members_include_viewable_image?
+      member_presenters.any? { |presenter| current_ability.can?(:read, presenter.id) }
+    end
   end
 end

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,8 +1,4 @@
 # frozen_string_literal: true
 class ImagePresenter < Hyrax::WorkShowPresenter
   delegate :alt_description, :alt_date_created, :college, :department, :alternate_title, :date_photographed, :genre, :time_period, :required_software, :note, :geo_subject, :cultural_context, :doi, to: :solr_document
-
-  def members_include_viewable_image?
-    member_presenters.any? { |presenter| current_ability.can?(:read, presenter.id) }
-  end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -118,4 +118,41 @@ describe Hyrax::WorkShowPresenter do
       end
     end
   end
+
+  describe '#members_include_viewable_image?' do
+    let(:user_key) { 'a_user_key' }
+    let(:attributes) do
+      { "id" => '888888',
+        "title_tesim" => ['foo', 'bar'],
+        "human_readable_type_tesim" => ["Generic Work"],
+        "has_model_ssim" => ["GenericWork"],
+        "date_created_tesim" => ['an unformatted date'],
+        "depositor_tesim" => user_key }
+    end
+    let(:solr_document) { SolrDocument.new(attributes) }
+    let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
+    let(:ability) { double Ability }
+    let(:presenter) { described_class.new(solr_document, ability, request) }
+    let(:file_set_presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+    let(:member_presenters) { [file_set_presenter] }
+
+    subject { presenter.members_include_viewable_image? }
+
+    before do
+      allow(presenter).to receive(:member_presenters).and_return(member_presenters)
+      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
+    end
+
+    context 'when the work has at least one viewable image' do
+      let(:read_permission) { true }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the work has no viewable images' do
+      let(:read_permission) { false }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -16,41 +16,4 @@ RSpec.describe ImagePresenter do
   it { is_expected.to delegate_method(:note).to(:solr_document) }
   it { is_expected.to delegate_method(:alt_description).to(:solr_document) }
   it { is_expected.to delegate_method(:alt_date_created).to(:solr_document) }
-
-  describe '#members_include_viewable_image?' do
-    let(:user_key) { 'a_user_key' }
-    let(:attributes) do
-      { "id" => '888888',
-        "title_tesim" => ['foo', 'bar'],
-        "human_readable_type_tesim" => ["Generic Work"],
-        "has_model_ssim" => ["GenericWork"],
-        "date_created_tesim" => ['an unformatted date'],
-        "depositor_tesim" => user_key }
-    end
-    let(:solr_document) { SolrDocument.new(attributes) }
-    let(:request) { double(host: 'example.org', base_url: 'http://example.org') }
-    let(:ability) { double Ability }
-    let(:presenter) { described_class.new(solr_document, ability, request) }
-    let(:file_set_presenter) { Hyrax::FileSetPresenter.new(solr_document, ability) }
-    let(:member_presenters) { [file_set_presenter] }
-
-    subject { presenter.members_include_viewable_image? }
-
-    before do
-      allow(presenter).to receive(:member_presenters).and_return(member_presenters)
-      allow(ability).to receive(:can?).with(:read, solr_document.id).and_return(read_permission)
-    end
-
-    context 'when the work has at least one viewable image' do
-      let(:read_permission) { true }
-
-      it { is_expected.to be true }
-    end
-
-    context 'when the work has no viewable images' do
-      let(:read_permission) { false }
-
-      it { is_expected.to be false }
-    end
-  end
 end


### PR DESCRIPTION
Fixes #1901 

Moves the `members_include_viewable_image?` method from the ImagePresenter to WorkShowPresenter so it can be used by all work types.

The reviewer of this PR should make sure they can create works of different types with images attached and verify the UniversalViewer properly displays them.