### PR TITLE
Fix facet search when sting contains ampersand

### DIFF
--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require Hyrax::Engine.root.join('app/renderers/hyrax/renderers/faceted_attribute_renderer.rb')
+module Hyrax
+  module Renderers
+    class FacetedAttributeRenderer < AttributeRenderer
+      private
+
+        def li_value(value)
+          link_to(ERB::Util.h(value), search_path(value).gsub('%26amp%3B', '%26'))
+        end
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Hyrax::Renderers::FacetedAttributeRenderer do
+  let(:field) { :department }
+  let(:renderer) { described_class.new(field, ['libraries & archives']) }
+
+  describe "#attribute_to_html" do
+    subject { Nokogiri::HTML(renderer.render) }
+    let(:expected) { Nokogiri::HTML(tr_content) }
+    let(:tr_content) do
+      %(
+      <tr><th>Department</th>
+      <td><ul class='tabular'>
+      <li class="attribute department"><a href="/catalog?f%5Bdepartment_sim%5D%5B%5D=libraries+%26+archives">libraries & archives</a></li>
+      </ul></td></tr>
+    )
+    end
+
+    it { expect(subject).to be_equivalent_to(expected) }
+  end
+end


### PR DESCRIPTION
Fixes #1926 

Overrides the #li_value method in Hyrax's FacetedAttributeRenderer class so that ampersands are properly handled.  Without this fix, clicking on a faceted search link on the works show page would yield no results searches with `&` in them.

The problem was that `&` was being encoded to `&amp;` and then to `%26amp%3B` which is nice for browsers, but solr doesn't understand it.  So it now substitutes `%26amp%3B` for just `%26` which solr interprets as `&`