### PR TITLE
Use Eastern time zone when sending embargo notifcations

### DIFF
--- a/lib/tasks/embargo_manager.rake
+++ b/lib/tasks/embargo_manager.rake
@@ -8,6 +8,7 @@ namespace :embargo_manager do # rubocop:disable Metrics/BlockLength
     ONE_DAY = 1
     ZERO_DAYS = 0
     results_cap = 1_000_000
+    Time.zone = 'EST'
 
     solr_results = ActiveFedora::SolrService.query('embargo_release_date_dtsi:[* TO *]', rows: results_cap)
     solr_results.each do |work|


### PR DESCRIPTION
The embargo notification rake task is calculating the current time using UTC instead of Eastern time zone.  So when the task runs late at night it thinks it's already the next day.

This just adds a `Time.zone = 'EST'` so that `Time.zone.today` returns the current time for our time zone.

I've tested this on scholar-qa.  It works as expected.