### PR TITLE
fix sitemap links

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -39,7 +39,7 @@ class SitemapsController < ApplicationController
     end
 
     def sans_fedora_poly_url(work_type, work_id)
-      strip_locale_from_url(root_url + "concern/#{work_type.underscore}/#{work_id}")
+      strip_locale_from_url(root_url + "concern/#{work_type.underscore.pluralize}/#{work_id}")
     end
 
     def retrieve_facet_urls(work_type)

--- a/spec/features/sitemap_spec.rb
+++ b/spec/features/sitemap_spec.rb
@@ -52,5 +52,5 @@ private
   end
 
   def build_test_path(work_type, work_id)
-    "/concern/#{work_type}/#{work_id}"
+    "/concern/#{work_type.pluralize}/#{work_id}"
   end


### PR DESCRIPTION
Fixes #1908 

Fixes the broken link in the site map by pluralizing the name of the work type 
as Glen suggested in the issue