### PR TITLE
Set DOI status after work deletion

### DIFF
--- a/app/jobs/identifier_delete_job.rb
+++ b/app/jobs/identifier_delete_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class IdentifierDeleteJob < ActiveJob::Base
+  def perform(identifier_uri)
+    RestClient.post(
+      post_uri(identifier_uri),
+      "_status: unavailable",
+      content_type: :text
+    )
+  end
+
+  private
+
+    def post_uri(identifier_uri)
+      u = URI.parse(identifier_uri)
+      u.user = doi_remote_service.username
+      u.password = doi_remote_service.password
+      u.to_s
+    end
+
+    def doi_remote_service
+      @doi_remote_service ||= Hydra::RemoteIdentifier.remote_service(:doi)
+    end
+end

--- a/app/models/concerns/remotely_identified_by_doi.rb
+++ b/app/models/concerns/remotely_identified_by_doi.rb
@@ -7,6 +7,8 @@ module RemotelyIdentifiedByDoi
   module Attributes
     extend ActiveSupport::Concern
     included do
+      before_destroy :withdraw_identifier
+
       property :doi, predicate: ::RDF::URI.new('http://purl.org/dc/terms/identifier#managedDOI'), multiple: false do |index|
         index.as :stored_searchable
       end
@@ -43,6 +45,12 @@ module RemotelyIdentifiedByDoi
 
         def remote_doi_assignment_strategy?
           doi_assignment_strategy.to_s == doi_remote_service.accessor_name.to_s
+        end
+
+      private
+
+        def withdraw_identifier
+          IdentifierDeleteJob.perform_later(identifier_url) unless identifier_url.blank?
         end
     end
   end

--- a/spec/jobs/identifier_delete_job_spec.rb
+++ b/spec/jobs/identifier_delete_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe IdentifierDeleteJob do
+  let(:doi_remote_service) do
+    double("Doi Remote Service", username: "foo", password: "bar")
+  end
+
+  let(:identifier_uri) { "https://www.example.com" }
+  let(:expected_post_uri) { "https://foo:bar@www.example.com" }
+
+  before do
+    allow(Hydra::RemoteIdentifier).to receive(:remote_service).and_return(doi_remote_service)
+  end
+
+  describe "#perform" do
+    it "calls RestClient with the correct params" do
+      expect(RestClient).to receive(:post).with(
+        expected_post_uri,
+        "_status: unavailable",
+        content_type: :text
+      )
+
+      described_class.perform_now(identifier_uri)
+    end
+  end
+end

--- a/spec/support/shared/is_remotely_identifiable_by_doi.rb
+++ b/spec/support/shared/is_remotely_identifiable_by_doi.rb
@@ -315,4 +315,28 @@ shared_examples 'is remotely identifiable by doi' do
       end
     end
   end
+
+  context "deleting a work" do
+    let(:work) { FactoryBot.create(described_class.to_s.underscore.to_sym) }
+
+    context "when a DOI has been minted" do
+      before do
+        work.stub(:identifier_url).and_return("http://example.org")
+      end
+
+      it "removes the identifier" do
+        expect(IdentifierDeleteJob).to receive(:perform_later)
+        work.destroy
+      end
+    end
+
+    context "when a DOI has not been minted" do
+      before { work.stub(:identifier_url).and_return(nil) }
+
+      it "does not remove the identifier" do
+        expect(IdentifierDeleteJob).not_to receive(:perform_later)
+        work.destroy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #1903 

Implementing `:withdraw_identifier` as an `before_destroy` callback on the `remotely_identified_by_doi` concern.

This passes if off to a worker to work around any errors with API availability. API availability is not handled elsewhere in the app, but we wanted to make sure the UX wasn't disrupted by the error.

Worker failures will collect any errors.