### PR TITLE
Implement video partial fix

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,11 +1,12 @@
   <video controls="controls" class="img-responsive video-js vjs-default-skin" data-setup="{}" preload="auto">
     <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
     <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+    <source src="<%= hyrax.download_path(file_set) %>" />  
     Your browser does not support the video tag.
   </video>
 
   <% if Hyrax.config.display_media_download_link %>
-    <% if file_is_too_large_to_download(file_set) %>            
+    <% if file_is_too_large_to_download(file_set) %>
       <%= show_request_file_button(file_set, t('hyrax.file_set.show.requestable_content.video_link')) %>
     <% else %>
       <%= link_to hyrax.download_path(file_set),


### PR DESCRIPTION
Fixes #1951 

Present short summary (50 characters or less)

Adds an additional source for Safari to correctly load videos from Scholar.
`<source src="<%= hyrax.download_path(file_set) %>" />`

 ucrate link to original issue
<a href="https://github.com/uclibs/ucrate/issues/351">https://github.com/uclibs/ucrate/issues/351</a>