### PR TITLE
Update vulnerable ffi gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -844,7 +844,7 @@ GEM
       faraday
     fcrepo_wrapper (0.9.0)
       ruby-progressbar
-    ffi (1.9.18)
+    ffi (1.9.25)
     figaro (1.1.1)
       thor (~> 0.14)
     flipflop (2.3.1)


### PR DESCRIPTION
Update the `ffi` gem to resolve a security vulnerability reported by GitHub.