### PR TITLE
Disable citation features on work show pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1275,7 +1275,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    retriable (3.1.1)
+    retriable (3.1.2)
     riiif (0.2.4)
       rails (> 3.2.0)
     rsolr (1.1.2)
@@ -1318,8 +1318,8 @@ GEM
       multipart-post
       oauth2
     ruby-openid (2.7.0)
-    ruby-progressbar (1.9.0)
-    rubyzip (1.2.1)
+    ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
@@ -1376,7 +1376,7 @@ GEM
       httparty (>= 0.11.0)
       oauth2 (>= 0.9.2)
     slop (4.6.1)
-    solr_wrapper (1.2.0)
+    solr_wrapper (2.0.0)
       faraday
       retriable
       ruby-progressbar

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,0 +1,11 @@
+<div class="citations">
+    <% if Hyrax.config.citations? %>
+      <%= link_to "Citations", hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-default' %>
+      <div class='citations-heading'><%= t('.header') %></div>
+      <p class='citations-list'>
+      <%= link_to 'EndNote', polymorphic_path([main_app, presenter], format: 'endnote') %>
+      | <%= link_to 'Zotero', hyrax.zotero_path, id: 'zoteroLink', name: 'zotero' %>
+      | <%= link_to 'Mendeley', hyrax.mendeley_path, id: 'mendeleyLink', name: 'mendeley' %>
+      </p>
+    <% end %>
+</div>

--- a/config/initializers/hyrax.rb.bamboo
+++ b/config/initializers/hyrax.rb.bamboo
@@ -48,7 +48,7 @@ Hyrax.config do |config|
 
   # Enables a link to the citations page for a work
   # Default is false
-  config.citations = true
+  config.citations = false
 
   # Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)
   # config.temp_file_base = '/home/developer1'

--- a/config/initializers/hyrax.rb.sample
+++ b/config/initializers/hyrax.rb.sample
@@ -48,7 +48,7 @@ Hyrax.config do |config|
 
   # Enables a link to the citations page for a work
   # Default is false
-  config.citations = true
+  config.citations = false
 
   # Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)
   # config.temp_file_base = '/home/developer1'

--- a/spec/views/hyrax/base/_citations.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_citations.html.erb_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'hyrax/base/_citations.html.erb', type: :view do
+  let(:user) { create(:user) }
+  let(:object_profile) { ["{\"id\":\"999\"}"] }
+  let(:contributor) { ['Frodo'] }
+  let(:creator)     { ['Bilbo'] }
+  let(:solr_document) do
+    SolrDocument.new(
+      id: '999',
+      object_profile_ssm: object_profile,
+      has_model_ssim: ['GenericWork'],
+      human_readable_type_tesim: ['Generic Work'],
+      contributor_tesim: contributor,
+      creator_tesim: creator,
+      rights_tesim: ['http://creativecommons.org/licenses/by/3.0/us/']
+    )
+  end
+  let(:ability) { Ability.new(user) }
+  let(:presenter) do
+    Hyrax::WorkShowPresenter.new(solr_document, ability)
+  end
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+  before do
+    Hyrax.config.citations = citations
+    allow(controller).to receive(:can?).with(:edit, presenter).and_return(false)
+    render 'hyrax/base/citations', presenter: presenter
+  end
+  context 'when enabled' do
+    let(:citations) { true }
+
+    it 'appears on page' do
+      expect(page).to have_selector('a#citations', count: 1)
+      expect(page).to have_content('EndNote')
+      expect(page).to have_content('Zotero')
+      expect(page).to have_content('Mendeley')
+    end
+  end
+
+  context 'when disabled' do
+    let(:citations) { false }
+
+    it 'does not appear on page' do
+      expect(page).to have_no_selector('a#citations')
+      expect(page).to have_no_content('EndNote')
+      expect(page).to have_no_content('Zotero')
+      expect(page).to have_no_content('Mendeley')
+    end
+  end
+end


### PR DESCRIPTION
Since the order of authors cannot be preserved,
citations generated by Scholar may have the
incorrect order of authors.  Since order is very
important, we are disabling these features until
ordering is fixed.

The product owners have weighed in on this.

(There's also a second commit in this PR with a required update to the solr_wrapper gem)