### PR TITLE
Force saving of downloaded files instead of viewing inline

### DIFF
--- a/app/controllers/concerns/hydra/controller/download_behavior.rb
+++ b/app/controllers/concerns/hydra/controller/download_behavior.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require HydraHead::Engine.root.join('app/controllers/concerns/hydra/controller/download_behavior.rb')
+module Hydra
+  module Controller
+    module DownloadBehavior
+      extend ActiveSupport::Concern
+
+      protected
+
+        def content_options
+          { disposition: disposition, type: file.mime_type, filename: file_name }
+        end
+
+        def disposition
+          if file.mime_type == 'application/pdf'
+            'attachment'
+          else
+            'inline'
+          end
+        end
+    end
+  end
+end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+class DownloadsController < ApplicationController
+  include Hydra::Controller::DownloadBehavior
+end
+
+describe DownloadsController do
+  describe "#content_options" do
+    let(:file_set) { create(:file_set) }
+    let(:file) { file_set.original_file }
+
+    before do
+      binary = StringIO.new("test")
+      Hydra::Works::AddFileToFileSet.call(file_set, binary, :original_file, versioning: true)
+      allow(controller).to receive(:default_file).and_return file
+    end
+
+    subject { controller.send(:content_options) }
+
+    context 'when the file is a PDF' do
+      before do
+        allow(file).to receive(:mime_type).and_return 'application/pdf'
+      end
+
+      it 'has disposition set to "attachment"' do
+        expect(subject[:disposition]).to eq 'attachment'
+      end
+    end
+
+    context 'when the file is not a PDF' do
+      before do
+        allow(file).to receive(:mime_type).and_return 'image/jpeg'
+      end
+
+      it 'has disposition set to "inline"' do
+        expect(subject[:disposition]).to eq 'inline'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1936 

Overrides the `#content_options` method in `Hydra::Controller::DownloadBehavior` to change the disposition from `inline` to `attachment` when the file is a PDF.  This change causes the application to prompt to save the PDF instead of displaying it.