### PR TITLE
Delete Lease option in edit file set page

### DIFF
--- a/app/views/hyrax/base/_form_permission.html.erb
+++ b/app/views/hyrax/base/_form_permission.html.erb
@@ -1,0 +1,32 @@
+<% # This is used by works and by FileSet and the layout (col-6 vs col-12) is different for both %>
+<% if f.object.embargo_release_date %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif f.object.lease_expiration_date %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+  <fieldset class="set-access-controls">
+    <legend>
+      Visibility
+      <small>Who should be able to view or download this content?</small>
+    </legend>
+
+    <div class="form-group">
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO %>
+        <%= render "form_permission_embargo", f: f %>
+      </label>
+      <label class="radio">
+        <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE %>
+        <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+      </label>
+    </div>
+  </fieldset>
+<% end %>

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "Editing a file:", type: :feature do
+describe "Editing a file:", type: :feature, js: true do
   let(:user) { FactoryBot.create(:user) }
   let(:file_title) { 'Some kind of title' }
   let(:work) { FactoryBot.build(:work, user: user) }
@@ -21,6 +21,14 @@ describe "Editing a file:", type: :feature do
       click_link 'Versions'
       click_button 'Upload New Version'
       expect(page).to have_content "Edit #{file_title}"
+    end
+  end
+
+  context 'when the user is editing the file' do
+    it 'does not show the lease option' do
+      visit edit_hyrax_file_set_path(file_set)
+      click_link 'Permission'
+      expect(page).not_to have_content('Lease')
     end
   end
 end


### PR DESCRIPTION
Fixes #1912 

Deleted the view of lease in editing file page.
I didn't find the spec/view file for '_form_permission.html.erb', so I just added a feature spec of it. 