### PR TITLE
Display seperate field for work and file views

### DIFF
--- a/app/views/hyrax/users/_vitals.html.erb
+++ b/app/views/hyrax/users/_vitals.html.erb
@@ -8,6 +8,7 @@
   <span class="glyphicon glyphicon-upload"></span> <%= link_to_field('depositor', user.to_s, t("hyrax.dashboard.stats.works"), generic_type: "Work") %>
 
   <ul class="views-downloads-dashboard list-unstyled">
+      <li><span class="badge badge-optional"><%= user.total_work_views %></span> <%= t("hyrax.dashboard.stats.work_views").pluralize(user.total_work_views) %></li>
       <li><span class="badge badge-optional"><%= user.total_file_views %></span> <%= t("hyrax.dashboard.stats.file_views").pluralize(user.total_file_views) %></li>
       <li><span class="badge badge-optional"><%= user.total_file_downloads %></span> <%= t("hyrax.dashboard.stats.file_downloads").pluralize(user.total_file_downloads) %></li>
   </ul>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -11,6 +11,9 @@ en:
     user_profile:
       tab_highlighted:   "Highlighted Works"
     dashboard:
+      stats:
+        file_views:             "File View"
+        work_views:             "Work View"
       help_statement_html:      "<strong>Please Note:</strong> Your proxies can do anything on your behalf in Scholar@UC. Be selective in who you give proxy access. If you authorize a proxy they can create and upload files on your behalf as well as edit, or delete those corresponding works and files. The proxy relationship can be revoked by the owner at any time. Use work-specific editors for more fine-grained access control."
       view_collections:         "View My Collections"
       create_collection:        "Create Collection"

--- a/spec/views/hyrax/user/_vitals.html.erb_spec.rb
+++ b/spec/views/hyrax/user/_vitals.html.erb_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'hyrax/users/_vitals.html.erb', type: :view do
+  let(:user) { stub_model(User, user_key: 'cam156') }
+  let(:current_user) { stub_model(User, user_key: 'mjg') }
+
+  before do
+    allow(view).to receive(:signed_in?).and_return(true)
+    allow(view).to receive(:current_user).and_return(current_user)
+    allow(view).to receive(:user).and_return(current_user)
+    assign(:user, user)
+    render
+  end
+
+  it 'displays user work and file analytics' do
+    expect(rendered).to have_content 'File Views'
+    expect(rendered).to have_content 'Work Views'
+    expect(rendered).to have_content 'Downloads'
+  end
+end


### PR DESCRIPTION
Fixes #1904 

Adds work views and an additional field on the user show page

<img width="290" alt="image" src="https://user-images.githubusercontent.com/12132647/39485634-5920e9d2-4d47-11e8-99bd-92ecbc503436.png">

